### PR TITLE
fix: resolve asset file paths differently when they are inside project

### DIFF
--- a/packages/ffmpeg/server/FFmpegExporterServer.ts
+++ b/packages/ffmpeg/server/FFmpegExporterServer.ts
@@ -187,8 +187,15 @@ export class FFmpegExporterServer {
         (SAMPLE_RATE * padStart) / 1000,
     );
 
+    let resolvedPath: string;
+    if (asset.src.startsWith('/@fs')) {
+      resolvedPath = asset.src.replace('/@fs', '');
+    } else {
+      resolvedPath = path.join(this.config.output, '..', asset.src);
+    }
+
     await new Promise<void>((resolve, reject) => {
-      ffmpeg(asset.src.replace('/@fs', ''))
+      ffmpeg(resolvedPath)
         .audioChannels(2)
         .audioCodec('pcm_s16le')
         .audioFrequency(SAMPLE_RATE)


### PR DESCRIPTION
When assets like video or audio located inside a motion canvas project folder are imported, their path in asset.src is not absolute, but relative to the project folder. However, we have previously handled all file paths as if they were absolute. This PR fixes it.