### PR TITLE
feat: publish package to npm

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./packages/docs/build
-          external_repository: revideo/revideo.github.io
+          external_repository: motion-canvas/motion-canvas.github.io

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,4 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./packages/docs/build
-          external_repository: motion-canvas/motion-canvas.github.io
+          external_repository: revideo/revideo.github.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
           cache: npm
-      - run: git config --global user.email "129169430+revideo-bot@users.noreply.github.com"
-      - run: git config --global user.name "revideo-bot"
+      - run: git config --global user.email "129169430+motion-canvas-bot@users.noreply.github.com"
+      - run: git config --global user.name "motion-canvas-bot"
       - run: npm ci
       - run: npx lerna run build
       - if: ${{ inputs.releaseType == 'release' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,8 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
           cache: npm
-      - run: git config --global user.email "129169430+motion-canvas-bot@users.noreply.github.com"
-      - run: git config --global user.name "motion-canvas-bot"
+      - run: git config --global user.email "129169430+revideo-bot@users.noreply.github.com"
+      - run: git config --global user.name "revideo-bot"
       - run: npm ci
       - run: npx lerna run build
       - if: ${{ inputs.releaseType == 'release' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.3](https://github.com/havenhq/revideo/compare/v0.1.2...v0.1.3) (2024-03-17)
+
+
+### Bug Fixes
+
+* revert version bump to 0.1.1 ([998aca2](https://github.com/havenhq/revideo/commit/998aca20439d46bb804fd8bf9b3776639bfb8103))
+
+
+
+
+
 ## [0.1.2](https://github.com/havenhq/revideo/compare/v0.1.1...v0.1.2) (2024-03-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/havenhq/revideo/compare/v0.1.0...v0.1.1) (2024-03-17)
+
+
+### Bug Fixes
+
+* resolve import issues in quickstart project ([e839086](https://github.com/havenhq/revideo/commit/e8390869c087c92c9d448cd16e9cc648d6b2dbe0))
+
+
+
+
+
 
 
 **Note:** Version bump only for package revideo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,650 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* **2d:** account for offset in cardinal points ([#883](https://github.com/havenhq/revideo/issues/883)) ([24da258](https://github.com/havenhq/revideo/commit/24da258f5937087b363eeb9146a9d22747b02e70)), closes [#882](https://github.com/havenhq/revideo/issues/882)
+* **2d:** account for spawners in scene graph ([#935](https://github.com/havenhq/revideo/issues/935)) ([ca325f5](https://github.com/havenhq/revideo/commit/ca325f5ad0ae987e76106f5e65fef3ed7b3ca08d))
+* **2d:** add missing Curve properties to Circle ([#805](https://github.com/havenhq/revideo/issues/805)) ([38c7900](https://github.com/havenhq/revideo/commit/38c79000403d7c3c99dde9e4c825a448d5f55054))
+* **2d:** add missing Fragment export ([#553](https://github.com/havenhq/revideo/issues/553)) ([229afb4](https://github.com/havenhq/revideo/commit/229afb4fe7d95f09b480ab4a813f8dff549f381f))
+* **2d:** add missing jsx dev runtime ([#547](https://github.com/havenhq/revideo/issues/547)) ([d61cb7d](https://github.com/havenhq/revideo/commit/d61cb7dd24ab66ae17d5bd6f5ccb34c4fd1e7569)), closes [#545](https://github.com/havenhq/revideo/issues/545)
+* **2d:** add missing middle property ([#891](https://github.com/havenhq/revideo/issues/891)) ([61e2e96](https://github.com/havenhq/revideo/commit/61e2e96e3b8f37a68ebdddb432baba04858fd4f3))
+* **2d:** add missing shape export ([#111](https://github.com/havenhq/revideo/issues/111)) ([02a1fa7](https://github.com/havenhq/revideo/commit/02a1fa7ea62155e498809f2e57ff29a18c82ac12))
+* **2d:** better error handling ([#524](https://github.com/havenhq/revideo/issues/524)) ([b7475ba](https://github.com/havenhq/revideo/commit/b7475ba5ff35d37ee198577d1205d6ecd6fd2092))
+* **2d:** calculate arrow orientations for curves correctly ([#597](https://github.com/havenhq/revideo/issues/597)) ([1626811](https://github.com/havenhq/revideo/commit/1626811ec4cd1bd2a3d43e393ced40a7da462c3a))
+* **2d:** calculate Txt cache bbox from contents ([#836](https://github.com/havenhq/revideo/issues/836)) ([33e1a12](https://github.com/havenhq/revideo/commit/33e1a1296f21d26e9ed45ae92132825dca17054d)), closes [#465](https://github.com/havenhq/revideo/issues/465)
+* **2d:** clone size correctly ([#562](https://github.com/havenhq/revideo/issues/562)) ([cdd3df1](https://github.com/havenhq/revideo/commit/cdd3df1bff25b04b905e289264831d8d328caaab)), closes [#559](https://github.com/havenhq/revideo/issues/559)
+* **2d:** correct layout defaults ([#442](https://github.com/havenhq/revideo/issues/442)) ([c116c35](https://github.com/havenhq/revideo/commit/c116c355179ba3b2487634fb82b9a5bc2ea266bf))
+* **2d:** correctly append Txt nodes to view ([#644](https://github.com/havenhq/revideo/issues/644)) ([24bb51a](https://github.com/havenhq/revideo/commit/24bb51aa04778c33ce327926b27332efaa554e5f))
+* **2d:** correctly support external image urls ([#678](https://github.com/havenhq/revideo/issues/678)) ([a08556b](https://github.com/havenhq/revideo/commit/a08556b6e2822a55db593f610ea4dd6cb8494adb)), closes [#677](https://github.com/havenhq/revideo/issues/677)
+* **2d:** fix audio offset editing ([#674](https://github.com/havenhq/revideo/issues/674)) ([58d6ef7](https://github.com/havenhq/revideo/commit/58d6ef79fa06e377e0c1821efe73585586d124a6))
+* **2d:** fix cache bbox for lines ([#467](https://github.com/havenhq/revideo/issues/467)) ([9fd1444](https://github.com/havenhq/revideo/commit/9fd144417bb0b6301da6c522a988775f5ff142ac)), closes [#466](https://github.com/havenhq/revideo/issues/466)
+* **2d:** fix circle segment ([#557](https://github.com/havenhq/revideo/issues/557)) ([adebff4](https://github.com/havenhq/revideo/commit/adebff492b76a512d79151b00adf1b383d25c5b5))
+* **2d:** fix CodeBlock types ([#563](https://github.com/havenhq/revideo/issues/563)) ([25160fa](https://github.com/havenhq/revideo/commit/25160fa4d92af88429110356e42f6e3b4f88a90f)), closes [#560](https://github.com/havenhq/revideo/issues/560)
+* **2d:** fix curve arrow alignment when animating start signal ([#615](https://github.com/havenhq/revideo/issues/615)) ([2fefc40](https://github.com/havenhq/revideo/commit/2fefc4026050159ba204c7629832ad83e8bfa51b))
+* **2d:** fix cyclic dependency in cardinal points ([#645](https://github.com/havenhq/revideo/issues/645)) ([def23f9](https://github.com/havenhq/revideo/commit/def23f925ee7200c8740ecd51c7f6117d67b6ef8))
+* **2d:** fix font ligatures in CodeBlock ([#231](https://github.com/havenhq/revideo/issues/231)) ([11ee3fe](https://github.com/havenhq/revideo/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
+* **2d:** fix Gradient and Pattern signals ([#376](https://github.com/havenhq/revideo/issues/376)) ([6e0dc8a](https://github.com/havenhq/revideo/commit/6e0dc8af8d19f93fd6a42addca2b3a2958b4dd33))
+* **2d:** fix height when tweening text ([#905](https://github.com/havenhq/revideo/issues/905)) ([1c6a796](https://github.com/havenhq/revideo/commit/1c6a7965be137c1ab69741cdd1e9aaa6df4208c4))
+* **2d:** fix import order ([#94](https://github.com/havenhq/revideo/issues/94)) ([bcc0bcf](https://github.com/havenhq/revideo/commit/bcc0bcffae47855bd8f7ab06454aaebe93c4aa24)), closes [#76](https://github.com/havenhq/revideo/issues/76)
+* **2d:** fix initial value of endOffset ([#433](https://github.com/havenhq/revideo/issues/433)) ([9fe82b3](https://github.com/havenhq/revideo/commit/9fe82b3d21ba0150a2378e541a4652ca707c2d15))
+* **2d:** fix layout calculation for nodes not explicitly added to view ([#331](https://github.com/havenhq/revideo/issues/331)) ([528e2d5](https://github.com/havenhq/revideo/commit/528e2d5a0abec99819e022d2848b256ece9f869a))
+* **2d:** fix letterSpacing ([#448](https://github.com/havenhq/revideo/issues/448)) ([bb5ffc4](https://github.com/havenhq/revideo/commit/bb5ffc48efa82b9db818e8e52aa35e9c2ad8ce89)), closes [#447](https://github.com/havenhq/revideo/issues/447)
+* **2d:** fix line arc length ([#503](https://github.com/havenhq/revideo/issues/503)) ([4f1cd59](https://github.com/havenhq/revideo/commit/4f1cd59e6bcba0b16b36be88b28a60ae46d4d9ab)), closes [#497](https://github.com/havenhq/revideo/issues/497)
+* **2d:** fix Line cache ([#232](https://github.com/havenhq/revideo/issues/232)) ([a953b64](https://github.com/havenhq/revideo/commit/a953b64540c020657845efc84d4179142a7a0974)), closes [#205](https://github.com/havenhq/revideo/issues/205)
+* **2d:** fix line jitter under certain conditions ([#863](https://github.com/havenhq/revideo/issues/863)) ([fb110a2](https://github.com/havenhq/revideo/commit/fb110a2f3583fc040bf2c39560934162bd146d9b))
+* **2d:** fix Line overview crashing ([#142](https://github.com/havenhq/revideo/issues/142)) ([6bd5fd9](https://github.com/havenhq/revideo/commit/6bd5fd941e583e44f5d920ecd20215efb1eed58a))
+* **2d:** fix nested cache canvases ([#554](https://github.com/havenhq/revideo/issues/554)) ([e601441](https://github.com/havenhq/revideo/commit/e6014413b215af6fb1a7953f8db83893d4025f0b)), closes [#551](https://github.com/havenhq/revideo/issues/551)
+* **2d:** fix package.json entry ([#720](https://github.com/havenhq/revideo/issues/720)) ([12e9bf6](https://github.com/havenhq/revideo/commit/12e9bf6f40ab7afc02e2f55260544f3864920ded))
+* **2d:** fix performance issue with audio track ([#427](https://github.com/havenhq/revideo/issues/427)) ([c993770](https://github.com/havenhq/revideo/commit/c993770937ddfdf0ac39b144a1f79f1a300f7899))
+* **2d:** fix signal initialization ([#382](https://github.com/havenhq/revideo/issues/382)) ([ea36e79](https://github.com/havenhq/revideo/commit/ea36e791a20bfd1b491ffa9917be686c51bc3899))
+* **2d:** fix tweening cardinal points ([#829](https://github.com/havenhq/revideo/issues/829)) ([cc16737](https://github.com/havenhq/revideo/commit/cc16737cd59081582fbb488a880e8d3c11c14918))
+* **2d:** fix Txt decorators ([#526](https://github.com/havenhq/revideo/issues/526)) ([25b30ed](https://github.com/havenhq/revideo/commit/25b30ed3861f46d72147335480912ce5f564be79))
+* **2d:** fix types ([#659](https://github.com/havenhq/revideo/issues/659)) ([a32af29](https://github.com/havenhq/revideo/commit/a32af29ef3bd2e5dbf08697ebfee53230fceadc1))
+* **2d:** fix version link ([#608](https://github.com/havenhq/revideo/issues/608)) ([4fe5b7a](https://github.com/havenhq/revideo/commit/4fe5b7a5150fbdf43ea50ecf3dc8b4690c0e2e34))
+* **2d:** format whitespaces according to HTML ([#372](https://github.com/havenhq/revideo/issues/372)) ([83fb565](https://github.com/havenhq/revideo/commit/83fb565742d98f060c0400c8cbaf9961b69f34d0)), closes [#370](https://github.com/havenhq/revideo/issues/370)
+* **2d:** handle division by zero in lines ([#407](https://github.com/havenhq/revideo/issues/407)) ([a17871a](https://github.com/havenhq/revideo/commit/a17871a2ce63dd5bb32bc719037327c4e9dde217))
+* **2d:** handle floating point errors in acos ([#381](https://github.com/havenhq/revideo/issues/381)) ([5bca8fd](https://github.com/havenhq/revideo/commit/5bca8fd0bbdcf28f2793c124b7d6b0afd560c4b8))
+* **2d:** handle lines with no points ([#233](https://github.com/havenhq/revideo/issues/233)) ([8108474](https://github.com/havenhq/revideo/commit/81084743dfad7b6419760796fda825047909d4d4)), closes [#212](https://github.com/havenhq/revideo/issues/212)
+* **2d:** ignore children with disabled layout ([#669](https://github.com/havenhq/revideo/issues/669)) ([b98c462](https://github.com/havenhq/revideo/commit/b98c4625c3634495e86ca23d19355035e457db06)), closes [#580](https://github.com/havenhq/revideo/issues/580)
+* **2d:** improve Curve hitbox ([#778](https://github.com/havenhq/revideo/issues/778)) ([8af723c](https://github.com/havenhq/revideo/commit/8af723c0322de39d2defe0363bba03f4f9542f08))
+* **2d:** improve Rect radius ([#221](https://github.com/havenhq/revideo/issues/221)) ([3437e42](https://github.com/havenhq/revideo/commit/3437e42713a3f4a8d44d246ee01e2eb23b61e06a)), closes [#207](https://github.com/havenhq/revideo/issues/207)
+* **2d:** make Text respect textWrap=pre ([#287](https://github.com/havenhq/revideo/issues/287)) ([cb07f4b](https://github.com/havenhq/revideo/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
+* **2d:** minor fixes ([#915](https://github.com/havenhq/revideo/issues/915)) ([63cfc9e](https://github.com/havenhq/revideo/commit/63cfc9e033f2c2ac6d6ed2a0d8f615fcf642ab59))
+* **2d:** point arrow heads in correct direction ([#792](https://github.com/havenhq/revideo/issues/792)) ([52ed52e](https://github.com/havenhq/revideo/commit/52ed52e963cc69a066a0353680acaca35b9c937a)), closes [#783](https://github.com/havenhq/revideo/issues/783)
+* **2d:** prevent src warnings in Icon and Latex ([#899](https://github.com/havenhq/revideo/issues/899)) ([5eebab7](https://github.com/havenhq/revideo/commit/5eebab71d8061e233872e049e77b847f9fd077a1))
+* **2d:** remove circular dependencies ([#780](https://github.com/havenhq/revideo/issues/780)) ([cdf3af5](https://github.com/havenhq/revideo/commit/cdf3af500a58151ee3549c6e728751aab3e6f75c))
+* **2d:** smoothly play videos when presenting ([#600](https://github.com/havenhq/revideo/issues/600)) ([294fe6a](https://github.com/havenhq/revideo/commit/294fe6ac056ab074c77214fcf9035f53fac9258c)), closes [#578](https://github.com/havenhq/revideo/issues/578)
+* **2d:** some signal setters not returning owners ([#143](https://github.com/havenhq/revideo/issues/143)) ([09ab7f9](https://github.com/havenhq/revideo/commit/09ab7f96afcaae608399a653c0b4878ba9b467d4))
+* **2d:** stop code highlighting from jumping ([#230](https://github.com/havenhq/revideo/issues/230)) ([67ef1c4](https://github.com/havenhq/revideo/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
+* **2d:** stop mutating children ([#903](https://github.com/havenhq/revideo/issues/903)) ([f9552a8](https://github.com/havenhq/revideo/commit/f9552a8658ccde6c7b2466ad40b12cf28c6ec805))
+* **2d:** switch iframes to ShadowDOM ([#90](https://github.com/havenhq/revideo/issues/90)) ([86176be](https://github.com/havenhq/revideo/commit/86176be055c08aba59272afcda00ed586f6c7ad6))
+* **2d:** textDirection property for RTL/LTR text ([#404](https://github.com/havenhq/revideo/issues/404)) ([f240b1b](https://github.com/havenhq/revideo/commit/f240b1bd140a884f6901b7cfcb97ce3e9ce4b48d))
+* **2d:** textWrap not working in Firefox ([#541](https://github.com/havenhq/revideo/issues/541)) ([f10e057](https://github.com/havenhq/revideo/commit/f10e057fd13ed9dcc70ebc0ca63963708ec159c8)), closes [#517](https://github.com/havenhq/revideo/issues/517)
+* **2d:** wait for reused async resources ([#599](https://github.com/havenhq/revideo/issues/599)) ([280e065](https://github.com/havenhq/revideo/commit/280e065fe69e9a744b7b12eb4609e7d87f76bb63)), closes [#593](https://github.com/havenhq/revideo/issues/593)
+* account for italic fonts in cache ([#968](https://github.com/havenhq/revideo/issues/968)) ([abb0906](https://github.com/havenhq/revideo/commit/abb090695c4257d9877d0cb11954093c49149ddc)), closes [#934](https://github.com/havenhq/revideo/issues/934)
+* add missing Arrow setters ([#82](https://github.com/havenhq/revideo/issues/82)) ([49843c9](https://github.com/havenhq/revideo/commit/49843c9d38ee75de50ffc241d2a615be78f9e1f5))
+* add missing canvas package ([26c8f4f](https://github.com/havenhq/revideo/commit/26c8f4ff9947841b38f123466b7efd7f43706ffb))
+* add missing public path ([#40](https://github.com/havenhq/revideo/issues/40)) ([48213de](https://github.com/havenhq/revideo/commit/48213de087d6bb35f29919f5588e3a4517e080b6))
+* add monospace font fallback in case JetBrains Mono is missing ([#24](https://github.com/havenhq/revideo/issues/24)) ([276a310](https://github.com/havenhq/revideo/commit/276a310d63a4ea128a3640d6e0871045514c1c01)), closes [#16](https://github.com/havenhq/revideo/issues/16)
+* bug with createEaseInOutBack in interpolationFunctions.ts ([#69](https://github.com/havenhq/revideo/issues/69)) ([2b95876](https://github.com/havenhq/revideo/commit/2b958768a6d01f81e4fde51a018209e0fe800f8f))
+* change executable file permissions ([#38](https://github.com/havenhq/revideo/issues/38)) ([23025a2](https://github.com/havenhq/revideo/commit/23025a2caefd993f7e4751b1efced3a25ed497a6))
+* code will trigger PrismJS such that JSX is correctly highlighted ([#20](https://github.com/havenhq/revideo/issues/20)) ([b323231](https://github.com/havenhq/revideo/commit/b32323184b5f479bc09950fdf9c570b5276ea600)), closes [#17](https://github.com/havenhq/revideo/issues/17)
+* **core:** add missing type references ([#41](https://github.com/havenhq/revideo/issues/41)) ([325c244](https://github.com/havenhq/revideo/commit/325c2442814ca19407fe0060a819aded4456f90e))
+* **core:** clear DependencyContext promises once resolved ([#617](https://github.com/havenhq/revideo/issues/617)) ([97b68da](https://github.com/havenhq/revideo/commit/97b68dabfdf86c0e0a188212308b8aba0fb35cab))
+* **core:** clear semi-transparent backgrounds ([#424](https://github.com/havenhq/revideo/issues/424)) ([1ebff1c](https://github.com/havenhq/revideo/commit/1ebff1c92bebce56d11c61eb9dadca47f5a80ac1)), closes [#423](https://github.com/havenhq/revideo/issues/423)
+* **core:** fix looping ([#217](https://github.com/havenhq/revideo/issues/217)) ([a38e1a7](https://github.com/havenhq/revideo/commit/a38e1a7c8fc21384cc17f3f982802071b8cd0cbf)), closes [#178](https://github.com/havenhq/revideo/issues/178)
+* **core:** fix playback state ([#471](https://github.com/havenhq/revideo/issues/471)) ([1c259d0](https://github.com/havenhq/revideo/commit/1c259d0d574bb56dbc8bc448300d9b94ee4d0bc4))
+* **core:** fix relative time ([#461](https://github.com/havenhq/revideo/issues/461)) ([8d4946e](https://github.com/havenhq/revideo/commit/8d4946ebf56590bc3934087f95955180b4901566))
+* **core:** fix snapshots ([#638](https://github.com/havenhq/revideo/issues/638)) ([437cc5e](https://github.com/havenhq/revideo/commit/437cc5efddbb242b10f7902e18fe15162a45d7bd))
+* **core:** fix tree shaking ([#555](https://github.com/havenhq/revideo/issues/555)) ([8de199e](https://github.com/havenhq/revideo/commit/8de199eaf833622a96ad746c984fb7f3a77df4b8))
+* **core:** fix Vector2.exactlyEquals ([#437](https://github.com/havenhq/revideo/issues/437)) ([028d264](https://github.com/havenhq/revideo/commit/028d26499d8f3fb34500b22e8dcde2d080c2e2b0))
+* **core:** handle malicious event names ([#819](https://github.com/havenhq/revideo/issues/819)) ([aba8eba](https://github.com/havenhq/revideo/commit/aba8ebaf347ac3cbf6a9446c1aa60f629c7c18bd))
+* **core:** keep falsy values with deepTween ([#45](https://github.com/havenhq/revideo/issues/45)) ([93c934f](https://github.com/havenhq/revideo/commit/93c934f9b59462581267cca5033bf132b831ce54))
+* **core:** playback speed is reset after saving with faulty code ([#204](https://github.com/havenhq/revideo/issues/204)). ([#339](https://github.com/havenhq/revideo/issues/339)) ([6771e5e](https://github.com/havenhq/revideo/commit/6771e5e17edcdc4cce074d7da0962cf71ba6c228))
+* **core:** project `variables` ([#690](https://github.com/havenhq/revideo/issues/690)) ([149f39c](https://github.com/havenhq/revideo/commit/149f39c3219aa74115be80490bd6c5f236779b0e)), closes [#689](https://github.com/havenhq/revideo/issues/689)
+* **core:** render only within the range ([#436](https://github.com/havenhq/revideo/issues/436)) ([36ccebe](https://github.com/havenhq/revideo/commit/36ccebe5321d84eeaa16f8b74a79c1001ee7ac0b))
+* correctly await re-renders ([#918](https://github.com/havenhq/revideo/issues/918)) ([873a9a3](https://github.com/havenhq/revideo/commit/873a9a3eed2676de4cc7f31fbd5ea58817a80aff))
+* create missing output directories ([#13](https://github.com/havenhq/revideo/issues/13)) ([17f1e3f](https://github.com/havenhq/revideo/commit/17f1e3fd37ec89998d67b22bd6762fc85b4778a2)), closes [#4](https://github.com/havenhq/revideo/issues/4)
+* **create:** fix package type ([#40](https://github.com/havenhq/revideo/issues/40)) ([f07aa5d](https://github.com/havenhq/revideo/commit/f07aa5d8f6c3485464ed3158187340c7db7d5af7))
+* **create:** update templates ([#439](https://github.com/havenhq/revideo/issues/439)) ([8483557](https://github.com/havenhq/revideo/commit/8483557f0a3ca7914aafacceab5d466abba59df0))
+* detect missing meta files ([#83](https://github.com/havenhq/revideo/issues/83)) ([d1e2193](https://github.com/havenhq/revideo/commit/d1e219361c7f61673073b377917c88d82f0e5d9e)), closes [#79](https://github.com/havenhq/revideo/issues/79)
+* display newlines in Code correctly ([#38](https://github.com/havenhq/revideo/issues/38)) ([df8f390](https://github.com/havenhq/revideo/commit/df8f390848d7a8e03193d64e460142e00ed95031))
+* **docs:** fix a typo ([#55](https://github.com/havenhq/revideo/issues/55)) ([2691148](https://github.com/havenhq/revideo/commit/26911481fa5f3d1f76ecd550ba6f61f44bac6124))
+* **docs:** fix broken links ([#105](https://github.com/havenhq/revideo/issues/105)) ([f79427d](https://github.com/havenhq/revideo/commit/f79427d588190908ba4015b7820d529f25e64e6a))
+* **docs:** fix fiddle accessibility ([#647](https://github.com/havenhq/revideo/issues/647)) ([3037f65](https://github.com/havenhq/revideo/commit/3037f657bec44a54f9e5c3d4802e77a7b06ee261))
+* **docs:** fix last updated footer ([#776](https://github.com/havenhq/revideo/issues/776)) ([09c0085](https://github.com/havenhq/revideo/commit/09c008587fcd4b52edbc5e7599ee378482f4230b)), closes [#767](https://github.com/havenhq/revideo/issues/767)
+* **docs:** fix links to examples ([#106](https://github.com/havenhq/revideo/issues/106)) ([d445b56](https://github.com/havenhq/revideo/commit/d445b564746bb5e8cbabcddaa9857ffec80a8755))
+* **docs:** fix search ([#336](https://github.com/havenhq/revideo/issues/336)) ([e44ec02](https://github.com/havenhq/revideo/commit/e44ec02539a67f099471a6aa84f673a236494687))
+* **docs:** fix small typo ([#107](https://github.com/havenhq/revideo/issues/107)) ([fe6cbb0](https://github.com/havenhq/revideo/commit/fe6cbb0083407f3de4594c76692a417bf4f616ee))
+* **docs:** fix the showcase editor ([#589](https://github.com/havenhq/revideo/issues/589)) ([4964e77](https://github.com/havenhq/revideo/commit/4964e7742dea46975dba911fe382737c8508535c))
+* **docs:** fix typo in configuration.mdx ([#185](https://github.com/havenhq/revideo/issues/185)) ([ca67529](https://github.com/havenhq/revideo/commit/ca67529925d3483cb84a36e852e5bad79c3861eb))
+* **docs:** fix typo in logging.mdx ([#652](https://github.com/havenhq/revideo/issues/652)) ([5d04494](https://github.com/havenhq/revideo/commit/5d044945ae126ea3fa4e5c14a1062ddcec39e0c3))
+* **docs:** improve predicate type ([#148](https://github.com/havenhq/revideo/issues/148)) ([3abee4f](https://github.com/havenhq/revideo/commit/3abee4f89ef467a48eb68382ac6d46d443ad28d9))
+* **docs:** invalid source code link ([#502](https://github.com/havenhq/revideo/issues/502)) ([3588d53](https://github.com/havenhq/revideo/commit/3588d53d45f9bc9b57aad10353d207cccdfb0dba)), closes [#499](https://github.com/havenhq/revideo/issues/499)
+* **docs:** name collisions between members ([#117](https://github.com/havenhq/revideo/issues/117)) ([1e52b94](https://github.com/havenhq/revideo/commit/1e52b945cac15dc7da2d9db8fbcf5d88ba293c6f))
+* **docs:** small corrections ([#108](https://github.com/havenhq/revideo/issues/108)) ([9212343](https://github.com/havenhq/revideo/commit/921234377bad7bb0f334c5dda04498cce26f7891))
+* **docs:** support multiple fiddles ([#572](https://github.com/havenhq/revideo/issues/572)) ([899f133](https://github.com/havenhq/revideo/commit/899f133dd6632e0ffa559bf3f258f94cf75891a7))
+* **docs:** support multiple fiddles again ([#574](https://github.com/havenhq/revideo/issues/574)) ([d1867e9](https://github.com/havenhq/revideo/commit/d1867e90998f5e36f819779bb5473a43ca4b3d7e))
+* **e2e:** update snapshot names ([#536](https://github.com/havenhq/revideo/issues/536)) ([b150f08](https://github.com/havenhq/revideo/commit/b150f080807e33cfe8ded302951411e4c14741db))
+* empty time events crashing ([a1c53de](https://github.com/havenhq/revideo/commit/a1c53deba7c405ddf1a3b4874f22b63e0b085af9))
+* exclude preact from optimizations ([#894](https://github.com/havenhq/revideo/issues/894)) ([15687cc](https://github.com/havenhq/revideo/commit/15687cc975abcf4538a5ce51402d2308057d42e5))
+* fix compound property setter ([#218](https://github.com/havenhq/revideo/issues/218)) ([6cd1b95](https://github.com/havenhq/revideo/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)), closes [#208](https://github.com/havenhq/revideo/issues/208) [#210](https://github.com/havenhq/revideo/issues/210)
+* fix dependency bundling ([#897](https://github.com/havenhq/revideo/issues/897)) ([5376012](https://github.com/havenhq/revideo/commit/5376012cd02b8bca5abc2d3cf5a724662244c449))
+* fix dependency bundling again ([#898](https://github.com/havenhq/revideo/issues/898)) ([d6e0f48](https://github.com/havenhq/revideo/commit/d6e0f48e67cf6baee710b8d5b185e620e67ceda5))
+* fix docs workflow ([#102](https://github.com/havenhq/revideo/issues/102)) ([f591169](https://github.com/havenhq/revideo/commit/f5911699a7ae6b970ee4c0de891383a9c0cd5d0d))
+* fix docs workflow ([#103](https://github.com/havenhq/revideo/issues/103)) ([b9e2006](https://github.com/havenhq/revideo/commit/b9e20063be6aab75471d2a91cf862ac5bdc70e12))
+* fix docs workflow ([#104](https://github.com/havenhq/revideo/issues/104)) ([7e59a1a](https://github.com/havenhq/revideo/commit/7e59a1a5f77f4be65e599f539e16f6cf58785d9c))
+* fix hot reload ([#26](https://github.com/havenhq/revideo/issues/26)) ([2ad746e](https://github.com/havenhq/revideo/commit/2ad746e1eff705c2eb29ea9c83ad9810eeb54b05))
+* fix meta file version and timing ([#32](https://github.com/havenhq/revideo/issues/32)) ([a369610](https://github.com/havenhq/revideo/commit/a36961007eb7ac238b87ade3a03da101a1940800))
+* fix player state not being saved ([#85](https://github.com/havenhq/revideo/issues/85)) ([74b54b9](https://github.com/havenhq/revideo/commit/74b54b970d1287e80fe2334a034844ad6a80c23b))
+* fix project selection screen ([#938](https://github.com/havenhq/revideo/issues/938)) ([3b3f287](https://github.com/havenhq/revideo/commit/3b3f2871d9884c67f7d46215dd12fc02e27f8054))
+* fix scaffolding ([#93](https://github.com/havenhq/revideo/issues/93)) ([95c55ed](https://github.com/havenhq/revideo/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
+* fix tsdoc comments ([#21](https://github.com/havenhq/revideo/issues/21)) ([4b6cb66](https://github.com/havenhq/revideo/commit/4b6cb660ad82befcfd41188c7a8f9c8c0cba93ed)), closes [#18](https://github.com/havenhq/revideo/issues/18)
+* improper cloning of custom fields ([#925](https://github.com/havenhq/revideo/issues/925)) ([4981da7](https://github.com/havenhq/revideo/commit/4981da74e7b2b0e106fa14f1af2eac62d2bf82f4))
+* **legacy:** add missing files ([#61](https://github.com/havenhq/revideo/issues/61)) ([fad87d5](https://github.com/havenhq/revideo/commit/fad87d5aa5500e7c63cb914fc51044db6225502e))
+* limit fps to positive numbers ([#937](https://github.com/havenhq/revideo/issues/937)) ([c7c0c67](https://github.com/havenhq/revideo/commit/c7c0c6730e1a00e6b23077188bfc2d389e98cff2)), closes [#936](https://github.com/havenhq/revideo/issues/936)
+* load project state correctly ([#27](https://github.com/havenhq/revideo/issues/27)) ([8ae0233](https://github.com/havenhq/revideo/commit/8ae02335d71858413bffb265573bd83a1e38d89e))
+* make panes scrollable ([#14](https://github.com/havenhq/revideo/issues/14)) ([dc9fd38](https://github.com/havenhq/revideo/commit/dc9fd380285c9dfcc6d8503cca87c32e01f11381))
+* marked index.mjs as executable such that the cli will run on linux ([#47](https://github.com/havenhq/revideo/issues/47)) ([722d5eb](https://github.com/havenhq/revideo/commit/722d5eb72b8f4659ff93f57737d70f2650b91f81)), closes [#46](https://github.com/havenhq/revideo/issues/46)
+* MeshBoneMaterial opacity ([24db561](https://github.com/havenhq/revideo/commit/24db5613aca19e5de2672aaf31f422e51aee19c8))
+* plug memory leaks ([#385](https://github.com/havenhq/revideo/issues/385)) ([de0af00](https://github.com/havenhq/revideo/commit/de0af00a7d2e019e2a933791c62b7901755be7b0))
+* pre-commit hook will now work on linux and mac ([#51](https://github.com/havenhq/revideo/issues/51)) ([ef80035](https://github.com/havenhq/revideo/commit/ef80035ff7f67f48339049e9f0ded60c79180cb6))
+* prevent Color tree shaking ([#666](https://github.com/havenhq/revideo/issues/666)) ([e5028e3](https://github.com/havenhq/revideo/commit/e5028e3c176d5ba74dd3f28c2f25672390c76936)), closes [#577](https://github.com/havenhq/revideo/issues/577)
+* prevent consumePromises from halting ([#657](https://github.com/havenhq/revideo/issues/657)) ([363a189](https://github.com/havenhq/revideo/commit/363a189b0c7f5926c9d5ae00b58b48e8ed4d9b48))
+* prevent scrolling timeline with arrow keys ([#4](https://github.com/havenhq/revideo/issues/4)) ([dfc8108](https://github.com/havenhq/revideo/commit/dfc8108976f5c20a4b4a44bee788ee71011769c6))
+* previous scene being rendered twice ([#97](https://github.com/havenhq/revideo/issues/97)) ([90205bd](https://github.com/havenhq/revideo/commit/90205bdc1a086abe5f73b04cb4616c6af5ec4377))
+* previous scene invisible when seeking ([65e32f0](https://github.com/havenhq/revideo/commit/65e32f03b79af730064c935eaf1645019c303399))
+* previous scenes not getting disposed ([bf3a1fc](https://github.com/havenhq/revideo/commit/bf3a1fcf5fc22758893b5b742ca00a5741a5d560))
+* range middle-click expansion ([1c0b724](https://github.com/havenhq/revideo/commit/1c0b7243cffa3e33779b736ecce2dad19880f796))
+* re-render the scene when canvas changes ([#55](https://github.com/havenhq/revideo/issues/55)) ([191f96d](https://github.com/havenhq/revideo/commit/191f96da1441bc37d6e61e1acdcfde6994a7f9f3))
+* remove dependency pre-bundling warning ([#676](https://github.com/havenhq/revideo/issues/676)) ([38c81ff](https://github.com/havenhq/revideo/commit/38c81ffa5ea0ef2d2beec9d015896f5873629d74))
+* remove inconsistency in playhead controls ([#1](https://github.com/havenhq/revideo/issues/1)) ([58cdb4a](https://github.com/havenhq/revideo/commit/58cdb4a26144f9933dba64d687fa63d442f115bd))
+* resolve asset file paths differently when they are inside project ([#5](https://github.com/havenhq/revideo/issues/5)) ([e0a3917](https://github.com/havenhq/revideo/commit/e0a39175a34f501ffce0fa4508c83e84244fd43c))
+* respect child origins in LinearLayout ([5ee114d](https://github.com/havenhq/revideo/commit/5ee114ddd9e48d6cea5360ea090c17f1dbc8c641))
+* restrict size of cache canvas ([#544](https://github.com/havenhq/revideo/issues/544)) ([49ec554](https://github.com/havenhq/revideo/commit/49ec55490718e503d9a39437ae13c189dc4fe9ea))
+* restrict the corner radius of a rectangle ([#9](https://github.com/havenhq/revideo/issues/9)) ([cc86a4a](https://github.com/havenhq/revideo/commit/cc86a4a6d5b44e75ed02a1bdf90b588450a663b2)), closes [#8](https://github.com/havenhq/revideo/issues/8)
+* save time events only if they're actively used ([#35](https://github.com/havenhq/revideo/issues/35)) ([bd78c89](https://github.com/havenhq/revideo/commit/bd78c8967ba395beeb352006b5f33768b4a4c498)), closes [#33](https://github.com/havenhq/revideo/issues/33) [#34](https://github.com/havenhq/revideo/issues/34)
+* save timeline state ([9d57b8a](https://github.com/havenhq/revideo/commit/9d57b8ae1f7cfd6ec468d3348aa0fda4afd88a84))
+* support color to null tweening ([#387](https://github.com/havenhq/revideo/issues/387)) ([02e9f22](https://github.com/havenhq/revideo/commit/02e9f22027a1c3a85ffcc259aeca913318fb6f54))
+* support hmr when navigating ([370ea16](https://github.com/havenhq/revideo/commit/370ea1676a1c34313c0fb917c0f0691538f72016))
+* support legacy imports again ([#868](https://github.com/havenhq/revideo/issues/868)) ([77c4e2e](https://github.com/havenhq/revideo/commit/77c4e2eeb8b0f73bdef1f72e3d81f34c79748929))
+* support multiple async players ([#450](https://github.com/havenhq/revideo/issues/450)) ([d7ec469](https://github.com/havenhq/revideo/commit/d7ec469e747eefd909f4dd59dd713f5d86308222)), closes [#434](https://github.com/havenhq/revideo/issues/434)
+* support nested threads ([#84](https://github.com/havenhq/revideo/issues/84)) ([4a4a95f](https://github.com/havenhq/revideo/commit/4a4a95f5891b5ec674f67f6b889abe4e855509ac))
+* the resolution fields in Rendering no longer reset each other ([#73](https://github.com/havenhq/revideo/issues/73)) ([ddabec5](https://github.com/havenhq/revideo/commit/ddabec549be3cecec27cf9f5643b036e12a83472))
+* timeline will no longer seek when scrolling using the scrollbar ([#19](https://github.com/havenhq/revideo/issues/19)) ([c1b1680](https://github.com/havenhq/revideo/commit/c1b168065814edfe7dc4283366a98826c7d93d88))
+* typo on codeblock remove comments ([#368](https://github.com/havenhq/revideo/issues/368)) ([2025adc](https://github.com/havenhq/revideo/commit/2025adc6e7aa11d81b6f5f6989e8eae18cf86cb7))
+* **ui:** correctly drag time events ([#912](https://github.com/havenhq/revideo/issues/912)) ([81f6dd6](https://github.com/havenhq/revideo/commit/81f6dd6e485be451a50a695a146ed6b69e30bbc2))
+* **ui:** correctly reset zoom ([#432](https://github.com/havenhq/revideo/issues/432)) ([a33ee14](https://github.com/havenhq/revideo/commit/a33ee14dfac3e1fe24c89d76631e23fe4cb625a6))
+* **ui:** don't seek when editing time events ([#26](https://github.com/havenhq/revideo/issues/26)) ([524c200](https://github.com/havenhq/revideo/commit/524c200ef1bd6a6f52096d04c2aeed24a24cda6f))
+* **ui:** downgrade preact ([#1](https://github.com/havenhq/revideo/issues/1)) ([5f7456f](https://github.com/havenhq/revideo/commit/5f7456fe4c5a1cc76ccd8fed5a6f9a8a4e846d27))
+* **ui:** fix "go to source" ([#895](https://github.com/havenhq/revideo/issues/895)) ([ec729de](https://github.com/havenhq/revideo/commit/ec729dea0d65bc69aefc0abd601f365af1c4ed68))
+* **ui:** fix collapse ([#698](https://github.com/havenhq/revideo/issues/698)) ([6bd8703](https://github.com/havenhq/revideo/commit/6bd8703ec9b16f55b3817f6a1f9130f17b66c69a))
+* **ui:** fix inspector tab ([#374](https://github.com/havenhq/revideo/issues/374)) ([c4cb378](https://github.com/havenhq/revideo/commit/c4cb378c2f9d972bb41542bbe3b3aa314fa1f3ad))
+* **ui:** fix new version link ([#505](https://github.com/havenhq/revideo/issues/505)) ([7459e7f](https://github.com/havenhq/revideo/commit/7459e7f8355163f3cb6a3ed791fc41a2962a186e))
+* **ui:** fix onChange handlers ([#515](https://github.com/havenhq/revideo/issues/515)) ([a23d06c](https://github.com/havenhq/revideo/commit/a23d06cbf6e29f37a9259e50fe71c482640b83fb))
+* **ui:** fix out of range warning ([#939](https://github.com/havenhq/revideo/issues/939)) ([c9f466f](https://github.com/havenhq/revideo/commit/c9f466f20ff1a3e2cb77aa5575823947ef9beeee))
+* **ui:** fix play-pause button ([#299](https://github.com/havenhq/revideo/issues/299)) ([191f54a](https://github.com/havenhq/revideo/commit/191f54a0a5a9de2fd2dc27bffc6d21d692ce6f72))
+* **ui:** fix snapshot ([#643](https://github.com/havenhq/revideo/issues/643)) ([590216a](https://github.com/havenhq/revideo/commit/590216ac094d6b6ef3e9c773499bc52063f617b1))
+* **ui:** fix transparent background ([#886](https://github.com/havenhq/revideo/issues/886)) ([83f652f](https://github.com/havenhq/revideo/commit/83f652fdcfa075f5de24186ffdffd1b7db1d8fc9))
+* **ui:** fix typo in viewport ID ([#620](https://github.com/havenhq/revideo/issues/620)) ([3a83f20](https://github.com/havenhq/revideo/commit/3a83f20cb1b8ddc7b95a8e36bf6f3d0cd036693b))
+* **ui:** fix zoom to fit ([#561](https://github.com/havenhq/revideo/issues/561)) ([1c947b4](https://github.com/havenhq/revideo/commit/1c947b417e218809f33928d6cbb89d463bdc2e66))
+* **ui:** ignore shortcuts when typing ([#521](https://github.com/havenhq/revideo/issues/521)) ([4d3e1a1](https://github.com/havenhq/revideo/commit/4d3e1a13caee2ddd03857961a44dd10a7e1cb32a)), closes [#518](https://github.com/havenhq/revideo/issues/518)
+* **ui:** misaligned overlay ([#127](https://github.com/havenhq/revideo/issues/127)) ([0379730](https://github.com/havenhq/revideo/commit/03797302a302e28caf9f2428cfce4a122f827775))
+* **ui:** prevent context menu in viewport ([#123](https://github.com/havenhq/revideo/issues/123)) ([0fdd85e](https://github.com/havenhq/revideo/commit/0fdd85ecf5b61907ce1e16f5fb9253540528a8b0))
+* **ui:** prevent spawning multiple color pickers ([#747](https://github.com/havenhq/revideo/issues/747)) ([48ffd1f](https://github.com/havenhq/revideo/commit/48ffd1f2eec21f9880e172632a2310f5676e3c19)), closes [#744](https://github.com/havenhq/revideo/issues/744)
+* **ui:** prevent timeline scroll when zooming ([#162](https://github.com/havenhq/revideo/issues/162)) ([b8278ae](https://github.com/havenhq/revideo/commit/b8278aeb7b92f215bccbd1aa57de17c9233cff01))
+* **ui:** remember state of custom tabs ([#900](https://github.com/havenhq/revideo/issues/900)) ([eac45b8](https://github.com/havenhq/revideo/commit/eac45b88ed09fc7cddc3336e46d8697de5775b1f))
+* **ui:** remove glossy <select> effect in Safari ([#292](https://github.com/havenhq/revideo/issues/292)) ([9c062b2](https://github.com/havenhq/revideo/commit/9c062b26e48fbdb1905daae25a3fb34df82307d3))
+* **ui:** support small ranges ([#739](https://github.com/havenhq/revideo/issues/739)) ([cf32d8b](https://github.com/havenhq/revideo/commit/cf32d8b08b94f5044987eb554cd250fc79fbc99d)), closes [#738](https://github.com/havenhq/revideo/issues/738)
+* **ui:** use signals correctly ([#906](https://github.com/havenhq/revideo/issues/906)) ([f67d691](https://github.com/havenhq/revideo/commit/f67d691b5f2f6358120e9582a1839ef3d49c77b8))
+* **ui:** version comparison issue ([#520](https://github.com/havenhq/revideo/issues/520)) ([93b5e08](https://github.com/havenhq/revideo/commit/93b5e088b4a4fda0d2177cb2cc6680c34fa72d30)), closes [#519](https://github.com/havenhq/revideo/issues/519)
+* use correct scene sizes ([#146](https://github.com/havenhq/revideo/issues/146)) ([f279638](https://github.com/havenhq/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+* **vite-plugin:** add missing headers to html ([#219](https://github.com/havenhq/revideo/issues/219)) ([2552bcf](https://github.com/havenhq/revideo/commit/2552bcfbe2e90f3d4b86810d39f8cee24349e405)), closes [#201](https://github.com/havenhq/revideo/issues/201)
+* **vite-plugin:** can't assign port ([#538](https://github.com/havenhq/revideo/issues/538)) ([61b692b](https://github.com/havenhq/revideo/commit/61b692bf97bb7e15d31469ada2e3dda84c2b99f8))
+* **vite-plugin:** create empty output directory if not exist ([#787](https://github.com/havenhq/revideo/issues/787)) ([20cceef](https://github.com/havenhq/revideo/commit/20cceef8525e809bff9706fcd7082d7e103a085b))
+* **vite-plugin:** fix js template ([#337](https://github.com/havenhq/revideo/issues/337)) ([3b33d73](https://github.com/havenhq/revideo/commit/3b33d73416541d491b633bada29f085f5489f6c2))
+* **vite-plugin:** handle unusual characters in file names ([#821](https://github.com/havenhq/revideo/issues/821)) ([1e57497](https://github.com/havenhq/revideo/commit/1e5749785d55a41605a5438eee08672ef01f3914)), closes [#764](https://github.com/havenhq/revideo/issues/764)
+* **vite-plugin:** ignore query param in devserver ([#351](https://github.com/havenhq/revideo/issues/351)) ([5644d72](https://github.com/havenhq/revideo/commit/5644d72d36adcdc817f0856aaff0be5507338cb8))
+
+
+### Code Refactoring
+
+* introduce improved names ([#425](https://github.com/havenhq/revideo/issues/425)) ([4a2188d](https://github.com/havenhq/revideo/commit/4a2188d339587fa658b2134befc3fe63c835c5d7))
+* remove legacy package ([6a84120](https://github.com/havenhq/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+
+
+### Features
+
+* **2d:** add antialiased signal to Shape ([#282](https://github.com/havenhq/revideo/issues/282)) ([7c6905d](https://github.com/havenhq/revideo/commit/7c6905d72c6c2f49e10f0a80704c0afe3504d01b))
+* **2d:** add arcLength helper methods to Curve ([#627](https://github.com/havenhq/revideo/issues/627)) ([3c7546e](https://github.com/havenhq/revideo/commit/3c7546e7a509deb6fff8f669c3df0a69b492bd2e))
+* **2d:** add Bézier nodes ([#603](https://github.com/havenhq/revideo/issues/603)) ([9841cfd](https://github.com/havenhq/revideo/commit/9841cfdc3947ca4e6d6e42ed21eae88e855f855d))
+* **2d:** add cardinal points ([#636](https://github.com/havenhq/revideo/issues/636)) ([2136a25](https://github.com/havenhq/revideo/commit/2136a2558a9ed968ee505e4e5cce33d989dfdc13)), closes [#391](https://github.com/havenhq/revideo/issues/391)
+* **2d:** add closed property for circle ([#378](https://github.com/havenhq/revideo/issues/378)) ([62a9605](https://github.com/havenhq/revideo/commit/62a9605d4c54e7bf2d2d44d47bf769f5b27378a5))
+* **2d:** add completion property for curves ([#635](https://github.com/havenhq/revideo/issues/635)) ([6577d6d](https://github.com/havenhq/revideo/commit/6577d6ddfaf779ba02f3862d2a357166138b99ca))
+* **2d:** add default computed values for signals ([#259](https://github.com/havenhq/revideo/issues/259)) ([18f61a6](https://github.com/havenhq/revideo/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
+* **2d:** add fromDegrees method to Vector2 ([#622](https://github.com/havenhq/revideo/issues/622)) ([e78b9d5](https://github.com/havenhq/revideo/commit/e78b9d51674269ab82e0c2fe4c475b5799b94975))
+* **2d:** add Icon Component ([#306](https://github.com/havenhq/revideo/issues/306)) ([3479631](https://github.com/havenhq/revideo/commit/3479631ef34e39f90a8d8de441317672be1840d9)), closes [#305](https://github.com/havenhq/revideo/issues/305)
+* **2d:** add LaTeX component ([#228](https://github.com/havenhq/revideo/issues/228)) ([4c26d2a](https://github.com/havenhq/revideo/commit/4c26d2aaf0c697486639aa917cd5c585d3d0ea74))
+* **2d:** add line counter for CodeBlock ([#802](https://github.com/havenhq/revideo/issues/802)) ([c3f9676](https://github.com/havenhq/revideo/commit/c3f9676b6984731a09a44ab0b1fcfc226975fa08))
+* **2d:** add methods for rearranging children ([#81](https://github.com/havenhq/revideo/issues/81)) ([63f6c1a](https://github.com/havenhq/revideo/commit/63f6c1aa51ac4ecd093151c8cd30910f2e72bcac))
+* **2d:** add moveBelow, moveAbove and moveTo methods to Node ([#365](https://github.com/havenhq/revideo/issues/365)) ([16752a3](https://github.com/havenhq/revideo/commit/16752a3b8ae7461b33d6208a9675729f374e8324))
+* **2d:** add option for preformatted text ([#147](https://github.com/havenhq/revideo/issues/147)) ([989be53](https://github.com/havenhq/revideo/commit/989be532d86642e1125bb7fa62a801b09c1b8f26))
+* **2d:** add Path component ([#700](https://github.com/havenhq/revideo/issues/700)) ([2128b6b](https://github.com/havenhq/revideo/commit/2128b6bf871cabe19e1abc749f18945c78c01f84))
+* **2d:** add playbackRate signal to Video component ([#831](https://github.com/havenhq/revideo/issues/831)) ([5902b82](https://github.com/havenhq/revideo/commit/5902b824b36400876be0ee970e2c6211299faf21)), closes [#711](https://github.com/havenhq/revideo/issues/711)
+* **2d:** add Polygon component ([#463](https://github.com/havenhq/revideo/issues/463)) ([15adb3e](https://github.com/havenhq/revideo/commit/15adb3e312a4998b44c0b9c5fe5b5236f51c71c9)), closes [#455](https://github.com/havenhq/revideo/issues/455)
+* **2d:** add querying helpers ([#852](https://github.com/havenhq/revideo/issues/852)) ([614de6b](https://github.com/havenhq/revideo/commit/614de6bd8542322d1db4b123b875f6fad85cc4eb))
+* **2d:** add Ray node ([#628](https://github.com/havenhq/revideo/issues/628)) ([649447c](https://github.com/havenhq/revideo/commit/649447cd5f2089afc64cc7bd4b0276e69d1e9a30))
+* **2d:** add save and restore methods to nodes ([#406](https://github.com/havenhq/revideo/issues/406)) ([870e194](https://github.com/havenhq/revideo/commit/870e1947d97382bc6d82857c077140bbef7cf7e8))
+* **2d:** add skew property ([#803](https://github.com/havenhq/revideo/issues/803)) ([eff7c7b](https://github.com/havenhq/revideo/commit/eff7c7be0c013139140b398350242457736d48c7))
+* **2d:** add smooth corners and sharpness to rect ([#310](https://github.com/havenhq/revideo/issues/310)) ([f7fbefd](https://github.com/havenhq/revideo/commit/f7fbefd27f7f6972cfb5a45a68e5d0aed9593ae4))
+* **2d:** add spline node ([#514](https://github.com/havenhq/revideo/issues/514)) ([3ce2111](https://github.com/havenhq/revideo/commit/3ce2111309e698450dc4c6e2ad47024995863e73))
+* **2d:** add start and end signals to Grid node ([#761](https://github.com/havenhq/revideo/issues/761)) ([e37ea80](https://github.com/havenhq/revideo/commit/e37ea806b94e93c6324d8e1b502468925b731e8e))
+* **2d:** add SVG component ([#763](https://github.com/havenhq/revideo/issues/763)) ([8eadc11](https://github.com/havenhq/revideo/commit/8eadc11937d4201545894f2f5b204d477a3f9094))
+* **2d:** add textAlign property ([#451](https://github.com/havenhq/revideo/issues/451)) ([3d15825](https://github.com/havenhq/revideo/commit/3d15825f3cc5a35ba081a31510741b824f3bc6ab)), closes [#303](https://github.com/havenhq/revideo/issues/303)
+* **2d:** add video component property getter ([#240](https://github.com/havenhq/revideo/issues/240)) ([59de5ab](https://github.com/havenhq/revideo/commit/59de5ab2c089589773a2f9ad7588eda7d72693a7))
+* **2d:** add z-index property to nodes ([#398](https://github.com/havenhq/revideo/issues/398)) ([4280af3](https://github.com/havenhq/revideo/commit/4280af3b4b7bd5970fe5e743949a0fcca2c314f3))
+* **2d:** always clip images and videos ([#773](https://github.com/havenhq/revideo/issues/773)) ([3938c59](https://github.com/havenhq/revideo/commit/3938c59394bfc42e5562504687d783ff306d7d32))
+* **2d:** clamp opacity value between 0 and 1 ([#835](https://github.com/havenhq/revideo/issues/835)) ([c54b2f8](https://github.com/havenhq/revideo/commit/c54b2f837a8e8b872df3610f4cc6caa94a728500)), closes [#830](https://github.com/havenhq/revideo/issues/830)
+* **2d:** code bounding box helpers ([#948](https://github.com/havenhq/revideo/issues/948)) ([0ffd56f](https://github.com/havenhq/revideo/commit/0ffd56f5f8076913e687e5b908311aa7832d8b7b))
+* **2d:** code range helpers ([#947](https://github.com/havenhq/revideo/issues/947)) ([044c9ac](https://github.com/havenhq/revideo/commit/044c9acd6ee7e4e337fb4d51286126f583a8da6f))
+* **2d:** code selection and modification ([#163](https://github.com/havenhq/revideo/issues/163)) ([e8e884a](https://github.com/havenhq/revideo/commit/e8e884a1a5574425dbf15272718911c12cfa2327))
+* **2d:** construct lines using signals ([#133](https://github.com/havenhq/revideo/issues/133)) ([2968a24](https://github.com/havenhq/revideo/commit/2968a2426564469fb4f4343fe71a6d30e95361f2))
+* **2d:** expand animations and reduced motion ([#671](https://github.com/havenhq/revideo/issues/671)) ([b8e9d03](https://github.com/havenhq/revideo/commit/b8e9d03488f8ca7085b3e7e1b095a52f39f2bc89))
+* **2d:** immediate restore ([#736](https://github.com/havenhq/revideo/issues/736)) ([634d51d](https://github.com/havenhq/revideo/commit/634d51d2afe8a536673c364874f8f3d1a450b846))
+* **2d:** improve property declarations ([27e7d26](https://github.com/havenhq/revideo/commit/27e7d267ee91bf1e8ca79686b6ec31347f9f4d41))
+* **2d:** improve Rect corner radius ([#120](https://github.com/havenhq/revideo/issues/120)) ([b471fe0](https://github.com/havenhq/revideo/commit/b471fe0e37c0a426d3af8299c9c3c22539e7df05))
+* **2d:** improve Video node ([#601](https://github.com/havenhq/revideo/issues/601)) ([3801d83](https://github.com/havenhq/revideo/commit/3801d83415bbdeeee5d6d53d0c18e5d9e78fba56))
+* **2d:** make `View2D` extend `Rect` ([#379](https://github.com/havenhq/revideo/issues/379)) ([93db5fc](https://github.com/havenhq/revideo/commit/93db5fc41617c0902e85fda90fbfc930c2b4634b))
+* **2d:** make Circle extend Curve ([#771](https://github.com/havenhq/revideo/issues/771)) ([4c8cf19](https://github.com/havenhq/revideo/commit/4c8cf1954093958eac507921dc18f67dd64b2052))
+* **2d:** make Polygon extend Curve ([#961](https://github.com/havenhq/revideo/issues/961)) ([739c9fc](https://github.com/havenhq/revideo/commit/739c9fccbc101f8b2eed680a11c00f317fdc4dd3))
+* **2d:** make Rect extend Curve ([#759](https://github.com/havenhq/revideo/issues/759)) ([9810212](https://github.com/havenhq/revideo/commit/9810212648824b9a2fa2ecd6b597e3319d20b325))
+* **2d:** nested Txt nodes ([#861](https://github.com/havenhq/revideo/issues/861)) ([f2786d0](https://github.com/havenhq/revideo/commit/f2786d0cd0d06065ca1e9eb9f6b4c11a74b6c283)), closes [#540](https://github.com/havenhq/revideo/issues/540)
+* **2d:** simplify layout prop ([c24cb12](https://github.com/havenhq/revideo/commit/c24cb12a22b7c85fdfb051917fa9ee1e0911717c))
+* **2d:** support HMR for images ([#641](https://github.com/havenhq/revideo/issues/641)) ([cf17520](https://github.com/havenhq/revideo/commit/cf17520aa8ddf19dcfc419c63cf7255892d45b71))
+* **2d:** support letter spacing in Code ([#955](https://github.com/havenhq/revideo/issues/955)) ([2a87c37](https://github.com/havenhq/revideo/commit/2a87c37c832de86c4b524b33fd68806627daec8b))
+* **2d:** support tweening in applyState ([#859](https://github.com/havenhq/revideo/issues/859)) ([b7ed2e2](https://github.com/havenhq/revideo/commit/b7ed2e24773227e5b576ff056eb23de9b9ff1676))
+* **2d:** support tweening Line points ([#853](https://github.com/havenhq/revideo/issues/853)) ([4bf37d7](https://github.com/havenhq/revideo/commit/4bf37d74d2e4bb9d9cc034aff121a32da9a6d146))
+* **2d:** unify desired sizes ([#118](https://github.com/havenhq/revideo/issues/118)) ([401a799](https://github.com/havenhq/revideo/commit/401a79946b034a96b9abff2f3fb5efd6cc9080f3))
+* **2d:** unify layout properties ([#355](https://github.com/havenhq/revideo/issues/355)) ([3cae97e](https://github.com/havenhq/revideo/commit/3cae97ea704d0533020fa87326dacadcc037d517)), closes [#352](https://github.com/havenhq/revideo/issues/352)
+* **2d:** visual feedback about rendering process ([#681](https://github.com/havenhq/revideo/issues/681)) ([d0495f5](https://github.com/havenhq/revideo/commit/d0495f5c6396c05454a5323e4486ab4829adbc9e))
+* **2d:** warn about missing image source ([#817](https://github.com/havenhq/revideo/issues/817)) ([6dcdb5f](https://github.com/havenhq/revideo/commit/6dcdb5f3b83d4860b1557e4745972e0af68f92f3))
+* add `useDuration` helper ([#226](https://github.com/havenhq/revideo/issues/226)) ([fa97d6c](https://github.com/havenhq/revideo/commit/fa97d6c7f076f287c9b86d2f8852341bd368ef1c)), closes [#171](https://github.com/havenhq/revideo/issues/171)
+* add advanced caching ([#69](https://github.com/havenhq/revideo/issues/69)) ([2a644c9](https://github.com/havenhq/revideo/commit/2a644c9315acfcc5280a5eacc9904df140a61e4f))
+* add audio volume control through arrow keys ([#856](https://github.com/havenhq/revideo/issues/856)) ([8b86fd4](https://github.com/havenhq/revideo/commit/8b86fd4e70f91a0d5b1150d760427ca355666341))
+* add base class for shapes ([#67](https://github.com/havenhq/revideo/issues/67)) ([d38c172](https://github.com/havenhq/revideo/commit/d38c1724e129c553739cbfc27c4e5cd8f737f067))
+* add basic documentation structure ([#10](https://github.com/havenhq/revideo/issues/10)) ([1e46433](https://github.com/havenhq/revideo/commit/1e46433af37e8fec18dec6efc7dc1e3b70d9a869)), closes [#2](https://github.com/havenhq/revideo/issues/2)
+* add basic logger ([#88](https://github.com/havenhq/revideo/issues/88)) ([3d82e86](https://github.com/havenhq/revideo/commit/3d82e863af3dc88b3709adbcd0b84e790d05c3b8)), closes [#17](https://github.com/havenhq/revideo/issues/17)
+* add basic transform to Node class ([#83](https://github.com/havenhq/revideo/issues/83)) ([9e114c8](https://github.com/havenhq/revideo/commit/9e114c8830a99c78e6a4fd9265b0e7552758af14))
+* add cloning ([#80](https://github.com/havenhq/revideo/issues/80)) ([47d7a0f](https://github.com/havenhq/revideo/commit/47d7a0fa5da9a03d8ed91557db651f6f960e28b1))
+* add CodeBlock component based on code-fns to 2D ([#78](https://github.com/havenhq/revideo/issues/78)) ([ad346f1](https://github.com/havenhq/revideo/commit/ad346f118d63b1e321ec315e1c70b925670124a1))
+* add coordinates to preview ([#737](https://github.com/havenhq/revideo/issues/737)) ([330c1f9](https://github.com/havenhq/revideo/commit/330c1f962fb920269301e7ee8a2c49cbfc723d85))
+* add default renderer ([#63](https://github.com/havenhq/revideo/issues/63)) ([9255490](https://github.com/havenhq/revideo/commit/92554900965fe088538f5e703dbab2fd84f904d7)), closes [#56](https://github.com/havenhq/revideo/issues/56) [#58](https://github.com/havenhq/revideo/issues/58)
+* add DEG2RAD and RAD2DEG constants ([#630](https://github.com/havenhq/revideo/issues/630)) ([01801e8](https://github.com/havenhq/revideo/commit/01801e8766058e75a6a020400650fb00f8f430cc))
+* add deprecation support ([#130](https://github.com/havenhq/revideo/issues/130)) ([da0e104](https://github.com/havenhq/revideo/commit/da0e104451af72eedb3eedd998f60b305fffdb0e))
+* add docs to monorepo ([#22](https://github.com/havenhq/revideo/issues/22)) ([129d557](https://github.com/havenhq/revideo/commit/129d557004c63df7a4ed514d0503709f03cf6e6b))
+* add E2E testing ([#101](https://github.com/havenhq/revideo/issues/101)) ([6398c54](https://github.com/havenhq/revideo/commit/6398c54e4c4d6667ce9f45b9bbef6ea110ea2215)), closes [#42](https://github.com/havenhq/revideo/issues/42)
+* add ease back interp functions ([#30](https://github.com/havenhq/revideo/issues/30)) ([c11046d](https://github.com/havenhq/revideo/commit/c11046d939bf5a29e28bda0ef97feabe2f985a0f))
+* add eslint ([658f468](https://github.com/havenhq/revideo/commit/658f468318c8ad88088bd5230172fb4d0bc2af00))
+* add experimental features ([#876](https://github.com/havenhq/revideo/issues/876)) ([498d387](https://github.com/havenhq/revideo/commit/498d3871d05d4dcc83453654bec7762d2ab32e7e))
+* add Grid node ([e1f83da](https://github.com/havenhq/revideo/commit/e1f83da1f43d20d392df4acb11e3df9cc457585d))
+* add inspection ([#82](https://github.com/havenhq/revideo/issues/82)) ([4d7f2ae](https://github.com/havenhq/revideo/commit/4d7f2aee6daeda1a2146b632dfdc28b455295776))
+* add layered layout ([381b2c0](https://github.com/havenhq/revideo/commit/381b2c083d90aa4fe815370afd0138dde114bf4a))
+* add LayoutText ([328b7b7](https://github.com/havenhq/revideo/commit/328b7b7f193b60223269002812f29922bc78132e))
+* add markdown logs ([#138](https://github.com/havenhq/revideo/issues/138)) ([e42447a](https://github.com/havenhq/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+* add meta files ([#28](https://github.com/havenhq/revideo/issues/28)) ([e29f7d0](https://github.com/havenhq/revideo/commit/e29f7d0ed01c7fb84f0931be5485fdde1aa0a5c2)), closes [#7](https://github.com/havenhq/revideo/issues/7)
+* add middle cardinal point ([#758](https://github.com/havenhq/revideo/issues/758)) ([b036eaf](https://github.com/havenhq/revideo/commit/b036eafc00381831c08267a78cf9d74973f4025a))
+* add missing flexbox properties ([#405](https://github.com/havenhq/revideo/issues/405)) ([4e78b4b](https://github.com/havenhq/revideo/commit/4e78b4b2fe4df42ce0a8da6fd41ad38b0104e7f5))
+* add missing layout props ([#72](https://github.com/havenhq/revideo/issues/72)) ([f808a56](https://github.com/havenhq/revideo/commit/f808a562b192fd03dba4b0d353284db344d6a80b))
+* add new hooks for plugins ([#679](https://github.com/havenhq/revideo/issues/679)) ([74e18bc](https://github.com/havenhq/revideo/commit/74e18bce71abd7e26a6415240603241b48cb36c2))
+* add node spawners ([#149](https://github.com/havenhq/revideo/issues/149)) ([da18a4e](https://github.com/havenhq/revideo/commit/da18a4e24104022a84ecd6cec1666b520186058f))
+* add option to group output by scenes ([#477](https://github.com/havenhq/revideo/issues/477)) ([9934593](https://github.com/havenhq/revideo/commit/99345937e7ac92fb674fdee10288e467ffd941e2))
+* add polyline ([#84](https://github.com/havenhq/revideo/issues/84)) ([4ceaf84](https://github.com/havenhq/revideo/commit/4ceaf842915ac43d81f292c58a4dc73a8d1bb8e9))
+* add pull request verification ([d91bab5](https://github.com/havenhq/revideo/commit/d91bab55832fed3e494842e9e17eed5281efecbb))
+* add random number generator ([#116](https://github.com/havenhq/revideo/issues/116)) ([d505312](https://github.com/havenhq/revideo/commit/d5053123eef308c7a2a61d92b6e76c637f4ed0b8)), closes [#14](https://github.com/havenhq/revideo/issues/14)
+* add rendering again ([#43](https://github.com/havenhq/revideo/issues/43)) ([c10d3db](https://github.com/havenhq/revideo/commit/c10d3dbb63f6248eda04128ef0aa9d72c1edfcf7))
+* add reparent helper ([80b95a9](https://github.com/havenhq/revideo/commit/80b95a9ce89d4a2eeea7e467257486e961602d69))
+* add scaffolding package ([#36](https://github.com/havenhq/revideo/issues/36)) ([266a561](https://github.com/havenhq/revideo/commit/266a561c619b57b403ec9c64185985b48bff29da)), closes [#30](https://github.com/havenhq/revideo/issues/30)
+* add support for meta files ([#11](https://github.com/havenhq/revideo/issues/11)) ([456790a](https://github.com/havenhq/revideo/commit/456790ab8c88bf28baa4843078013ff881c1a439))
+* add support for npm workspaces ([741567f](https://github.com/havenhq/revideo/commit/741567f8af4185a2b1bc5284064514d96e75f5f2))
+* add Text and Image components ([#70](https://github.com/havenhq/revideo/issues/70)) ([85c7dcd](https://github.com/havenhq/revideo/commit/85c7dcdb4f8ca2f0bfb03950c85a8d6f6652fcdf))
+* add video node ([#86](https://github.com/havenhq/revideo/issues/86)) ([f4aa654](https://github.com/havenhq/revideo/commit/f4aa65437a18cc85b00199f80cd5e04654c00c4b))
+* added a theme property to the CodeBlock component ([#279](https://github.com/havenhq/revideo/issues/279)) ([fe34fa8](https://github.com/havenhq/revideo/commit/fe34fa8ebfe66cd356fb1c3d85adedef11e03b45))
+* added color space option to Project and Player ([#89](https://github.com/havenhq/revideo/issues/89)) ([e1e2ac4](https://github.com/havenhq/revideo/commit/e1e2ac44ea35a9280b31e57fb365a227c7d2bba0)), closes [#80](https://github.com/havenhq/revideo/issues/80)
+* added Color Space option to Rendering panel  ([#24](https://github.com/havenhq/revideo/issues/24)) ([33f691d](https://github.com/havenhq/revideo/commit/33f691de086dbdb40841ba04a0ba5446a06056bb))
+* added custom resolution inputs to the rendering pane ([#20](https://github.com/havenhq/revideo/issues/20)) ([1f799b6](https://github.com/havenhq/revideo/commit/1f799b695e54f6cf3a16ede61a82a53be2e0c803))
+* added deepTween function and rewrote colorTween to use colorjs.io ([#88](https://github.com/havenhq/revideo/issues/88)) ([eb7ca3c](https://github.com/havenhq/revideo/commit/eb7ca3c8974ab2b2c905338a01e900c8938805b5)), closes [#73](https://github.com/havenhq/revideo/issues/73) [#78](https://github.com/havenhq/revideo/issues/78)
+* added file type and quality options to rendering panel ([#50](https://github.com/havenhq/revideo/issues/50)) ([bee71ef](https://github.com/havenhq/revideo/commit/bee71ef2673c269db47a4433831720b7ad0fb4e8)), closes [#24](https://github.com/havenhq/revideo/issues/24)
+* added useContext and useContextAfter hooks ([#63](https://github.com/havenhq/revideo/issues/63)) ([352e131](https://github.com/havenhq/revideo/commit/352e13104361389e81d96eadeb41a680eaafafdb)), closes [#58](https://github.com/havenhq/revideo/issues/58)
+* animation player ([#92](https://github.com/havenhq/revideo/issues/92)) ([8155118](https://github.com/havenhq/revideo/commit/8155118eb13dc2a8b422b81aabacc923ce2f919b))
+* AnimationClip ([681146a](https://github.com/havenhq/revideo/commit/681146a8e92a4360975472939eb2494b89f02eff))
+* application settings ([#697](https://github.com/havenhq/revideo/issues/697)) ([54016f5](https://github.com/havenhq/revideo/commit/54016f5cf3500abe13a217537307a3735d60f536)), closes [#167](https://github.com/havenhq/revideo/issues/167)
+* arc tween ratio ([27dbb0b](https://github.com/havenhq/revideo/commit/27dbb0bd2749600cdee6944a469ee10870989a28))
+* audio offset ([88f40aa](https://github.com/havenhq/revideo/commit/88f40aa93bb23090058965bd7d76b81106804c05))
+* audio playback ([e9a6fdb](https://github.com/havenhq/revideo/commit/e9a6fdb51e62dd8e7a0ca43e7ae6908ff7d92c53))
+* audio toggle control ([300f18e](https://github.com/havenhq/revideo/commit/300f18e9c9c0ad559edb14bbfce889a717ab15c2))
+* audio waveform track ([9aff955](https://github.com/havenhq/revideo/commit/9aff955ef472644834d1232b90a93b935127fffd))
+* auto meta fields ([#565](https://github.com/havenhq/revideo/issues/565)) ([645af6d](https://github.com/havenhq/revideo/commit/645af6d2b7e8d9332b6f08419c318ee9434d7f3f))
+* better children and spawners ([#858](https://github.com/havenhq/revideo/issues/858)) ([9b5c23d](https://github.com/havenhq/revideo/commit/9b5c23d2076180cf710656c817369a07b253e3ec))
+* better dependencies between packages ([#152](https://github.com/havenhq/revideo/issues/152)) ([a0a37b3](https://github.com/havenhq/revideo/commit/a0a37b3645fcb91206e65fd0a95b2f486b308c75))
+* better dependencies between packages ([#153](https://github.com/havenhq/revideo/issues/153)) ([59a73d4](https://github.com/havenhq/revideo/commit/59a73d49a7b92c416e1f836a0f53bb676e9f924b))
+* better naming conventions ([#62](https://github.com/havenhq/revideo/issues/62)) ([a9d764f](https://github.com/havenhq/revideo/commit/a9d764fbceb639497ef45f44c90f9b6e408213d3))
+* better playback controls ([796ae33](https://github.com/havenhq/revideo/commit/796ae3356c4853a38e1e6471cb62e73b47f02fd2))
+* better time events ([8c2bf27](https://github.com/havenhq/revideo/commit/8c2bf27ac7bac9d6f77a15ec99d433baa4329c0e))
+* better time events ([1acd71b](https://github.com/havenhq/revideo/commit/1acd71bb4d13d927040b42a8f77faf87ee185a3b))
+* blob rendering ([4dff949](https://github.com/havenhq/revideo/commit/4dff949de9a7cfa781e9738c625c5c46d63e1da5))
+* browser based renderer ([13dc24c](https://github.com/havenhq/revideo/commit/13dc24ca69e31dab911cc1211b56684c28425e85))
+* button for opening the output directory ([#663](https://github.com/havenhq/revideo/issues/663)) ([79f320c](https://github.com/havenhq/revideo/commit/79f320c07c422ca927b34bf339094fe0e70ffd0d))
+* circular mask for surfaces ([4db62d8](https://github.com/havenhq/revideo/commit/4db62d8a6572dda0931e0826f2fab359ee9accad))
+* clamp function ([94543d1](https://github.com/havenhq/revideo/commit/94543d1079a46d9a8c8d26b87bd91dc2c5e17aea))
+* color picker ([ac48055](https://github.com/havenhq/revideo/commit/ac48055b4ffd833fb1fca6fcd0b2fd7d38a57aab))
+* configurable framerate and resolution ([a715f5c](https://github.com/havenhq/revideo/commit/a715f5c1acd28e2e1dd5496ea8cb4b23b4cea7be))
+* configurable framerate and resolution ([a591683](https://github.com/havenhq/revideo/commit/a591683f93e92f1f41ad89fd7d23eea67d32e3ac))
+* connections ([49254fc](https://github.com/havenhq/revideo/commit/49254fc36cc03c8f8557c14ff86ab38f56229b04))
+* convert built-in types to webgl ([#929](https://github.com/havenhq/revideo/issues/929)) ([a0f0b7d](https://github.com/havenhq/revideo/commit/a0f0b7d8996547e1a316097422ec02bddeeccec6))
+* **core:** accept PossibleMatrix2D when transforming bbox ([#770](https://github.com/havenhq/revideo/issues/770)) ([ae05282](https://github.com/havenhq/revideo/commit/ae0528266f5794aa0517f32b897c5fe6ff092a58))
+* **core:** add `debug` helper function ([#293](https://github.com/havenhq/revideo/issues/293)) ([b870873](https://github.com/havenhq/revideo/commit/b8708732af0fc08d9ff9eeecbbb77d65f1b36eb8))
+* **core:** add `gauss` function to `Random` ([#709](https://github.com/havenhq/revideo/issues/709)) ([d7de3d5](https://github.com/havenhq/revideo/commit/d7de3d56d05dc88c7cbd557a73a25d083abb54e4))
+* **core:** add `loopFor` function ([#650](https://github.com/havenhq/revideo/issues/650)) ([a42eb52](https://github.com/havenhq/revideo/commit/a42eb520fef7de06038f0df9eaad1fa35122c97a))
+* **core:** add `loopUntil` function ([#624](https://github.com/havenhq/revideo/issues/624)) ([b7aa4b5](https://github.com/havenhq/revideo/commit/b7aa4b57c76374e67bd19ce40c44cd650cf67327))
+* **core:** add configurable line numbers ([#44](https://github.com/havenhq/revideo/issues/44)) ([831334c](https://github.com/havenhq/revideo/commit/831334ca32a504991e875af37446fef4f055c285)), closes [#12](https://github.com/havenhq/revideo/issues/12)
+* **core:** add fadeTransition ([#384](https://github.com/havenhq/revideo/issues/384)) ([a248785](https://github.com/havenhq/revideo/commit/a248785e87d1c6ebc08581f4fda6be428a89824c))
+* **core:** add helper method for arc lerps ([#640](https://github.com/havenhq/revideo/issues/640)) ([bc304d2](https://github.com/havenhq/revideo/commit/bc304d242e4819650fa86636180ac5594ba743d3))
+* **core:** add intersects method to BBox ([#485](https://github.com/havenhq/revideo/issues/485)) ([604b0e7](https://github.com/havenhq/revideo/commit/604b0e7c22b4e5d196310e650f7c764526a80712))
+* **core:** add Matrix2D type ([#340](https://github.com/havenhq/revideo/issues/340)) ([66b41e6](https://github.com/havenhq/revideo/commit/66b41e6beaca5c2ba4b6bd1a7e68ca16d183b0e9))
+* **core:** add rotate and polarLerp methods to vector ([#756](https://github.com/havenhq/revideo/issues/756)) ([a18bac3](https://github.com/havenhq/revideo/commit/a18bac3c1755fa3e3240b5469ac7bc1f08b4fd24))
+* **core:** add spring interpolation ([#356](https://github.com/havenhq/revideo/issues/356)) ([1463b15](https://github.com/havenhq/revideo/commit/1463b1592e22fad9d8298c11270e2099119e2229))
+* **core:** add static properties to Vector2 corresponding to Origins ([#855](https://github.com/havenhq/revideo/issues/855)) ([9bbd249](https://github.com/havenhq/revideo/commit/9bbd249e1f7864a49ff2da49bc18d9309888f902)), closes [#844](https://github.com/havenhq/revideo/issues/844)
+* **core:** add step parameter to range function ([#373](https://github.com/havenhq/revideo/issues/373)) ([923209a](https://github.com/havenhq/revideo/commit/923209a4106c8e7f570853dcc47a10e65e0d04d8))
+* **core:** additional easing functions ([#274](https://github.com/havenhq/revideo/issues/274)) ([f81ce43](https://github.com/havenhq/revideo/commit/f81ce43019fe253e99f4ab6311c2251b40e2eae3))
+* **core:** allow getting real size of scenes ([#889](https://github.com/havenhq/revideo/issues/889)) ([3a6a672](https://github.com/havenhq/revideo/commit/3a6a672bed9098bec81d9c5347459317cbbf4c2a))
+* **core:** allow ordering of scenes during transition ([#832](https://github.com/havenhq/revideo/issues/832)) ([7a62b59](https://github.com/havenhq/revideo/commit/7a62b59c377dca8bf1f56bb551b47b9a75a6afba)), closes [#369](https://github.com/havenhq/revideo/issues/369)
+* **core:** disallow tweening to/from undefined values ([#257](https://github.com/havenhq/revideo/issues/257)) ([d4bb791](https://github.com/havenhq/revideo/commit/d4bb79145300b52c4b4d101df2afaff5ea11a9e9))
+* **core:** error double event name ([#341](https://github.com/havenhq/revideo/issues/341)) ([053b2a6](https://github.com/havenhq/revideo/commit/053b2a6c22c4e726e3962fdaf0a2e8d149889a9b))
+* **core:** expand Vector2 type ([#579](https://github.com/havenhq/revideo/issues/579)) ([010bba5](https://github.com/havenhq/revideo/commit/010bba593e1c3ce368ab409dce09dbde8f999958))
+* **core:** helper methods for references ([#775](https://github.com/havenhq/revideo/issues/775)) ([3255add](https://github.com/havenhq/revideo/commit/3255add1b05a37017d60c2eaccf4368ab4f7f568))
+* **core:** hot module replacement for audio ([#793](https://github.com/havenhq/revideo/issues/793)) ([d40c1a8](https://github.com/havenhq/revideo/commit/d40c1a83c645c8984cca1ebc6fe687b445a0550c))
+* **core:** improve `SignalGenerator` chaining ([#651](https://github.com/havenhq/revideo/issues/651)) ([de72f1f](https://github.com/havenhq/revideo/commit/de72f1f70edf7cc48fd670d9b38e0cc27f8bdb57)), closes [#480](https://github.com/havenhq/revideo/issues/480)
+* **core:** improve loop function ([#952](https://github.com/havenhq/revideo/issues/952)) ([66c18bb](https://github.com/havenhq/revideo/commit/66c18bb41617a4fbe9e3be5253b3ced02caf0cae))
+* **core:** presentation mode ([#486](https://github.com/havenhq/revideo/issues/486)) ([c4f2e48](https://github.com/havenhq/revideo/commit/c4f2e48ae6c65804ae46edd88c29125b7f983d5c))
+* **core:** preserve custom fields in meta files ([#534](https://github.com/havenhq/revideo/issues/534)) ([2e3e22e](https://github.com/havenhq/revideo/commit/2e3e22efd62ba671624526fc10ea7dd2a04a5240))
+* **core:** seek to beginning of timeline in disable loop mode ([#823](https://github.com/havenhq/revideo/issues/823)) ([3595646](https://github.com/havenhq/revideo/commit/359564645575c6f20870f4bf9642e72404717f14)), closes [#822](https://github.com/havenhq/revideo/issues/822)
+* **core:** spawn function ([#951](https://github.com/havenhq/revideo/issues/951)) ([51d8cf0](https://github.com/havenhq/revideo/commit/51d8cf0b64592fe56a0e31b5c3acc155226a9b2e))
+* **core:** support Origin in slideTransition ([#801](https://github.com/havenhq/revideo/issues/801)) ([0a3df28](https://github.com/havenhq/revideo/commit/0a3df2829fd7b308604eda3d005e90daf032e284))
+* **core:** switch to vitest ([#99](https://github.com/havenhq/revideo/issues/99)) ([762eeb0](https://github.com/havenhq/revideo/commit/762eeb0a99c2f378d20dbd147f815ba6736099d9)), closes [#48](https://github.com/havenhq/revideo/issues/48)
+* **core:** thread pausing ([#639](https://github.com/havenhq/revideo/issues/639)) ([c0aab58](https://github.com/havenhq/revideo/commit/c0aab588b18c267d3bc04e25b2f80c792496dda2))
+* **core:** tree shaking ([#523](https://github.com/havenhq/revideo/issues/523)) ([65fec78](https://github.com/havenhq/revideo/commit/65fec7825fda33812b13f57bfeb1d82193a5d190))
+* create new release ([20282e9](https://github.com/havenhq/revideo/commit/20282e9745a42c5bf62d104afe65fa71fbd973a2))
+* **create:** add exporter selection ([#673](https://github.com/havenhq/revideo/issues/673)) ([82fd47d](https://github.com/havenhq/revideo/commit/82fd47d93ffad6125a685880a132ce0d3a388693))
+* **create:** include simple animation ([#931](https://github.com/havenhq/revideo/issues/931)) ([925f63f](https://github.com/havenhq/revideo/commit/925f63f3588922224511b1687ac44ba7b9920d83))
+* **create:** support command-line arguments ([#668](https://github.com/havenhq/revideo/issues/668)) ([fa62a98](https://github.com/havenhq/revideo/commit/fa62a9868d5cd33f1cb6ac5f147cca81917457dc))
+* custom loaders ([5a3ab9a](https://github.com/havenhq/revideo/commit/5a3ab9ad4d2d332d99d594c8812adc32a8d4b04c))
+* decouple Konva from core ([#54](https://github.com/havenhq/revideo/issues/54)) ([02b5c75](https://github.com/havenhq/revideo/commit/02b5c75dba482dcf90a626142c8952f29009e299)), closes [#49](https://github.com/havenhq/revideo/issues/49) [#31](https://github.com/havenhq/revideo/issues/31)
+* detect circular signal dependencies ([#129](https://github.com/havenhq/revideo/issues/129)) ([6fcdb41](https://github.com/havenhq/revideo/commit/6fcdb41df90dca1c39537a4f6d4960ab551f4d6e))
+* directional padding and margin ([441d121](https://github.com/havenhq/revideo/commit/441d1210adbd85406d7dbe2edc21da044724a1ee))
+* display array values in inspector ([#670](https://github.com/havenhq/revideo/issues/670)) ([e71d74c](https://github.com/havenhq/revideo/commit/e71d74c9c04995393ad8ee942b8e6e5baa6f982f))
+* display current package versions ([#501](https://github.com/havenhq/revideo/issues/501)) ([2972f67](https://github.com/havenhq/revideo/commit/2972f673e201310e69688ab6f2c1adf1cddf2bf3))
+* display time in seconds ([0290a9c](https://github.com/havenhq/revideo/commit/0290a9cb0775693a4cde7d1fa3bee90c9329dcfb))
+* **docs:** add logo ([#23](https://github.com/havenhq/revideo/issues/23)) ([78698e4](https://github.com/havenhq/revideo/commit/78698e40a428d5a1aa469fbdad9c7c88e82230bc))
+* **docs:** add migration guide for v10 ([#37](https://github.com/havenhq/revideo/issues/37)) ([0905daa](https://github.com/havenhq/revideo/commit/0905daa60f42943554555834339d3ab70fe9b9c3))
+* **docs:** add search ([#335](https://github.com/havenhq/revideo/issues/335)) ([48f74a6](https://github.com/havenhq/revideo/commit/48f74a60d54cc52c7f069a9ec39071c99163bd19))
+* **docs:** add snippet toggle for fiddles ([#598](https://github.com/havenhq/revideo/issues/598)) ([d8b4e7c](https://github.com/havenhq/revideo/commit/d8b4e7cb8726dc8622e6fecfe1321c7c4c396cae))
+* **docs:** added CodeBlock documentation ([#302](https://github.com/havenhq/revideo/issues/302)) ([73f7221](https://github.com/havenhq/revideo/commit/73f7221536e09d5cf77f75ca173d1a7637d5b98f))
+* **docs:** always re-build api references in `build` mode ([#298](https://github.com/havenhq/revideo/issues/298)) ([27a4d96](https://github.com/havenhq/revideo/commit/27a4d96593d8e925385252b0d6f62646cd9fa6d5)), closes [#294](https://github.com/havenhq/revideo/issues/294)
+* **docs:** fiddle editor ([#542](https://github.com/havenhq/revideo/issues/542)) ([3c68fef](https://github.com/havenhq/revideo/commit/3c68fefdf7bf375ee9345aba7dbf9e5ff35e3c3d))
+* **docs:** fiddle error highlighting ([#713](https://github.com/havenhq/revideo/issues/713)) ([f281aff](https://github.com/havenhq/revideo/commit/f281aff27e31c7e06a415cdbfc44157b1d13a2f1))
+* **docs:** import folding ([#706](https://github.com/havenhq/revideo/issues/706)) ([bdb035f](https://github.com/havenhq/revideo/commit/bdb035f045f96e58cadbe7f9e6e3d25e2ffb04b2))
+* **docs:** improve Fiddle functionality ([#642](https://github.com/havenhq/revideo/issues/642)) ([fd3d6b3](https://github.com/havenhq/revideo/commit/fd3d6b38c04b7350c8337556801b8c54b4439033)), closes [#637](https://github.com/havenhq/revideo/issues/637)
+* **docs:** improve the release blog ([#410](https://github.com/havenhq/revideo/issues/410)) ([f56bbdb](https://github.com/havenhq/revideo/commit/f56bbdb4a95e62035f277737ea5fba675e591270))
+* **docs:** visual changes ([be83edf](https://github.com/havenhq/revideo/commit/be83edf847fb35cc77590ff5720f9eca79e9b787))
+* editor improvements ([#121](https://github.com/havenhq/revideo/issues/121)) ([e8b32ce](https://github.com/havenhq/revideo/commit/e8b32ceff1b8216282c4b5713508ce1172645e20))
+* export everything from entry points ([#710](https://github.com/havenhq/revideo/issues/710)) ([3c885d9](https://github.com/havenhq/revideo/commit/3c885d9083b52fbbaccf1e2560ae50817949bc52))
+* expose parts of player to outside of shadow root ([#956](https://github.com/havenhq/revideo/issues/956)) ([c996d39](https://github.com/havenhq/revideo/commit/c996d394dda9ba8c6a32f0360bf09e722ec15b0e)), closes [#950](https://github.com/havenhq/revideo/issues/950)
+* extract konva to separate package ([#60](https://github.com/havenhq/revideo/issues/60)) ([4ecad3c](https://github.com/havenhq/revideo/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
+* filter reordering ([#119](https://github.com/havenhq/revideo/issues/119)) ([2398d0f](https://github.com/havenhq/revideo/commit/2398d0f9d57f36b47c9c66a988ca5607e9a3a30e))
+* finalize custom exporters ([#660](https://github.com/havenhq/revideo/issues/660)) ([6a50430](https://github.com/havenhq/revideo/commit/6a50430cdf9928992ca078eba39c484a5253da2b))
+* follow utility ([fddfc67](https://github.com/havenhq/revideo/commit/fddfc67a42fc0f8e2a6f76d00a30c813592caf9e))
+* force rendering to restart seek time ([#14](https://github.com/havenhq/revideo/issues/14)) ([e94027a](https://github.com/havenhq/revideo/commit/e94027a36fe2a0b11f3aa42bb3fa869c10fbe1ea)), closes [#6](https://github.com/havenhq/revideo/issues/6)
+* framerate-independent timing ([#64](https://github.com/havenhq/revideo/issues/64)) ([6891f59](https://github.com/havenhq/revideo/commit/6891f5974145878bc18f200e70cff5117ac32bd3)), closes [#57](https://github.com/havenhq/revideo/issues/57)
+* function components ([178db3d](https://github.com/havenhq/revideo/commit/178db3d95c091e9abdf79e67548836332f40dc89))
+* general improvements ([320cced](https://github.com/havenhq/revideo/commit/320ccede3d764b8aabbcea2d92ee808efa36708a))
+* general improvements ([dbff3cc](https://github.com/havenhq/revideo/commit/dbff3cce379fb18eec5900ef9d90ba752ab826b4))
+* get name from meta file ([#552](https://github.com/havenhq/revideo/issues/552)) ([ae2ed8a](https://github.com/havenhq/revideo/commit/ae2ed8a5998768f160ec340d8b63d600d27bc15c))
+* grid ([d201a4d](https://github.com/havenhq/revideo/commit/d201a4d09393001f7106c2f33b17b49434f047e7))
+* grid and debug overlays ([895a53a](https://github.com/havenhq/revideo/commit/895a53ab4222c8d57a3e0d924181ee370b1356d7))
+* grid overlay ([f7aca18](https://github.com/havenhq/revideo/commit/f7aca1854c390c90bea3614180eb73b1f91375b8))
+* implement absolute scale setter ([842079a](https://github.com/havenhq/revideo/commit/842079a6547af4032719c85837df3db7c1c6d30a))
+* implement properties tab ([#10](https://github.com/havenhq/revideo/issues/10)) ([e882a7f](https://github.com/havenhq/revideo/commit/e882a7f52315a63508035899037cbab3278c1553))
+* improve async signals ([#156](https://github.com/havenhq/revideo/issues/156)) ([db27b9d](https://github.com/havenhq/revideo/commit/db27b9d5fb69a88f42afd98c86c4a1cdceb88ea1))
+* improve error logs ([#953](https://github.com/havenhq/revideo/issues/953)) ([3b528cc](https://github.com/havenhq/revideo/commit/3b528cce13a3440c97641d1095ce09e737e89960))
+* improve image error handling ([#847](https://github.com/havenhq/revideo/issues/847)) ([db09d53](https://github.com/havenhq/revideo/commit/db09d5305a3c0507b035e3cd347eaa65b23d7d2e))
+* improve layouts ([9a1fb5c](https://github.com/havenhq/revideo/commit/9a1fb5c7cd740a6f696c907a8f1d8ed900995985))
+* improve surface clipping ([#41](https://github.com/havenhq/revideo/issues/41)) ([003b7d5](https://github.com/havenhq/revideo/commit/003b7d58d6490170cea81b2d1b37cf59b4d698cf))
+* introduce basic caching ([#68](https://github.com/havenhq/revideo/issues/68)) ([6420d36](https://github.com/havenhq/revideo/commit/6420d362d0e4ae058f55b6ff6bb2a3a32dec559b))
+* introduce editor plugins ([#879](https://github.com/havenhq/revideo/issues/879)) ([2b72007](https://github.com/havenhq/revideo/commit/2b720074d45fc254dc40b534785b591ae44a3f37))
+* jsx ([3a633e8](https://github.com/havenhq/revideo/commit/3a633e882714c85043c014f98cad2d5d30b40607))
+* keyboard shortcuts ([4a3a7b5](https://github.com/havenhq/revideo/commit/4a3a7b53bccd89bd1dd93207e3e1b9640bdf6102))
+* layouts ([749f929](https://github.com/havenhq/revideo/commit/749f9297beae67bfa61cfcdf45806329574b75d1))
+* loading indication ([93638d5](https://github.com/havenhq/revideo/commit/93638d5e056711fa0f0473d20d16074d9c6f3fd5))
+* make exporting concurrent ([4f9ef8d](https://github.com/havenhq/revideo/commit/4f9ef8d40d9d9c1147e2edfc0766c5ea5cc4297c))
+* make scenes independent of names ([#53](https://github.com/havenhq/revideo/issues/53)) ([417617e](https://github.com/havenhq/revideo/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)), closes [#25](https://github.com/havenhq/revideo/issues/25)
+* make surfaces transparent by default ([#42](https://github.com/havenhq/revideo/issues/42)) ([cd71285](https://github.com/havenhq/revideo/commit/cd712857579ec45b3e6f40d0e48fce80fefed5b9)), closes [#25](https://github.com/havenhq/revideo/issues/25)
+* mask animation ([5771963](https://github.com/havenhq/revideo/commit/57719638cbca8f93c0e36f9380bfbe557a8633cd))
+* merge properties and signals ([#124](https://github.com/havenhq/revideo/issues/124)) ([da3ba83](https://github.com/havenhq/revideo/commit/da3ba83d82ee74f5a5c3631b07597f08cdf9e8e4))
+* meta field descriptions ([#664](https://github.com/havenhq/revideo/issues/664)) ([80c9d07](https://github.com/havenhq/revideo/commit/80c9d07f88f4a3df0f99e5741b31313f891a5d51))
+* minor console improvements ([#145](https://github.com/havenhq/revideo/issues/145)) ([3e32e73](https://github.com/havenhq/revideo/commit/3e32e73434ad872049af9e3f1f711bc0185410f4))
+* minor improvements ([403c7c2](https://github.com/havenhq/revideo/commit/403c7c27ad969880a14c498ec6cefb9e7e7b7544))
+* minor improvements ([#77](https://github.com/havenhq/revideo/issues/77)) ([7c6e584](https://github.com/havenhq/revideo/commit/7c6e584aca353c9af55f0acb61b32b5f99727dba))
+* move back playhead by a frame ([#18](https://github.com/havenhq/revideo/issues/18)) ([b944cd7](https://github.com/havenhq/revideo/commit/b944cd71c075e10622bd7bc81de90024c73438b7))
+* navigate to scene and node source ([#144](https://github.com/havenhq/revideo/issues/144)) ([86d495d](https://github.com/havenhq/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+* navigate to slide source ([#490](https://github.com/havenhq/revideo/issues/490)) ([b5ae4bf](https://github.com/havenhq/revideo/commit/b5ae4bf37076b262a20949cca030db3902186c8d))
+* new animator ([#91](https://github.com/havenhq/revideo/issues/91)) ([d85f2f8](https://github.com/havenhq/revideo/commit/d85f2f8a54c0f8bbfbc451884385f30e5b3ec206))
+* new Code node ([#946](https://github.com/havenhq/revideo/issues/946)) ([26e55a3](https://github.com/havenhq/revideo/commit/26e55a37c416fb1313c8aadf40eed2824b45d330))
+* new playback architecture ([#402](https://github.com/havenhq/revideo/issues/402)) ([bbe3e2a](https://github.com/havenhq/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)), closes [#166](https://github.com/havenhq/revideo/issues/166)
+* new plugin hooks ([#723](https://github.com/havenhq/revideo/issues/723)) ([9a2b5ab](https://github.com/havenhq/revideo/commit/9a2b5ab8be0d001414fd00da3053d408e00fd1cd))
+* open time events in editor ([#87](https://github.com/havenhq/revideo/issues/87)) ([74b781d](https://github.com/havenhq/revideo/commit/74b781d57fca7ef1d10904673276f2a7354c01b8))
+* package separation ([e69a566](https://github.com/havenhq/revideo/commit/e69a56635fbc073766018c8e53139a2135dbca10))
+* pan with shift and left click ([#7](https://github.com/havenhq/revideo/issues/7)) ([4ff8241](https://github.com/havenhq/revideo/commit/4ff82419bd0066c8efa2675b196c273b7105a7ca)), closes [#5](https://github.com/havenhq/revideo/issues/5)
+* playback controls ([94dab5d](https://github.com/havenhq/revideo/commit/94dab5dc1b8deaa4eaab561454699b3c22393618))
+* **player:** add auto mode ([c107259](https://github.com/havenhq/revideo/commit/c107259f7c2a3886ccfe4ca0140d13064aed238f))
+* **player:** improve accessibility ([0fc9235](https://github.com/havenhq/revideo/commit/0fc923576e7b12f9bc799f3a4e861861d49a2406))
+* plugin architecture ([#564](https://github.com/havenhq/revideo/issues/564)) ([1c375b8](https://github.com/havenhq/revideo/commit/1c375b81e0af8a76467d42dd46a7031adb9d71d3))
+* project variables ([#255](https://github.com/havenhq/revideo/issues/255)) ([4883295](https://github.com/havenhq/revideo/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
+* Promise support ([711f793](https://github.com/havenhq/revideo/commit/711f7937d86a9a0b2b7011b25799499d786e056d))
+* remove strongly-typed-events ([#48](https://github.com/havenhq/revideo/issues/48)) ([41947b5](https://github.com/havenhq/revideo/commit/41947b5ab6a2ec69d963f3445d1ea65d835c73ff))
+* remove ui elements ([8e5c288](https://github.com/havenhq/revideo/commit/8e5c288750dfe9f697939abac03678b7885df428))
+* renderer ui ([8a4e5d3](https://github.com/havenhq/revideo/commit/8a4e5d32b1e55f054bf3e98ef54c49f66655c034))
+* rendering ([60ccda7](https://github.com/havenhq/revideo/commit/60ccda723361751f28bc1144de314388551c95a2))
+* replaced `scene.transition` with `useTransition` ([#68](https://github.com/havenhq/revideo/issues/68)) ([f521115](https://github.com/havenhq/revideo/commit/f521115889a7f341e03b4e7ee7530a70f37760d8)), closes [#56](https://github.com/havenhq/revideo/issues/56)
+* scene transitions ([d45f1d3](https://github.com/havenhq/revideo/commit/d45f1d36bd23fbb5d07c6865ae31e624cba11bd2))
+* sidebar ([d5345ba](https://github.com/havenhq/revideo/commit/d5345ba444296b1648fab17274e241d879054833))
+* signal error handling ([#89](https://github.com/havenhq/revideo/issues/89)) ([472ac65](https://github.com/havenhq/revideo/commit/472ac65938b804a6b698c8522ec0c3b6bdbcf1b1))
+* simplify size access ([#65](https://github.com/havenhq/revideo/issues/65)) ([3315e64](https://github.com/havenhq/revideo/commit/3315e64641e9778bc48ea3fb707e3c0eeb581dfe))
+* simplify size access further ([#66](https://github.com/havenhq/revideo/issues/66)) ([9091a5e](https://github.com/havenhq/revideo/commit/9091a5e05d8fadf72c50832c7c4467ac4424b72c))
+* simplify the process of importing images ([#39](https://github.com/havenhq/revideo/issues/39)) ([0c2341f](https://github.com/havenhq/revideo/commit/0c2341fe255ee1702181e04f4cd2024a9eeabce5)), closes [#19](https://github.com/havenhq/revideo/issues/19)
+* sprites and threading ([a541682](https://github.com/havenhq/revideo/commit/a5416828bfb5d40f92c695b8a9a6df7b2d6686ca))
+* support for multiple projects ([#57](https://github.com/havenhq/revideo/issues/57)) ([573752d](https://github.com/havenhq/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)), closes [#141414](https://github.com/havenhq/revideo/issues/141414)
+* support lower framerate ([3c81086](https://github.com/havenhq/revideo/commit/3c81086829ad12dda805c355649cce7c0f156d2e))
+* support multiple players ([#128](https://github.com/havenhq/revideo/issues/128)) ([24f75cf](https://github.com/havenhq/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+* surfaceFrom animation ([77bb69e](https://github.com/havenhq/revideo/commit/77bb69e6a6481d412f800f65b6303c4c5f33cc94))
+* surfaces ([99f9e96](https://github.com/havenhq/revideo/commit/99f9e96a108bbd2a08a1931fd042a5969354da60))
+* switch to monorepo ([6c8d190](https://github.com/havenhq/revideo/commit/6c8d190c7d3d24bb4eac29eeb4b6d1abf370e160)), closes [#23](https://github.com/havenhq/revideo/issues/23) [#86](https://github.com/havenhq/revideo/issues/86) [#49](https://github.com/havenhq/revideo/issues/49)
+* switch to signals ([#64](https://github.com/havenhq/revideo/issues/64)) ([d22d237](https://github.com/havenhq/revideo/commit/d22d23728597e6fa82ea5c5a99a6c0a56819bded))
+* switch to Vite ([#28](https://github.com/havenhq/revideo/issues/28)) ([65b9133](https://github.com/havenhq/revideo/commit/65b91337dbc47fe51cecc83657f79fab15343a0d)), closes [#141414](https://github.com/havenhq/revideo/issues/141414) [#13](https://github.com/havenhq/revideo/issues/13)
+* threading ([e9f6b2a](https://github.com/havenhq/revideo/commit/e9f6b2ad0838f0240e8bbd196061ba6ce23eac27))
+* three.js integration ([79cc975](https://github.com/havenhq/revideo/commit/79cc975ecaa35d54f0e530f9b732d6472d965c3a))
+* time events ([f47cc66](https://github.com/havenhq/revideo/commit/f47cc666f64ee5733ebe200503bd94a1a48a9c02))
+* time events ([026a284](https://github.com/havenhq/revideo/commit/026a2840a3625172431fb073a513fea4499164d4))
+* time parameter for tweens ([3fe90ed](https://github.com/havenhq/revideo/commit/3fe90edc49abb910522c75d4df3c56b40c29731f))
+* timeline range ([ed2d78d](https://github.com/havenhq/revideo/commit/ed2d78dbba4211aac5317035f7ce0931db90a59a))
+* timeline tracks ([93a89cd](https://github.com/havenhq/revideo/commit/93a89cd6edf055ac7847b508ee4364eb42a6bcd4))
+* turn Layout into node ([#75](https://github.com/havenhq/revideo/issues/75)) ([cdf8dc0](https://github.com/havenhq/revideo/commit/cdf8dc0a35522482dee2dd78a69606b79f52246e))
+* **ui:** add color picker ([#691](https://github.com/havenhq/revideo/issues/691)) ([a33059c](https://github.com/havenhq/revideo/commit/a33059c0f455814919db31bc9e5e932907c797e4))
+* **ui:** add custom presentation overlays ([#884](https://github.com/havenhq/revideo/issues/884)) ([4696d3c](https://github.com/havenhq/revideo/commit/4696d3c8cb8b68e3475406359f9cf6b875b1c838)), closes [#825](https://github.com/havenhq/revideo/issues/825)
+* **ui:** add direct range selection & playhead shortcuts ([#907](https://github.com/havenhq/revideo/issues/907)) ([39264fc](https://github.com/havenhq/revideo/commit/39264fc074da739efddf24ef080f6c5f279f8014))
+* **ui:** add external link to docs ([#346](https://github.com/havenhq/revideo/issues/346)) ([fc4ee5d](https://github.com/havenhq/revideo/commit/fc4ee5d028312904ed9e11c5341ac00f36e7242b))
+* **ui:** add goto start and goto end buttons ([#814](https://github.com/havenhq/revideo/issues/814)) ([449f194](https://github.com/havenhq/revideo/commit/449f1946474af9886135571c14c83b8440bdf28c))
+* **ui:** add number input dragging ([#917](https://github.com/havenhq/revideo/issues/917)) ([1b5c232](https://github.com/havenhq/revideo/commit/1b5c23260c3015608f202a103b4c0aebd1860e36)), closes [#799](https://github.com/havenhq/revideo/issues/799)
+* **ui:** add quarter resolution ([#421](https://github.com/havenhq/revideo/issues/421)) ([d0160d0](https://github.com/havenhq/revideo/commit/d0160d0d5ef76ffb0d3591566891b5efa4061744))
+* **ui:** add shortcuts to button titles ([#532](https://github.com/havenhq/revideo/issues/532)) ([3549dd3](https://github.com/havenhq/revideo/commit/3549dd3fd7ef47376a5a2dd516609499d3985ac3))
+* **ui:** add volume slider ([#872](https://github.com/havenhq/revideo/issues/872)) ([5ac3069](https://github.com/havenhq/revideo/commit/5ac3069f027ee123c212217dcf8d26a78a3aa106))
+* **ui:** custom checkbox style ([#529](https://github.com/havenhq/revideo/issues/529)) ([af98db1](https://github.com/havenhq/revideo/commit/af98db103d66e8af059dc483d49984b9adb9b95c))
+* **ui:** custom inspectors ([#913](https://github.com/havenhq/revideo/issues/913)) ([6c54424](https://github.com/havenhq/revideo/commit/6c544248a2bd733f2d42676a0ed60c93b79ee574))
+* **ui:** estimate remaining rendering time ([#795](https://github.com/havenhq/revideo/issues/795)) ([1a46148](https://github.com/havenhq/revideo/commit/1a4614801869ab36827ca857d66eed8de9cffd09)), closes [#784](https://github.com/havenhq/revideo/issues/784)
+* **ui:** improve rendering button ([#662](https://github.com/havenhq/revideo/issues/662)) ([2b4ae70](https://github.com/havenhq/revideo/commit/2b4ae70ea0b0305fbb2596e95bbc70440718bbe2))
+* **ui:** include function names in stack traces ([#693](https://github.com/havenhq/revideo/issues/693)) ([835c0fa](https://github.com/havenhq/revideo/commit/835c0fa4b70429db6fe96be96d6d9e44949f7f6c))
+* **ui:** list available shortcuts ([#444](https://github.com/havenhq/revideo/issues/444)) ([443fcc9](https://github.com/havenhq/revideo/commit/443fcc9feb1a1ca69aecbc4db2e194ce4f50f72e))
+* **ui:** make inspector toggleable ([#921](https://github.com/havenhq/revideo/issues/921)) ([a365951](https://github.com/havenhq/revideo/commit/a365951e69c01cac1ea23d173034ad83f988c8eb))
+* **ui:** new sidebar ([#692](https://github.com/havenhq/revideo/issues/692)) ([b555ee1](https://github.com/havenhq/revideo/commit/b555ee1d10f8a6e1b380c043dff2717ffa01a068)), closes [#492](https://github.com/havenhq/revideo/issues/492)
+* **ui:** presentation interface ([#487](https://github.com/havenhq/revideo/issues/487)) ([1899f02](https://github.com/havenhq/revideo/commit/1899f020fb1c0b2136de4401e6fc068bcf5e0cc4))
+* **ui:** scene graph ([#909](https://github.com/havenhq/revideo/issues/909)) ([bf85c5b](https://github.com/havenhq/revideo/commit/bf85c5b4a339719e79da1b87b1aed4492166ce79))
+* **ui:** scene graph icons ([#914](https://github.com/havenhq/revideo/issues/914)) ([e92ddef](https://github.com/havenhq/revideo/commit/e92ddef34860f5e710ff0f1a310758ec0ca95bcb))
+* **ui:** shift + right arrow moves to last frame ([#354](https://github.com/havenhq/revideo/issues/354)) ([4b81709](https://github.com/havenhq/revideo/commit/4b8170971400c5bf4fe690a58d3f44c3e1d00b94)), closes [#353](https://github.com/havenhq/revideo/issues/353)
+* **ui:** small improvements ([#833](https://github.com/havenhq/revideo/issues/833)) ([f44400c](https://github.com/havenhq/revideo/commit/f44400c458a1d7f49520494f01efb9936f4df83e))
+* **ui:** timeline dragging ([#794](https://github.com/havenhq/revideo/issues/794)) ([248e454](https://github.com/havenhq/revideo/commit/248e4546367f9d99221f64b811a07d54a9988e48)), closes [#699](https://github.com/havenhq/revideo/issues/699)
+* **ui:** timeline overhaul ([#47](https://github.com/havenhq/revideo/issues/47)) ([4232a60](https://github.com/havenhq/revideo/commit/4232a6072540b54451e99e18c1001db0175bb93f)), closes [#20](https://github.com/havenhq/revideo/issues/20)
+* **ui:** timeline scrubbing ([#862](https://github.com/havenhq/revideo/issues/862)) ([211b9a4](https://github.com/havenhq/revideo/commit/211b9a4327720afd1ce0ff93868a501c2fd745aa)), closes [#286](https://github.com/havenhq/revideo/issues/286)
+* **ui:** vertical line on time event ([#808](https://github.com/havenhq/revideo/issues/808)) ([18015d6](https://github.com/havenhq/revideo/commit/18015d6714ffe2a6255f26895aa9a7c1908a4f7a)), closes [#804](https://github.com/havenhq/revideo/issues/804)
+* **ui:** visual changes ([#96](https://github.com/havenhq/revideo/issues/96)) ([3d599f4](https://github.com/havenhq/revideo/commit/3d599f4e1788fbd15e996be8bf95679f1c6787bd))
+* **ui:** zoom controls ([#531](https://github.com/havenhq/revideo/issues/531)) ([752350d](https://github.com/havenhq/revideo/commit/752350d0c547e21806f1b70a5c68025012e5ec11))
+* unify core types ([#71](https://github.com/havenhq/revideo/issues/71)) ([9c5853d](https://github.com/havenhq/revideo/commit/9c5853d8bc65204693c38109a25d1fefd44241b7))
+* unify references and signals ([#137](https://github.com/havenhq/revideo/issues/137)) ([063aede](https://github.com/havenhq/revideo/commit/063aede0842f948d2c6704c6edd426e954bb4668))
+* update core to 6.0.0 ([#17](https://github.com/havenhq/revideo/issues/17)) ([f8d453b](https://github.com/havenhq/revideo/commit/f8d453b22beb5250ea822d274ed2ab6bfea5c39c))
+* update vite from v3 to v4 ([#495](https://github.com/havenhq/revideo/issues/495)) ([c409eee](https://github.com/havenhq/revideo/commit/c409eee0e61b67e43afed240c5ae279714681246)), closes [#197](https://github.com/havenhq/revideo/issues/197)
+* upgrade code-fns for new theme options and lazy loading ([#401](https://github.com/havenhq/revideo/issues/401)) ([8965ab1](https://github.com/havenhq/revideo/commit/8965ab1bef8b6ae919c8001d0527f5793293b285)), closes [#396](https://github.com/havenhq/revideo/issues/396) [#322](https://github.com/havenhq/revideo/issues/322)
+* use ES modules in fiddles ([#712](https://github.com/havenhq/revideo/issues/712)) ([dbe2ad5](https://github.com/havenhq/revideo/commit/dbe2ad5644219c5a98d38c6557abfb66d793c821))
+* use PossibleVector2 in Vector2 methods ([#478](https://github.com/havenhq/revideo/issues/478)) ([8ccb44a](https://github.com/havenhq/revideo/commit/8ccb44a265016e25b2b177a65d44f801c9d861f9))
+* use Web Audio API for waveform generation ([817e244](https://github.com/havenhq/revideo/commit/817e244bb2187532df7142199917412ccfe8d218))
+* use Web Audio API for waveform generation ([ba3e16f](https://github.com/havenhq/revideo/commit/ba3e16f04a12de87408ca68df5acacf5610ed617))
+* useAnimator utility ([ad32e8a](https://github.com/havenhq/revideo/commit/ad32e8a0add494021d4c5c9fe5b3915189f00a08))
+* viewport, playback, and timeline ([c5f9636](https://github.com/havenhq/revideo/commit/c5f96360258a8dca5faa66c79451969da7eebabc))
+* **vite-plugin:** add CORS Proxy ([#357](https://github.com/havenhq/revideo/issues/357)) ([a3c5822](https://github.com/havenhq/revideo/commit/a3c58228b7d3dab08fc27414d19870d35773b280)), closes [#338](https://github.com/havenhq/revideo/issues/338)
+* **vite-plugin:** add entry point ([#721](https://github.com/havenhq/revideo/issues/721)) ([e634b6c](https://github.com/havenhq/revideo/commit/e634b6cb67b3c569d21d424661708ca946ea4cc3))
+* **vite-plugin:** improve audio handling ([#154](https://github.com/havenhq/revideo/issues/154)) ([482f144](https://github.com/havenhq/revideo/commit/482f14447ae54543346fab0f9e5b94631c5cfd4d))
+* **vite-plugin:** support glob for project files ([#834](https://github.com/havenhq/revideo/issues/834)) ([67029c4](https://github.com/havenhq/revideo/commit/67029c4c2cf756cbe2b7ed59dc55cb895de81d52)), closes [#324](https://github.com/havenhq/revideo/issues/324)
+* waveform data ([400a756](https://github.com/havenhq/revideo/commit/400a756ebf7ee174d8cbaf03f1f74eddd1b75925))
+* webgl shaders ([#920](https://github.com/havenhq/revideo/issues/920)) ([849216e](https://github.com/havenhq/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+* world space cache ([#498](https://github.com/havenhq/revideo/issues/498)) ([633e9e1](https://github.com/havenhq/revideo/commit/633e9e140dfbbe397df6ddc1f96ed30782ddce94)), closes [#342](https://github.com/havenhq/revideo/issues/342)
+
+
+### Reverts
+
+* "ci(release): 9.1.3 [skip ci]" ([62953a6](https://github.com/havenhq/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+* chore(release): 1.4.0 [skip ci] ([d6121ae](https://github.com/havenhq/revideo/commit/d6121ae946e9e79e1e6ddee4b8b0dd839d122c55))
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/havenhq/revideo/issues/908)) ([86c5170](https://github.com/havenhq/revideo/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
+* feat: upgrade code-fns for new theme options and lazy loading ([#435](https://github.com/havenhq/revideo/issues/435)) ([3f5e439](https://github.com/havenhq/revideo/commit/3f5e43968f7add7c6322c9c8358d3b6fc178c2fe))
+
+
+### BREAKING CHANGES
+
+* multiple name changes
+
+To avoid collisions, names of certain classes have changed:
+- `Text => Txt`
+- `Image => Img`
+- `Rect (type) => BBox`
+
+Cache related methods of `Node` have changed:
+- `getCacheRect => getCacheBBox`
+- `cacheRect => cacheBBox`
+- `fullCacheRect => fullCacheBBox`
+
+The `CodeBlock` property has changed:
+- `CodeBlock.selectionOpacity => CodeBlock.unselectedOpacity`
+* `makeProject` no longer accepts some settings.
+
+Settings such as `background` and `audioOffset` are now stored in the project
+meta file.
+* remove legacy package
+* change names of timing and interpolation functions
+
+`TweenFunction` is now called `InterpolationFunction`.
+Individual functions are now called `[type]Lerp` instead of `[type]Tween`.
+For instance: `colorTween` is now `colorLerp`.
+
+`InterpolationFunction` is now called `TimingFunction`.
+This name is better aligned with the CSS spec.
+* change to import paths
+
+See [the migration guide](https://motion-canvas.github.io/guides/migration/12.0.0) for more info.
+* change the way scenes are imported
+
+Scene files no longer need to follow the pattern: `[name].scene.tsx`.
+When importing scenes in the project file, a dedicated `?scene` query param should be used:
+```ts
+import example from './scenes/example?scene';
+
+export default new Project({
+  name: 'project',
+  scenes: [example],
+});
+```
+* change the overall structure of a project
+
+`vite` and `@motion-canvas/vite-plugin` packages are now required to build a project:
+```
+npm i -D vite @motion-canvas/vite-plugin
+```
+The following `vite.config.ts` file needs to be created in the root of the project:
+```ts
+import {defineConfig} from 'vite';
+import motionCanvas from '@motion-canvas/vite-plugin';
+
+export default defineConfig({
+  plugins: [motionCanvas()],
+});
+```
+
+Types exposed by Motion Canvas are no longer global.
+An additional `motion-canvas.d.ts` file needs to be created in the `src` directory:
+```ts
+/// <reference types="@motion-canvas/core/project" />
+```
+
+ Finally, the `bootstrap` function no longer exists.
+ Project files should export an instance of the `Project` class instead:
+ ```ts
+ import {Project} from '@motion-canvas/core/lib';
+
+ import example from './scenes/example.scene';
+
+ export default new Project({
+   name: 'project',
+   scenes: [example],
+   // same options as in bootstrap() are available:
+* Animator.inferTweenFunction now returns deepTween,
+which does not work exactly as before, though should be a viable
+replacement in most cases.
+* `scene.transition()` has been replaced by `useTransition`
+
+Any use of slide transition must be updated from
+```ts
+yield* scene.transition(slideTransition());
+```
+to
+```ts
+yield* slideTranstion();
+```
+
+Any transitions must be rewritten to utilize `useTransition`.
+* Konva patches are not imported by default
+
+Projects using `KonvaScene`s should import the patches manually at the very top of the file project:
+```ts
+import '@motion-canvas/core/lib/patches'
+// ...
+bootstrap(...);
+```
+
+`getset` import path has changed:
+```ts
+import {getset} from '@motion-canvas/core/lib/decorators/getset';
+```
+* change the type exported by scene files
+
+Scene files need to export a special `SceneDescription` object instead of a simple generator function.
+* change event naming convention
+
+The names of all public events now use the following pattern: "on[WhatHappened]".
+Example: "onValueChanged".
+* change how images are imported
+
+By default, importing images will now return their urls instead of a SpriteData object.
+This behavior can be adjusted using the `?img` and `?anim` queries.
+* change time events API
+* `waitFor` and `waitUntil` were moved
+
+They should be imported from `@motion-canvas/core/lib/flow`.
+
+
+
+
+
 ## [3.14.2](https://github.com/motion-canvas/motion-canvas/compare/v3.14.1...v3.14.2) (2024-02-08)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package revideo
+
+
+
+
+
 # 0.1.0 (2024-03-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/havenhq/revideo/compare/v0.1.1...v0.1.2) (2024-03-17)
+
+
+### Bug Fixes
+
+* bump up ffmpeg version in quickstart ([aaefb4b](https://github.com/havenhq/revideo/commit/aaefb4bf928a6d64ff6f79f2e5f2613d62f8cc2d))
+
+
+
+
+
 ## [0.1.1](https://github.com/havenhq/revideo/compare/v0.1.0...v0.1.1) (2024-03-17)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Motion Canvas follows [semantic versioning][semver].
 
 ## Making a Pull Request
 
-1. Fork the motion-canvas/motion-canvas repo.
+1. Fork the revideo/revideo repo.
 2. In your forked repo, create a new branch for your changes:
    ```shell
    git checkout -b my-fix-branch main
@@ -117,15 +117,14 @@ This Contribution Guide was partially inspired by [React][react] and
 [discord]: https://chat.motioncanvas.io
 [semantic-release]:
   https://semantic-release.gitbook.io/semantic-release/support/faq#can-i-set-the-initial-release-version-of-my-package-to-0.0.1
-[main]: https://github.com/motion-canvas/motion-canvas/tree/main
-[issues]: https://github.com/motion-canvas/motion-canvas/issues
-[new-issue]: https://github.com/motion-canvas/motion-canvas/issues/new/choose
+[main]: https://github.com/revideo/revideo/tree/main
+[issues]: https://github.com/revideo/revideo/issues
+[new-issue]: https://github.com/revideo/revideo/issues/new/choose
 [new-feature]:
-  https://github.com/motion-canvas/motion-canvas/issues/new?template=feature_request.md
+  https://github.com/revideo/revideo/issues/new?template=feature_request.md
 [commit-format]:
   https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
 [angular]: https://github.com/angular/angular/blob/main/CONTRIBUTING.md
 [react]: https://reactjs.org/docs/how-to-contribute.html
-[label-accepted]:
-  https://github.com/motion-canvas/motion-canvas/labels/c-accepted
+[label-accepted]: https://github.com/revideo/revideo/labels/c-accepted
 [gist]: https://gist.github.com/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ versions. Only the newest release is being supported with security updates.
 **Please do not report security vulnerabilities through public GitHub issues.**
 
 Instead, please kindly email us at
-[aarthificial+motion-canvas@gmail.com](mailto:aarthificial+motion-canvas@gmail.com)
+[aarthificial+revideo@gmail.com](mailto:aarthificial+revideo@gmail.com)
 
 After receiving a report, we will try to confirm the problem. You should receive
 a response within 48 hours, informing you about our plans concerning the

--- a/lerna.json
+++ b/lerna.json
@@ -5,6 +5,5 @@
   "version": "3.14.2",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
-  "conventionalCommits": true,
-  "createRelease": "github"
+  "conventionalCommits": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "private": false,
-  "version": "3.14.2",
+  "version": "0.1.0",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
   "conventionalCommits": true

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "private": false,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
   "conventionalCommits": true

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "private": false,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
   "conventionalCommits": true

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "private": false,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "ignoreChanges": ["**/*.test.ts", "**/*.md"],
   "message": "ci(release): %v [skip ci]",
   "conventionalCommits": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@preact/preset-vite": "^2.7.0",
         "@wooorm/starry-night": "^3.3.0",
+        "lunr": "^2.3.9",
+        "marked": "^12.0.1",
         "shiki": "^1.1.7",
         "uuid": "^9.0.1"
       },
@@ -19129,6 +19131,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
@@ -19243,6 +19250,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.1.tgz",
+      "integrity": "sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mathjax-full": {
@@ -29455,6 +29473,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "packages/docs/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "packages/docs/node_modules/minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@preact/preset-vite": "^2.7.0",
         "@wooorm/starry-night": "^3.3.0",
         "shiki": "^1.1.7",
         "uuid": "^9.0.1"
@@ -225,70 +226,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/compat-data": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
@@ -324,14 +261,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -385,27 +314,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.0.tgz",
@@ -428,14 +336,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
@@ -450,14 +350,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
@@ -691,70 +583,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
@@ -1208,14 +1036,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
@@ -1779,14 +1599,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.23.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
@@ -2027,14 +1839,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -2152,14 +1956,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/types": {
@@ -2368,6 +2164,76 @@
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/format/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/format/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/format/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@commitlint/format/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@commitlint/format/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/format/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@commitlint/is-ignored": {
       "version": "18.6.1",
       "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-18.6.1.tgz",
@@ -2380,6 +2246,39 @@
       "engines": {
         "node": ">=v18"
       }
+    },
+    "node_modules/@commitlint/is-ignored/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@commitlint/is-ignored/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@commitlint/is-ignored/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@commitlint/lint": {
       "version": "18.6.1",
@@ -2416,6 +2315,76 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@commitlint/load/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@commitlint/message": {
@@ -2520,6 +2489,76 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@commitlint/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@commitlint/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -2654,6 +2693,51 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/@docusaurus/core/node_modules/commander": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
@@ -2674,6 +2758,55 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@docusaurus/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@docusaurus/core/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@docusaurus/cssnano-preset": {
       "version": "2.4.3",
@@ -2699,6 +2832,70 @@
       },
       "engines": {
         "node": ">=16.14"
+      }
+    },
+    "node_modules/@docusaurus/logger/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/logger/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@docusaurus/logger/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@docusaurus/logger/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@docusaurus/logger/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@docusaurus/logger/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
@@ -3325,6 +3522,17 @@
         "node": ">=16.14"
       }
     },
+    "node_modules/@docusaurus/utils/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@docusaurus/utils/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -3741,6 +3949,21 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "devOptional": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3757,6 +3980,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -4211,6 +4446,70 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/@jest/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
@@ -4280,6 +4579,76 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@lerna/child-process/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@lerna/child-process/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@lerna/child-process/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@lerna/child-process/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@lerna/child-process/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lerna/child-process/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@lerna/create": {
@@ -4358,6 +4727,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@lerna/create/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/@lerna/create/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4394,6 +4778,24 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "node_modules/@lerna/create/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@lerna/create/node_modules/execa": {
       "version": "5.0.0",
@@ -4484,6 +4886,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@lerna/create/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@lerna/create/node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -4491,6 +4902,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@lerna/create/node_modules/minimatch": {
@@ -4532,6 +4955,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@lerna/create/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@lerna/create/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@lerna/create/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -4548,6 +4998,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/@lerna/create/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@lerna/create/node_modules/yargs": {
       "version": "16.2.0",
@@ -4770,21 +5226,16 @@
         "@rushstack/node-core-library": "3.62.0"
       }
     },
-    "node_modules/@microsoft/api-extractor/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+    "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
+        "yallist": "^4.0.0"
       },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
@@ -4802,6 +5253,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/@microsoft/api-extractor/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
@@ -4814,6 +5274,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.14.2",
@@ -4854,6 +5320,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/@microsoft/tsdoc-config/node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4900,6 +5379,39 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/@npmcli/fs/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@npmcli/git": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-4.1.0.tgz",
@@ -4928,6 +5440,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/@npmcli/git/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@npmcli/git/node_modules/which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
@@ -4942,6 +5481,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/@npmcli/git/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@npmcli/installed-package-contents": {
       "version": "2.0.2",
@@ -5101,6 +5646,18 @@
         "nx": ">= 15 <= 17"
       }
     },
+    "node_modules/@nx/devkit/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@nx/devkit/node_modules/semver": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
@@ -5115,6 +5672,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@nx/devkit/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@nx/nx-darwin-arm64": {
       "version": "16.10.0",
@@ -5487,10 +6050,9 @@
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ=="
     },
     "node_modules/@preact/preset-vite": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.2.tgz",
-      "integrity": "sha512-m3tl+M8IO8jgiHnk+7LSTFl8axdPXloewi7iGVLdmCwf34XOzEUur0bZVewW4DUbUipFjTS2CXu27+5f/oexBA==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.7.0.tgz",
+      "integrity": "sha512-m5N0FVtxbCCDxNk55NGhsRpKJChYcupcuQHzMJc/Bll07IKZKn8amwYciyKFS9haU6AgzDAJ/ewvApr6Qg1DHw==",
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.22.15",
         "@babel/plugin-transform-react-jsx-development": "^7.22.5",
@@ -5499,41 +6061,11 @@
         "babel-plugin-transform-hook-names": "^1.0.2",
         "debug": "^4.3.4",
         "kolorist": "^1.8.0",
-        "magic-string": "0.30.5",
-        "node-html-parser": "^6.1.10",
-        "resolve": "^1.22.8",
-        "source-map": "^0.7.4",
-        "stack-trace": "^1.0.0-pre2"
+        "resolve": "^1.22.8"
       },
       "peerDependencies": {
         "@babel/core": "7.x",
         "vite": "2.x || 3.x || 4.x || 5.x"
-      }
-    },
-    "node_modules/@preact/preset-vite/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@preact/preset-vite/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@preact/signals": {
@@ -5563,14 +6095,12 @@
     "node_modules/@prefresh/babel-plugin": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@prefresh/babel-plugin/-/babel-plugin-0.5.1.tgz",
-      "integrity": "sha512-uG3jGEAysxWoyG3XkYfjYHgaySFrSsaEb4GagLzYaxlydbuREtaX+FTxuIidp241RaLl85XoHg9Ej6E4+V1pcg==",
-      "dev": true
+      "integrity": "sha512-uG3jGEAysxWoyG3XkYfjYHgaySFrSsaEb4GagLzYaxlydbuREtaX+FTxuIidp241RaLl85XoHg9Ej6E4+V1pcg=="
     },
     "node_modules/@prefresh/core": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@prefresh/core/-/core-1.5.2.tgz",
       "integrity": "sha512-A/08vkaM1FogrCII5PZKCrygxSsc11obExBScm3JF1CryK2uDS3ZXeni7FeKCx1nYdUkj4UcJxzPzc1WliMzZA==",
-      "dev": true,
       "peerDependencies": {
         "preact": "^10.0.0"
       }
@@ -5578,14 +6108,12 @@
     "node_modules/@prefresh/utils": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@prefresh/utils/-/utils-1.2.0.tgz",
-      "integrity": "sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ==",
-      "dev": true
+      "integrity": "sha512-KtC/fZw+oqtwOLUFM9UtiitB0JsVX0zLKNyRTA332sqREqSALIIQQxdUCS1P3xR/jT1e2e8/5rwH6gdcMLEmsQ=="
     },
     "node_modules/@prefresh/vite": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/@prefresh/vite/-/vite-2.4.5.tgz",
       "integrity": "sha512-iForDVJ2M8gQYnm5pHumvTEJjGGc7YNYC0GVKnHFL+GvFfKHfH9Rpq67nUAzNbjuLEpqEOUuQVQajMazWu2ZNQ==",
-      "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.1",
         "@prefresh/babel-plugin": "0.5.1",
@@ -5795,23 +6323,6 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@rollup/plugin-terser": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
@@ -5882,28 +6393,10 @@
         }
       }
     },
-    "node_modules/@rollup/plugin-typescript/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
       "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
       "dependencies": {
         "estree-walker": "^2.0.1",
         "picomatch": "^2.2.2"
@@ -5967,21 +6460,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@rushstack/node-core-library/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+    "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
+        "yallist": "^4.0.0"
       },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@rushstack/node-core-library/node_modules/semver": {
@@ -6008,6 +6496,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@rushstack/node-core-library/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@rushstack/rig-package": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.1.tgz",
@@ -6016,23 +6510,6 @@
       "dependencies": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
-      }
-    },
-    "node_modules/@rushstack/rig-package/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/@rushstack/ts-command-line": {
@@ -6277,6 +6754,33 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/@sigstore/sign/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sigstore/sign/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@sigstore/sign/node_modules/ssri": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
@@ -6321,6 +6825,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/@sigstore/sign/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@sigstore/tuf": {
       "version": "1.0.3",
@@ -7160,6 +7670,39 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
@@ -7273,6 +7816,39 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
@@ -7297,6 +7873,39 @@
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "6.21.0",
@@ -7923,18 +8532,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -7955,17 +8552,14 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "color-convert": "^1.9.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/anymatch": {
@@ -8173,14 +8767,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/babel-loader/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/babel-plugin-apply-mdx-type-prop": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.22.tgz",
@@ -8240,14 +8826,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
@@ -8305,7 +8883,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-hook-names/-/babel-plugin-transform-hook-names-1.0.2.tgz",
       "integrity": "sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==",
-      "dev": true,
       "peerDependencies": {
         "@babel/core": "^7.12.10"
       }
@@ -8524,11 +9101,14 @@
       }
     },
     "node_modules/boxen/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -8545,10 +9125,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/boxen/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "node_modules/boxen/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+    },
+    "node_modules/boxen/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/boxen/node_modules/string-width": {
       "version": "5.1.2",
@@ -8580,6 +9199,17 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/boxen/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/boxen/node_modules/type-fest": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
@@ -8605,6 +9235,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/brace-expansion": {
@@ -8714,6 +9355,39 @@
       "dependencies": {
         "semver": "^7.0.0"
       }
+    },
+    "node_modules/builtins/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/byte-size": {
       "version": "8.1.1",
@@ -8995,18 +9669,16 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/character-entities": {
@@ -9182,6 +9854,14 @@
         "node": ">= 10.0"
       }
     },
+    "node_modules/clean-css/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -9326,6 +10006,36 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -9479,20 +10189,17 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
+        "color-name": "1.1.3"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -9669,6 +10376,15 @@
         "source-map": "^0.6.1"
       }
     },
+    "node_modules/concat-with-sourcemaps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -9697,14 +10413,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/configstore/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/configstore/node_modules/write-file-atomic": {
@@ -10091,6 +10799,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/conventional-changelog-writer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/conventional-changelog-writer/node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -10214,6 +10934,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/conventional-changelog-writer/node_modules/type-fest": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -10225,6 +10960,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/conventional-commits-filter": {
       "version": "3.0.0",
@@ -10793,6 +11534,36 @@
         }
       }
     },
+    "node_modules/css-loader/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/css-loader/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/css-loader/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-4.2.2.tgz",
@@ -10854,6 +11625,14 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/css-minimizer-webpack-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -10879,6 +11658,14 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/css-what": {
@@ -12325,14 +13112,11 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.8.0"
       }
     },
     "node_modules/escodegen": {
@@ -12353,6 +13137,15 @@
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -12464,6 +13257,21 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "devOptional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -12472,6 +13280,76 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "devOptional": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "devOptional": true
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "devOptional": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
@@ -12490,6 +13368,30 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "devOptional": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esm": {
@@ -12563,8 +13465,7 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -12967,15 +13868,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -13150,14 +14042,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/find-up": {
@@ -13346,6 +14230,20 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -13354,6 +14252,37 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
       "version": "6.0.0",
@@ -13384,10 +14313,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
       "version": "3.1.2",
@@ -13417,6 +14365,31 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -13424,6 +14397,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/yaml": {
       "version": "1.10.2",
@@ -13651,6 +14629,21 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-pkg-repo/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/get-pkg-repo/node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -13661,6 +14654,24 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "node_modules/get-pkg-repo/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/get-pkg-repo/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/get-pkg-repo/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -14045,6 +15056,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/git-semver-tags/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/git-semver-tags/node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -14168,6 +15191,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/git-semver-tags/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/git-semver-tags/node_modules/type-fest": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -14179,6 +15217,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/git-semver-tags/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/git-up": {
       "version": "7.0.0",
@@ -14316,18 +15360,11 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "devOptional": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=4"
       }
     },
     "node_modules/globby": {
@@ -14487,6 +15524,15 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -14497,11 +15543,11 @@
       }
     },
     "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -14754,6 +15800,24 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -15357,6 +16421,39 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/init-package-json/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/init-package-json/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/init-package-json/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
@@ -15386,6 +16483,76 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internmap": {
@@ -15887,6 +17054,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/jake/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/jake/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -15895,6 +17077,49 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jake/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jake/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jake/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jake/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jake/node_modules/minimatch": {
@@ -15907,6 +17132,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jake/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-diff": {
@@ -15922,6 +17159,76 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-get-type": {
@@ -15959,6 +17266,59 @@
         }
       }
     },
+    "node_modules/jest-image-snapshot/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-image-snapshot/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-image-snapshot/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-image-snapshot/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jest-image-snapshot/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-image-snapshot/node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -15968,6 +17328,17 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/jest-image-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-util": {
@@ -15986,6 +17357,70 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/jest-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
@@ -15998,6 +17433,14 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-worker/node_modules/supports-color": {
@@ -16267,8 +17710,7 @@
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-      "dev": true
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
     },
     "node_modules/latest-version": {
       "version": "5.1.0",
@@ -16384,6 +17826,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/lerna/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/lerna/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -16420,6 +17877,24 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "node_modules/lerna/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/lerna/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/lerna/node_modules/execa": {
       "version": "5.0.0",
@@ -16510,6 +17985,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/lerna/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lerna/node_modules/is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
@@ -16517,6 +18001,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lerna/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/lerna/node_modules/minimatch": {
@@ -16558,6 +18054,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/lerna/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lerna/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lerna/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -16574,6 +18097,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/lerna/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/lerna/node_modules/yargs": {
       "version": "16.2.0",
@@ -16663,6 +18192,39 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/libnpmaccess/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/libnpmaccess/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/libnpmaccess/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/libnpmpublish": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-7.3.0.tgz",
@@ -16742,6 +18304,33 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/libnpmpublish/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/libnpmpublish/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/libnpmpublish/node_modules/ssri": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
@@ -16753,6 +18342,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/libnpmpublish/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/lilconfig": {
       "version": "3.0.0",
@@ -17234,6 +18829,76 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/log-update": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.0.0.tgz",
@@ -17457,14 +19122,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/magic-string": {
@@ -17492,6 +19154,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-dir/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
@@ -17961,6 +19656,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
@@ -17973,6 +19674,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/mitt": {
       "version": "3.0.1",
@@ -18230,15 +19937,38 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/node-html-parser": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.12.tgz",
-      "integrity": "sha512-/bT/Ncmv+fbMGX96XG9g05vFt43m/+SYKIs9oAemQVYyVcZmDAI2Xq/SbNcpOA35eF0Zk2av3Ksf+Xk8Vt8abA==",
+    "node_modules/node-gyp/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "dependencies": {
-        "css-select": "^5.1.0",
-        "he": "1.2.0"
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/node-machine-id": {
       "version": "1.1.12",
@@ -18285,6 +20015,39 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -18334,6 +20097,39 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm-install-checks/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-install-checks/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-install-checks/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
@@ -18372,6 +20168,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm-package-arg/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/npm-package-arg/node_modules/validate-npm-package-name": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
@@ -18380,6 +20203,12 @@
       "dependencies": {
         "builtins": "^1.0.3"
       }
+    },
+    "node_modules/npm-package-arg/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/npm-packlist": {
       "version": "5.1.1",
@@ -18489,6 +20318,39 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/npm-pick-manifest/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-pick-manifest/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-pick-manifest/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/npm-registry-fetch": {
       "version": "14.0.5",
@@ -18692,6 +20554,33 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm-registry-fetch/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-registry-fetch/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/npm-registry-fetch/node_modules/ssri": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
@@ -18736,6 +20625,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/npm-registry-fetch/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -18857,6 +20752,21 @@
         }
       }
     },
+    "node_modules/nx/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/nx/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -18866,6 +20776,40 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "node_modules/nx/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/nx/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/nx/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/nx/node_modules/glob": {
       "version": "7.1.4",
@@ -18882,6 +20826,27 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/nx/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nx/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/nx/node_modules/minimatch": {
@@ -18910,6 +20875,24 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/nx/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nx/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/nx/node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -19069,6 +21052,76 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/os-tmpdir": {
@@ -19338,14 +21391,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/package-json/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/pacote": {
       "version": "15.2.0",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-15.2.0.tgz",
@@ -19534,6 +21579,33 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/pacote/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pacote/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pacote/node_modules/ssri": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
@@ -19578,6 +21650,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/pacote/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -20218,6 +22296,36 @@
         "postcss": "^7.0.0 || ^8.0.1",
         "webpack": "^5.0.0"
       }
+    },
+    "node_modules/postcss-loader/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/postcss-loader/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/postcss-merge-idents": {
       "version": "5.1.1",
@@ -21325,12 +23433,87 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-dev-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/react-dev-utils/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
       "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/react-dev-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/react-dom": {
@@ -21645,6 +23828,39 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/read-package-json/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/read-package-json/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/read-package-json/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",
@@ -22312,12 +24528,16 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.1.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -22465,6 +24685,76 @@
       },
       "peerDependencies": {
         "postcss": "8.x"
+      }
+    },
+    "node_modules/rollup-plugin-postcss/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/rollup-plugin-postcss/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/rollup-plugin-postcss/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-postcss/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/rollup-plugin-postcss/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-postcss/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -22705,17 +24995,11 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver-diff": {
@@ -22727,14 +25011,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/semver-diff/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/send": {
@@ -23239,6 +25515,33 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/sigstore/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sigstore/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sigstore/node_modules/ssri": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
@@ -23283,6 +25586,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/sigstore/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/sirv": {
       "version": "2.0.4",
@@ -23441,14 +25750,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -23464,6 +25765,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -23604,15 +25913,6 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
-    },
-    "node_modules/stack-trace": {
-      "version": "1.0.0-pre2",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre2.tgz",
-      "integrity": "sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -23882,21 +26182,20 @@
       "integrity": "sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ=="
     },
     "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dependencies": {
-        "has-flag": "^4.0.0"
+        "has-flag": "^3.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -24067,6 +26366,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -24147,6 +26452,14 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "peerDependencies": {
         "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
@@ -24422,22 +26735,108 @@
         "tspc": "bin/tspc.js"
       }
     },
-    "node_modules/ts-patch/node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+    "node_modules/ts-patch/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
+        "color-convert": "^2.0.1"
       },
-      "bin": {
-        "resolve": "bin/resolve"
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/ts-patch/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-patch/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ts-patch/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ts-patch/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-patch/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-patch/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-patch/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-patch/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
@@ -24638,6 +27037,33 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/tuf-js/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tuf-js/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tuf-js/node_modules/ssri": {
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.5.tgz",
@@ -24683,6 +27109,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/tuf-js/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -24704,9 +27136,10 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -25112,6 +27545,20 @@
         "url": "https://github.com/yeoman/update-notifier?sponsor=1"
       }
     },
+    "node_modules/update-notifier/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/update-notifier/node_modules/boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -25144,6 +27591,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/update-notifier/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/update-notifier/node_modules/ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -25160,6 +27622,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/update-notifier/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/update-notifier/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/update-notifier/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/update-notifier/node_modules/is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -25169,6 +27655,53 @@
       },
       "bin": {
         "is-ci": "bin.js"
+      }
+    },
+    "node_modules/update-notifier/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/update-notifier/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/update-notifier/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/update-notifier/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/update-notifier/node_modules/widest-line": {
@@ -25197,6 +27730,11 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/update-notifier/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -25720,6 +28258,39 @@
         "typescript": "*"
       }
     },
+    "node_modules/vue-tsc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -25889,6 +28460,17 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
@@ -26138,6 +28720,70 @@
         "webpack": "3 || 4 || 5"
       }
     },
+    "node_modules/webpackbar/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/webpackbar/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/webpackbar/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/webpackbar/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/webpackbar/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/webpackbar/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -26347,6 +28993,72 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -26538,9 +29250,9 @@
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
       "version": "2.3.4",
@@ -26740,8 +29452,7 @@
     },
     "packages/docs/node_modules/clsx": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -27069,6 +29780,33 @@
         "node": ">=18"
       }
     },
+    "packages/renderer/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/renderer/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "packages/renderer/node_modules/socks-proxy-agent": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
@@ -27107,6 +29845,12 @@
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
+    },
+    "packages/renderer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "packages/template": {
       "name": "@revideo/template",
@@ -27158,6 +29902,14 @@
       },
       "peerDependencies": {
         "vite": "^4.5"
+      }
+    },
+    "packages/vite-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29404,7 +29404,7 @@
     },
     "packages/create": {
       "name": "@revideo/create",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8",
@@ -29554,7 +29554,7 @@
     },
     "packages/ffmpeg": {
       "name": "@revideo/ffmpeg",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "motion-canvas",
+  "name": "revideo",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "motion-canvas",
+      "name": "revideo",
       "workspaces": [
         "packages/*"
       ],
@@ -3086,6 +3086,14 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@docusaurus/theme-common": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.3.tgz",
@@ -3114,6 +3122,14 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-common/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
@@ -3166,6 +3182,14 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/fs-extra": {
@@ -4831,58 +4855,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "node_modules/@motion-canvas/2d": {
-      "resolved": "packages/2d",
-      "link": true
-    },
-    "node_modules/@motion-canvas/core": {
-      "resolved": "packages/core",
-      "link": true
-    },
-    "node_modules/@motion-canvas/create": {
-      "resolved": "packages/create",
-      "link": true
-    },
-    "node_modules/@motion-canvas/docs": {
-      "resolved": "packages/docs",
-      "link": true
-    },
-    "node_modules/@motion-canvas/e2e": {
-      "resolved": "packages/e2e",
-      "link": true
-    },
-    "node_modules/@motion-canvas/examples": {
-      "resolved": "packages/examples",
-      "link": true
-    },
-    "node_modules/@motion-canvas/ffmpeg": {
-      "resolved": "packages/ffmpeg",
-      "link": true
-    },
-    "node_modules/@motion-canvas/internal": {
-      "resolved": "packages/internal",
-      "link": true
-    },
-    "node_modules/@motion-canvas/player": {
-      "resolved": "packages/player",
-      "link": true
-    },
-    "node_modules/@motion-canvas/renderer": {
-      "resolved": "packages/renderer",
-      "link": true
-    },
-    "node_modules/@motion-canvas/template": {
-      "resolved": "packages/template",
-      "link": true
-    },
-    "node_modules/@motion-canvas/ui": {
-      "resolved": "packages/ui",
-      "link": true
-    },
-    "node_modules/@motion-canvas/vite-plugin": {
-      "resolved": "packages/vite-plugin",
-      "link": true
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5515,9 +5487,9 @@
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ=="
     },
     "node_modules/@preact/preset-vite": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.1.tgz",
-      "integrity": "sha512-a9KV4opdj17X2gOFuGup0aE+sXYABX/tJi/QDptOrleX4FlnoZgDWvz45tHOdVfrZX+3uvVsIYPHxRsTerkDNA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@preact/preset-vite/-/preset-vite-2.8.2.tgz",
+      "integrity": "sha512-m3tl+M8IO8jgiHnk+7LSTFl8axdPXloewi7iGVLdmCwf34XOzEUur0bZVewW4DUbUipFjTS2CXu27+5f/oexBA==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-transform-react-jsx": "^7.22.15",
@@ -5529,7 +5501,9 @@
         "kolorist": "^1.8.0",
         "magic-string": "0.30.5",
         "node-html-parser": "^6.1.10",
-        "resolve": "^1.22.8"
+        "resolve": "^1.22.8",
+        "source-map": "^0.7.4",
+        "stack-trace": "^1.0.0-pre2"
       },
       "peerDependencies": {
         "@babel/core": "7.x",
@@ -5551,6 +5525,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@preact/preset-vite/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@preact/signals": {
@@ -5634,6 +5617,58 @@
       "engines": {
         "node": ">=16.3.0"
       }
+    },
+    "node_modules/@revideo/2d": {
+      "resolved": "packages/2d",
+      "link": true
+    },
+    "node_modules/@revideo/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@revideo/create": {
+      "resolved": "packages/create",
+      "link": true
+    },
+    "node_modules/@revideo/docs": {
+      "resolved": "packages/docs",
+      "link": true
+    },
+    "node_modules/@revideo/e2e": {
+      "resolved": "packages/e2e",
+      "link": true
+    },
+    "node_modules/@revideo/examples": {
+      "resolved": "packages/examples",
+      "link": true
+    },
+    "node_modules/@revideo/ffmpeg": {
+      "resolved": "packages/ffmpeg",
+      "link": true
+    },
+    "node_modules/@revideo/internal": {
+      "resolved": "packages/internal",
+      "link": true
+    },
+    "node_modules/@revideo/player": {
+      "resolved": "packages/player",
+      "link": true
+    },
+    "node_modules/@revideo/renderer": {
+      "resolved": "packages/renderer",
+      "link": true
+    },
+    "node_modules/@revideo/template": {
+      "resolved": "packages/template",
+      "link": true
+    },
+    "node_modules/@revideo/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
+    "node_modules/@revideo/vite-plugin": {
+      "resolved": "packages/vite-plugin",
+      "link": true
     },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "25.0.7",
@@ -6028,9 +6063,9 @@
       "dev": true
     },
     "node_modules/@shikijs/core": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.1.7.tgz",
-      "integrity": "sha512-gTYLUIuD1UbZp/11qozD3fWpUTuMqPSf3svDMMrL0UmlGU7D9dPw/V1FonwAorCUJBltaaESxq90jrSjQyGixg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-OlFvx+nyr5C8zpcMBnSGir0YPD6K11uYhouqhNmm1qLiis4GA7SsGtu07r9gKS9omks8RtQqHrJL4S+lqWK01A=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -6809,11 +6844,11 @@
       }
     },
     "node_modules/@types/hast": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
-      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "dependencies": {
-        "@types/unist": "^2"
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/history": {
@@ -6872,6 +6907,11 @@
       "dependencies": {
         "@types/unist": "^2"
       }
+    },
+    "node_modules/@types/mdast/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -7045,9 +7085,9 @@
       }
     },
     "node_modules/@types/unist": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
-      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
@@ -7597,14 +7637,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/@wooorm/starry-night/node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7922,12 +7954,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-sequence-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-      "dev": true
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -8100,12 +8126,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -8304,6 +8330,36 @@
       "integrity": "sha512-9GYPpsPFvrWBkelIhOhTWtkeZxVxZOdb3VnFTCzlOo3OjvmTvzLoZFUT8kNFACx0vJej6QPney1Cf9BvzCNE/A==",
       "optional": true
     },
+    "node_modules/bare-fs": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.2.tgz",
+      "integrity": "sha512-X9IqgvyB0/VA5OZJyb5ZstoN62AzD7YxVGog13kkfYWYqJYcK0kcqLZ6TrmH5qr4/8//ejVcX4x/a0UvaogXmA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-os": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "streamx": "^2.13.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz",
+      "integrity": "sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
+      "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
+    },
     "node_modules/base16": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
@@ -8356,11 +8412,14 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bl": {
@@ -8891,9 +8950,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001597",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
-      "integrity": "sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==",
+      "version": "1.0.30001598",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001598.tgz",
+      "integrity": "sha512-j8mQRDziG94uoBfeFuqsJUNECW37DXpnvhcMJMdlH2u3MRkq1sAI0LJcXP1i/Py0KbSIC4UDj8YHPrTn5YsL+Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -9329,9 +9388,10 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9344,6 +9404,56 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/code-fns": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/code-fns/-/code-fns-0.8.2.tgz",
+      "integrity": "sha512-3VVeq3cnWxWiWKFLsVo+XWsOXBSW2gAx2uv0ViETLNmNuygEPHlCeDAv/Zy7xXqPgXtgLZyvIJZmx+ojTgOIGA==",
+      "dependencies": {
+        "@wooorm/starry-night": "^1.2.0"
+      }
+    },
+    "node_modules/code-fns/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/code-fns/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
+    "node_modules/code-fns/node_modules/@wooorm/starry-night": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@wooorm/starry-night/-/starry-night-1.7.0.tgz",
+      "integrity": "sha512-ktO0nkddrovIoNW2jAUT+Cdd9n1bWjy1Ir4CdcmgTaT6E94HLlQfu7Yv62falclBEwvsuVp3bSBw23wtta1fNw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "import-meta-resolve": "^2.0.0",
+        "vscode-oniguruma": "^1.0.0",
+        "vscode-textmate": "^9.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/code-fns/node_modules/import-meta-resolve": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
+      "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/code-fns/node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
     },
     "node_modules/codemirror": {
       "version": "6.0.1",
@@ -11996,9 +12106,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.705",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.705.tgz",
-      "integrity": "sha512-LKqhpwJCLhYId2VVwEzFXWrqQI5n5zBppz1W9ehhTlfYU8CUUW6kClbN8LHF/v7flMgRdETS772nqywJ+ckVAw=="
+      "version": "1.4.708",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.708.tgz",
+      "integrity": "sha512-iWgEEvREL4GTXXHKohhh33+6Y8XkPI5eHihDmm8zUk5Zo7HICEW+wI/j5kJ2tbuNUCXJ/sNXa03ajW635DiJXA=="
     },
     "node_modules/elkjs": {
       "version": "0.8.2",
@@ -14470,6 +14580,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-to-hyperscript/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-6.0.1.tgz",
@@ -14517,6 +14632,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-raw/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
     "node_modules/hast-util-raw/node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -14553,6 +14681,19 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/hastscript/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hastscript/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -17326,12 +17467,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "dev": true
-    },
     "node_modules/magic-string": {
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
@@ -17415,18 +17550,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/mathjax-full": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
@@ -17480,6 +17603,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/mdast-util-to-string": {
       "version": "2.0.0",
@@ -22901,11 +23029,11 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.1.7.tgz",
-      "integrity": "sha512-9kUTMjZtcPH3i7vHunA6EraTPpPOITYTdA5uMrvsJRexktqP0s7P3s9HVK80b4pP42FRVe03D7fT3NmJv2yYhw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.2.0.tgz",
+      "integrity": "sha512-xLhiTMOIUXCv5DqJ4I70GgQCtdlzsTqFLZWcMHHG3TAieBUbvEGthdrlPDlX4mL/Wszx9C6rEcxU6kMlg4YlxA==",
       "dependencies": {
-        "@shikijs/core": "1.1.7"
+        "@shikijs/core": "1.2.0"
       }
     },
     "node_modules/side-channel": {
@@ -23476,6 +23604,15 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
+    },
+    "node_modules/stack-trace": {
+      "version": "1.0.0-pre2",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-1.0.0-pre2.tgz",
+      "integrity": "sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -24638,9 +24775,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz",
-      "integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.1.tgz",
+      "integrity": "sha512-HGyF79+/qZ4soRvM+nHERR2pJ3VXDZ/8sL1uLahdgEDf580NkgiWOxLk33FetExqOWp352JZRsgXbG/4MaGOSg=="
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -24845,6 +24982,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-stringify-position/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
     "node_modules/unist-util-visit": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
@@ -24871,6 +25013,16 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
+    "node_modules/unist-util-visit/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -25320,6 +25472,16 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/vfile-message/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
+    "node_modules/vfile/node_modules/@types/unist": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
+      "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
     },
     "node_modules/vite": {
       "version": "4.5.2",
@@ -26473,6 +26635,15 @@
         "node": "^12.20.0 || >=14"
       }
     },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
@@ -26483,74 +26654,30 @@
       }
     },
     "packages/2d": {
-      "name": "@motion-canvas/2d",
+      "name": "@revideo/2d",
       "version": "3.14.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
-        "@motion-canvas/core": "^3.14.1",
+        "@revideo/core": "^3.14.1",
         "code-fns": "^0.8.2",
         "mathjax-full": "^3.2.2",
         "parse-svg-path": "^0.1.2"
       },
       "devDependencies": {
-        "@motion-canvas/internal": "0.0.0",
-        "@motion-canvas/ui": "^3.14.2",
         "@preact/signals": "^1.2.1",
+        "@revideo/internal": "0.0.0",
+        "@revideo/ui": "^3.14.2",
         "clsx": "^2.0.0",
         "jsdom": "^22.1.0",
         "preact": "^10.19.2",
         "vitest": "^0.34.6"
       }
     },
-    "packages/2d/node_modules/@wooorm/starry-night": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@wooorm/starry-night/-/starry-night-1.7.0.tgz",
-      "integrity": "sha512-ktO0nkddrovIoNW2jAUT+Cdd9n1bWjy1Ir4CdcmgTaT6E94HLlQfu7Yv62falclBEwvsuVp3bSBw23wtta1fNw==",
-      "dependencies": {
-        "@types/hast": "^2.0.0",
-        "import-meta-resolve": "^2.0.0",
-        "vscode-oniguruma": "^1.0.0",
-        "vscode-textmate": "^9.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/2d/node_modules/clsx": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/2d/node_modules/code-fns": {
-      "version": "0.8.2",
-      "license": "MIT",
-      "dependencies": {
-        "@wooorm/starry-night": "^1.2.0"
-      }
-    },
-    "packages/2d/node_modules/import-meta-resolve": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
-      "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "packages/2d/node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
-    },
     "packages/core": {
-      "name": "@motion-canvas/core",
+      "name": "@revideo/core",
       "version": "3.14.1",
       "license": "MIT",
       "dependencies": {
@@ -26558,13 +26685,13 @@
         "chroma-js": "^2.4.2"
       },
       "devDependencies": {
-        "@motion-canvas/internal": "0.0.0",
+        "@revideo/internal": "0.0.0",
         "jsdom": "^22.1.0",
         "vitest": "^0.34.6"
       }
     },
     "packages/create": {
-      "name": "@motion-canvas/create",
+      "name": "@revideo/create",
       "version": "3.14.2",
       "license": "MIT",
       "dependencies": {
@@ -26572,17 +26699,17 @@
         "prompts": "^2.4.2"
       },
       "bin": {
-        "create-motion-canvas": "index.js"
+        "create-revideo": "index.js"
       },
       "devDependencies": {
-        "@motion-canvas/2d": "^3.14.2",
-        "@motion-canvas/core": "^3.14.1",
-        "@motion-canvas/ui": "^3.14.2",
-        "@motion-canvas/vite-plugin": "^3.14.1"
+        "@revideo/2d": "^3.14.2",
+        "@revideo/core": "^3.14.1",
+        "@revideo/ui": "^3.14.2",
+        "@revideo/vite-plugin": "^3.14.1"
       }
     },
     "packages/docs": {
-      "name": "@motion-canvas/docs",
+      "name": "@revideo/docs",
       "version": "0.0.0",
       "dependencies": {
         "@babel/standalone": "^7.21.3",
@@ -26592,8 +26719,8 @@
         "@docusaurus/theme-mermaid": "^2.4.0",
         "@docusaurus/theme-search-algolia": "^2.4.0",
         "@mdx-js/react": "^1.6.22",
-        "@motion-canvas/examples": "*",
-        "@motion-canvas/player": "*",
+        "@revideo/examples": "*",
+        "@revideo/player": "*",
         "clsx": "^1.2.0",
         "codemirror": "^6.0.1",
         "prism-react-renderer": "^1.3.5",
@@ -26609,6 +26736,14 @@
       },
       "engines": {
         "node": ">=16.14"
+      }
+    },
+    "packages/docs/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "packages/docs/node_modules/minimatch": {
@@ -26627,9 +26762,8 @@
     },
     "packages/docs/node_modules/shiki": {
       "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-sequence-parser": "^1.1.0",
         "jsonc-parser": "^3.2.0",
@@ -26672,52 +26806,50 @@
     },
     "packages/docs/node_modules/vscode-oniguruma": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "packages/docs/node_modules/vscode-textmate": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "packages/e2e": {
-      "name": "@motion-canvas/e2e",
+      "name": "@revideo/e2e",
       "version": "0.0.0",
       "dependencies": {
-        "@motion-canvas/2d": "*",
-        "@motion-canvas/core": "*",
+        "@revideo/2d": "*",
+        "@revideo/core": "*",
         "jest-image-snapshot": "^6.2.0",
         "puppeteer": "^21.5.2",
         "vitest": "^0.34.6"
       },
       "devDependencies": {
-        "@motion-canvas/ui": "*",
-        "@motion-canvas/vite-plugin": "*"
+        "@revideo/ui": "*",
+        "@revideo/vite-plugin": "*"
       }
     },
     "packages/examples": {
-      "name": "@motion-canvas/examples",
+      "name": "@revideo/examples",
       "version": "0.0.0",
       "dependencies": {
-        "@motion-canvas/2d": "*",
-        "@motion-canvas/core": "*"
+        "@revideo/2d": "*",
+        "@revideo/core": "*"
       },
       "devDependencies": {
-        "@motion-canvas/ui": "*",
-        "@motion-canvas/vite-plugin": "*"
+        "@revideo/ui": "*",
+        "@revideo/vite-plugin": "*"
       }
     },
     "packages/ffmpeg": {
-      "name": "@motion-canvas/ffmpeg",
+      "name": "@revideo/ffmpeg",
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
-        "@motion-canvas/core": "^3.14.1",
-        "@motion-canvas/vite-plugin": "^3.14.1",
+        "@revideo/core": "^3.14.1",
+        "@revideo/vite-plugin": "^3.14.1",
         "fluent-ffmpeg": "^2.1.2",
         "vite": "^4.5"
       },
@@ -26726,7 +26858,7 @@
       }
     },
     "packages/internal": {
-      "name": "@motion-canvas/internal",
+      "name": "@revideo/internal",
       "version": "0.0.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
@@ -26751,28 +26883,29 @@
       }
     },
     "packages/player": {
-      "name": "@motion-canvas/player",
+      "name": "@revideo/player",
       "version": "3.14.1",
       "license": "MIT",
       "devDependencies": {
-        "@motion-canvas/core": "^3.14.1",
+        "@revideo/core": "^3.14.1",
         "sass": "^1.58.0",
         "terser": "^5.16.1"
       }
     },
     "packages/renderer": {
-      "name": "@motion-canvas/renderer",
+      "name": "@revideo/renderer",
       "version": "3.14.1",
       "license": "MIT",
       "devDependencies": {
-        "@motion-canvas/core": "*",
+        "@revideo/core": "*",
         "puppeteer": "^22.3.0"
       }
     },
     "packages/renderer/node_modules/@puppeteer/browsers": {
-      "version": "2.1.0",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.0.tgz",
+      "integrity": "sha512-MC7LxpcBtdfTbzwARXIkqGZ1Osn3nnZJlm+i0+VqHl72t//Xwl9wICrXT8BwtgC6s1xJNHsxOpvzISUqe92+sw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -26792,8 +26925,9 @@
     },
     "packages/renderer/node_modules/agent-base": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -26802,12 +26936,14 @@
       }
     },
     "packages/renderer/node_modules/chromium-bidi": {
-      "version": "0.5.12",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.13.tgz",
+      "integrity": "sha512-OHbYCetDxdW/xmlrafgOiLsIrw4Sp1BEeolbZ1UGJO5v/nekQOJBj/Kzyw6sqKcAVabUTo0GS3cTYgr6zIf00g==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.22.4"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -26815,8 +26951,9 @@
     },
     "packages/renderer/node_modules/cosmiconfig": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -26840,13 +26977,15 @@
     },
     "packages/renderer/node_modules/devtools-protocol": {
       "version": "0.0.1249869",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
+      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg==",
+      "dev": true
     },
     "packages/renderer/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -26857,8 +26996,9 @@
     },
     "packages/renderer/node_modules/https-proxy-agent": {
       "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -26869,16 +27009,18 @@
     },
     "packages/renderer/node_modules/lru-cache": {
       "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "packages/renderer/node_modules/proxy-agent": {
       "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -26894,14 +27036,15 @@
       }
     },
     "packages/renderer/node_modules/puppeteer": {
-      "version": "22.4.1",
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.5.0.tgz",
+      "integrity": "sha512-PNVflixb6w3FMhehYhLcaQHTCcNKVkjxekzyvWr0n0yBnhUYF0ZhiG4J1I14Mzui2oW8dGvUD8kbXj0GiN1pFg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.1.0",
+        "@puppeteer/browsers": "2.2.0",
         "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.4.1"
+        "puppeteer-core": "22.5.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -26911,13 +27054,13 @@
       }
     },
     "packages/renderer/node_modules/puppeteer-core": {
-      "version": "22.4.1",
+      "version": "22.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.5.0.tgz",
+      "integrity": "sha512-bcfmM1nNSysjnES/ZZ1KdwFAFFGL3N76qRpisBb4WL7f4UAD4vPDxlhKZ1HJCDgMSWeYmeder4kftyp6lKqMYg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.1.0",
-        "chromium-bidi": "0.5.12",
-        "cross-fetch": "4.0.0",
+        "@puppeteer/browsers": "2.2.0",
+        "chromium-bidi": "0.5.13",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1249869",
         "ws": "8.16.0"
@@ -26928,8 +27071,9 @@
     },
     "packages/renderer/node_modules/socks-proxy-agent": {
       "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -26941,8 +27085,9 @@
     },
     "packages/renderer/node_modules/tar-fs": {
       "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -26954,8 +27099,9 @@
     },
     "packages/renderer/node_modules/tar-stream": {
       "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -26963,27 +27109,27 @@
       }
     },
     "packages/template": {
-      "name": "@motion-canvas/template",
+      "name": "@revideo/template",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@motion-canvas/2d": "*",
-        "@motion-canvas/core": "*",
-        "@motion-canvas/ffmpeg": "*",
-        "@motion-canvas/renderer": "*"
+        "@revideo/2d": "*",
+        "@revideo/core": "*",
+        "@revideo/ffmpeg": "*",
+        "@revideo/renderer": "*"
       },
       "devDependencies": {
-        "@motion-canvas/ui": "*",
-        "@motion-canvas/vite-plugin": "*"
+        "@revideo/ui": "*",
+        "@revideo/vite-plugin": "*"
       }
     },
     "packages/ui": {
-      "name": "@motion-canvas/ui",
+      "name": "@revideo/ui",
       "version": "3.14.2",
       "license": "MIT",
       "dependencies": {
-        "@motion-canvas/core": "^3.14.1",
         "@preact/signals": "^1.2.1",
+        "@revideo/core": "^3.14.1",
         "preact": "^10.19.2"
       },
       "devDependencies": {
@@ -26995,16 +27141,8 @@
         "vite-plugin-dts": "^3.6.4"
       }
     },
-    "packages/ui/node_modules/clsx": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "packages/vite-plugin": {
-      "name": "@motion-canvas/vite-plugin",
+      "name": "@revideo/vite-plugin",
       "version": "3.14.1",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29367,13 +29367,13 @@
     },
     "packages/2d": {
       "name": "@revideo/2d",
-      "version": "3.14.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
         "@lezer/common": "^1.2.1",
         "@lezer/highlight": "^1.2.0",
-        "@revideo/core": "^3.14.1",
+        "@revideo/core": "^0.1.0",
         "code-fns": "^0.8.2",
         "mathjax-full": "^3.2.2",
         "parse-svg-path": "^0.1.2"
@@ -29381,7 +29381,7 @@
       "devDependencies": {
         "@preact/signals": "^1.2.1",
         "@revideo/internal": "0.0.0",
-        "@revideo/ui": "^3.14.2",
+        "@revideo/ui": "^0.1.0",
         "clsx": "^2.0.0",
         "jsdom": "^22.1.0",
         "preact": "^10.19.2",
@@ -29390,7 +29390,7 @@
     },
     "packages/core": {
       "name": "@revideo/core",
-      "version": "3.14.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/chroma-js": "^2.1.4",
@@ -29404,7 +29404,7 @@
     },
     "packages/create": {
       "name": "@revideo/create",
-      "version": "3.14.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8",
@@ -29414,10 +29414,10 @@
         "create-revideo": "index.js"
       },
       "devDependencies": {
-        "@revideo/2d": "^3.14.2",
-        "@revideo/core": "^3.14.1",
-        "@revideo/ui": "^3.14.2",
-        "@revideo/vite-plugin": "^3.14.1"
+        "@revideo/2d": "^0.1.0",
+        "@revideo/core": "^0.1.0",
+        "@revideo/ui": "^0.1.0",
+        "@revideo/vite-plugin": "^0.1.0"
       }
     },
     "packages/docs": {
@@ -29554,13 +29554,13 @@
     },
     "packages/ffmpeg": {
       "name": "@revideo/ffmpeg",
-      "version": "1.1.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@ffmpeg-installer/ffmpeg": "^1.1.0",
         "@ffprobe-installer/ffprobe": "^2.0.0",
-        "@revideo/core": "^3.14.1",
-        "@revideo/vite-plugin": "^3.14.1",
+        "@revideo/core": "^0.1.0",
+        "@revideo/vite-plugin": "^0.1.0",
         "fluent-ffmpeg": "^2.1.2",
         "vite": "^4.5"
       },
@@ -29595,20 +29595,20 @@
     },
     "packages/player": {
       "name": "@revideo/player",
-      "version": "3.14.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@revideo/core": "^3.14.1",
+        "@revideo/core": "^0.1.0",
         "sass": "^1.58.0",
         "terser": "^5.16.1"
       }
     },
     "packages/renderer": {
       "name": "@revideo/renderer",
-      "version": "3.14.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@revideo/core": "*",
+        "@revideo/core": "^0.1.0",
         "puppeteer": "^22.3.0"
       }
     },
@@ -29869,11 +29869,11 @@
     },
     "packages/ui": {
       "name": "@revideo/ui",
-      "version": "3.14.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals": "^1.2.1",
-        "@revideo/core": "^3.14.1",
+        "@revideo/core": "^0.1.0",
         "preact": "^10.19.2"
       },
       "devDependencies": {
@@ -29887,7 +29887,7 @@
     },
     "packages/vite-plugin": {
       "name": "@revideo/vite-plugin",
-      "version": "3.14.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29562,6 +29562,7 @@
         "@revideo/core": "^0.1.0",
         "@revideo/vite-plugin": "^0.1.0",
         "fluent-ffmpeg": "^2.1.2",
+        "uuid": "^9.0.1",
         "vite": "^4.5"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29404,7 +29404,7 @@
     },
     "packages/create": {
       "name": "@revideo/create",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29404,7 +29404,7 @@
     },
     "packages/create": {
       "name": "@revideo/create",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
   "dependencies": {
     "@preact/preset-vite": "^2.7.0",
     "@wooorm/starry-night": "^3.3.0",
+    "lunr": "^2.3.9",
+    "marked": "^12.0.1",
     "shiki": "^1.1.7",
     "uuid": "^9.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "*.{js,jsx,ts,tsx,md,scss}": "prettier --write"
   },
   "dependencies": {
+    "@preact/preset-vite": "^2.7.0",
     "@wooorm/starry-night": "^3.3.0",
     "shiki": "^1.1.7",
     "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "motion-canvas",
+  "name": "revideo",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -22,6 +22,7 @@
     "template:build": "npm run build -w packages/template",
     "examples:dev": "npm run dev -w packages/examples",
     "examples:build": "npm run build -w packages/examples",
+    "renderer:build": "npm run build -w packages/renderer",
     "player:dev": "npm run dev -w packages/player",
     "player:build": "npm run build -w packages/player",
     "docs:dev": "npm run dev -w packages/docs",

--- a/packages/2d/CHANGELOG.md
+++ b/packages/2d/CHANGELOG.md
@@ -3,6 +3,237 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* **2d:** account for offset in cardinal points ([#883](https://github.com/havenhq/revideo/issues/883)) ([24da258](https://github.com/havenhq/revideo/commit/24da258f5937087b363eeb9146a9d22747b02e70)), closes [#882](https://github.com/havenhq/revideo/issues/882)
+* **2d:** account for spawners in scene graph ([#935](https://github.com/havenhq/revideo/issues/935)) ([ca325f5](https://github.com/havenhq/revideo/commit/ca325f5ad0ae987e76106f5e65fef3ed7b3ca08d))
+* **2d:** add missing Curve properties to Circle ([#805](https://github.com/havenhq/revideo/issues/805)) ([38c7900](https://github.com/havenhq/revideo/commit/38c79000403d7c3c99dde9e4c825a448d5f55054))
+* **2d:** add missing Fragment export ([#553](https://github.com/havenhq/revideo/issues/553)) ([229afb4](https://github.com/havenhq/revideo/commit/229afb4fe7d95f09b480ab4a813f8dff549f381f))
+* **2d:** add missing jsx dev runtime ([#547](https://github.com/havenhq/revideo/issues/547)) ([d61cb7d](https://github.com/havenhq/revideo/commit/d61cb7dd24ab66ae17d5bd6f5ccb34c4fd1e7569)), closes [#545](https://github.com/havenhq/revideo/issues/545)
+* **2d:** add missing middle property ([#891](https://github.com/havenhq/revideo/issues/891)) ([61e2e96](https://github.com/havenhq/revideo/commit/61e2e96e3b8f37a68ebdddb432baba04858fd4f3))
+* **2d:** add missing shape export ([#111](https://github.com/havenhq/revideo/issues/111)) ([02a1fa7](https://github.com/havenhq/revideo/commit/02a1fa7ea62155e498809f2e57ff29a18c82ac12))
+* **2d:** better error handling ([#524](https://github.com/havenhq/revideo/issues/524)) ([b7475ba](https://github.com/havenhq/revideo/commit/b7475ba5ff35d37ee198577d1205d6ecd6fd2092))
+* **2d:** calculate arrow orientations for curves correctly ([#597](https://github.com/havenhq/revideo/issues/597)) ([1626811](https://github.com/havenhq/revideo/commit/1626811ec4cd1bd2a3d43e393ced40a7da462c3a))
+* **2d:** calculate Txt cache bbox from contents ([#836](https://github.com/havenhq/revideo/issues/836)) ([33e1a12](https://github.com/havenhq/revideo/commit/33e1a1296f21d26e9ed45ae92132825dca17054d)), closes [#465](https://github.com/havenhq/revideo/issues/465)
+* **2d:** clone size correctly ([#562](https://github.com/havenhq/revideo/issues/562)) ([cdd3df1](https://github.com/havenhq/revideo/commit/cdd3df1bff25b04b905e289264831d8d328caaab)), closes [#559](https://github.com/havenhq/revideo/issues/559)
+* **2d:** correct layout defaults ([#442](https://github.com/havenhq/revideo/issues/442)) ([c116c35](https://github.com/havenhq/revideo/commit/c116c355179ba3b2487634fb82b9a5bc2ea266bf))
+* **2d:** correctly append Txt nodes to view ([#644](https://github.com/havenhq/revideo/issues/644)) ([24bb51a](https://github.com/havenhq/revideo/commit/24bb51aa04778c33ce327926b27332efaa554e5f))
+* **2d:** correctly support external image urls ([#678](https://github.com/havenhq/revideo/issues/678)) ([a08556b](https://github.com/havenhq/revideo/commit/a08556b6e2822a55db593f610ea4dd6cb8494adb)), closes [#677](https://github.com/havenhq/revideo/issues/677)
+* **2d:** fix cache bbox for lines ([#467](https://github.com/havenhq/revideo/issues/467)) ([9fd1444](https://github.com/havenhq/revideo/commit/9fd144417bb0b6301da6c522a988775f5ff142ac)), closes [#466](https://github.com/havenhq/revideo/issues/466)
+* **2d:** fix circle segment ([#557](https://github.com/havenhq/revideo/issues/557)) ([adebff4](https://github.com/havenhq/revideo/commit/adebff492b76a512d79151b00adf1b383d25c5b5))
+* **2d:** fix CodeBlock types ([#563](https://github.com/havenhq/revideo/issues/563)) ([25160fa](https://github.com/havenhq/revideo/commit/25160fa4d92af88429110356e42f6e3b4f88a90f)), closes [#560](https://github.com/havenhq/revideo/issues/560)
+* **2d:** fix curve arrow alignment when animating start signal ([#615](https://github.com/havenhq/revideo/issues/615)) ([2fefc40](https://github.com/havenhq/revideo/commit/2fefc4026050159ba204c7629832ad83e8bfa51b))
+* **2d:** fix cyclic dependency in cardinal points ([#645](https://github.com/havenhq/revideo/issues/645)) ([def23f9](https://github.com/havenhq/revideo/commit/def23f925ee7200c8740ecd51c7f6117d67b6ef8))
+* **2d:** fix font ligatures in CodeBlock ([#231](https://github.com/havenhq/revideo/issues/231)) ([11ee3fe](https://github.com/havenhq/revideo/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
+* **2d:** fix Gradient and Pattern signals ([#376](https://github.com/havenhq/revideo/issues/376)) ([6e0dc8a](https://github.com/havenhq/revideo/commit/6e0dc8af8d19f93fd6a42addca2b3a2958b4dd33))
+* **2d:** fix height when tweening text ([#905](https://github.com/havenhq/revideo/issues/905)) ([1c6a796](https://github.com/havenhq/revideo/commit/1c6a7965be137c1ab69741cdd1e9aaa6df4208c4))
+* **2d:** fix import order ([#94](https://github.com/havenhq/revideo/issues/94)) ([bcc0bcf](https://github.com/havenhq/revideo/commit/bcc0bcffae47855bd8f7ab06454aaebe93c4aa24)), closes [#76](https://github.com/havenhq/revideo/issues/76)
+* **2d:** fix initial value of endOffset ([#433](https://github.com/havenhq/revideo/issues/433)) ([9fe82b3](https://github.com/havenhq/revideo/commit/9fe82b3d21ba0150a2378e541a4652ca707c2d15))
+* **2d:** fix layout calculation for nodes not explicitly added to view ([#331](https://github.com/havenhq/revideo/issues/331)) ([528e2d5](https://github.com/havenhq/revideo/commit/528e2d5a0abec99819e022d2848b256ece9f869a))
+* **2d:** fix letterSpacing ([#448](https://github.com/havenhq/revideo/issues/448)) ([bb5ffc4](https://github.com/havenhq/revideo/commit/bb5ffc48efa82b9db818e8e52aa35e9c2ad8ce89)), closes [#447](https://github.com/havenhq/revideo/issues/447)
+* **2d:** fix line arc length ([#503](https://github.com/havenhq/revideo/issues/503)) ([4f1cd59](https://github.com/havenhq/revideo/commit/4f1cd59e6bcba0b16b36be88b28a60ae46d4d9ab)), closes [#497](https://github.com/havenhq/revideo/issues/497)
+* **2d:** fix Line cache ([#232](https://github.com/havenhq/revideo/issues/232)) ([a953b64](https://github.com/havenhq/revideo/commit/a953b64540c020657845efc84d4179142a7a0974)), closes [#205](https://github.com/havenhq/revideo/issues/205)
+* **2d:** fix line jitter under certain conditions ([#863](https://github.com/havenhq/revideo/issues/863)) ([fb110a2](https://github.com/havenhq/revideo/commit/fb110a2f3583fc040bf2c39560934162bd146d9b))
+* **2d:** fix Line overview crashing ([#142](https://github.com/havenhq/revideo/issues/142)) ([6bd5fd9](https://github.com/havenhq/revideo/commit/6bd5fd941e583e44f5d920ecd20215efb1eed58a))
+* **2d:** fix nested cache canvases ([#554](https://github.com/havenhq/revideo/issues/554)) ([e601441](https://github.com/havenhq/revideo/commit/e6014413b215af6fb1a7953f8db83893d4025f0b)), closes [#551](https://github.com/havenhq/revideo/issues/551)
+* **2d:** fix package.json entry ([#720](https://github.com/havenhq/revideo/issues/720)) ([12e9bf6](https://github.com/havenhq/revideo/commit/12e9bf6f40ab7afc02e2f55260544f3864920ded))
+* **2d:** fix signal initialization ([#382](https://github.com/havenhq/revideo/issues/382)) ([ea36e79](https://github.com/havenhq/revideo/commit/ea36e791a20bfd1b491ffa9917be686c51bc3899))
+* **2d:** fix tweening cardinal points ([#829](https://github.com/havenhq/revideo/issues/829)) ([cc16737](https://github.com/havenhq/revideo/commit/cc16737cd59081582fbb488a880e8d3c11c14918))
+* **2d:** fix Txt decorators ([#526](https://github.com/havenhq/revideo/issues/526)) ([25b30ed](https://github.com/havenhq/revideo/commit/25b30ed3861f46d72147335480912ce5f564be79))
+* **2d:** fix types ([#659](https://github.com/havenhq/revideo/issues/659)) ([a32af29](https://github.com/havenhq/revideo/commit/a32af29ef3bd2e5dbf08697ebfee53230fceadc1))
+* **2d:** format whitespaces according to HTML ([#372](https://github.com/havenhq/revideo/issues/372)) ([83fb565](https://github.com/havenhq/revideo/commit/83fb565742d98f060c0400c8cbaf9961b69f34d0)), closes [#370](https://github.com/havenhq/revideo/issues/370)
+* **2d:** handle division by zero in lines ([#407](https://github.com/havenhq/revideo/issues/407)) ([a17871a](https://github.com/havenhq/revideo/commit/a17871a2ce63dd5bb32bc719037327c4e9dde217))
+* **2d:** handle floating point errors in acos ([#381](https://github.com/havenhq/revideo/issues/381)) ([5bca8fd](https://github.com/havenhq/revideo/commit/5bca8fd0bbdcf28f2793c124b7d6b0afd560c4b8))
+* **2d:** handle lines with no points ([#233](https://github.com/havenhq/revideo/issues/233)) ([8108474](https://github.com/havenhq/revideo/commit/81084743dfad7b6419760796fda825047909d4d4)), closes [#212](https://github.com/havenhq/revideo/issues/212)
+* **2d:** ignore children with disabled layout ([#669](https://github.com/havenhq/revideo/issues/669)) ([b98c462](https://github.com/havenhq/revideo/commit/b98c4625c3634495e86ca23d19355035e457db06)), closes [#580](https://github.com/havenhq/revideo/issues/580)
+* **2d:** improve Curve hitbox ([#778](https://github.com/havenhq/revideo/issues/778)) ([8af723c](https://github.com/havenhq/revideo/commit/8af723c0322de39d2defe0363bba03f4f9542f08))
+* **2d:** improve Rect radius ([#221](https://github.com/havenhq/revideo/issues/221)) ([3437e42](https://github.com/havenhq/revideo/commit/3437e42713a3f4a8d44d246ee01e2eb23b61e06a)), closes [#207](https://github.com/havenhq/revideo/issues/207)
+* **2d:** make Text respect textWrap=pre ([#287](https://github.com/havenhq/revideo/issues/287)) ([cb07f4b](https://github.com/havenhq/revideo/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
+* **2d:** minor fixes ([#915](https://github.com/havenhq/revideo/issues/915)) ([63cfc9e](https://github.com/havenhq/revideo/commit/63cfc9e033f2c2ac6d6ed2a0d8f615fcf642ab59))
+* **2d:** point arrow heads in correct direction ([#792](https://github.com/havenhq/revideo/issues/792)) ([52ed52e](https://github.com/havenhq/revideo/commit/52ed52e963cc69a066a0353680acaca35b9c937a)), closes [#783](https://github.com/havenhq/revideo/issues/783)
+* **2d:** prevent src warnings in Icon and Latex ([#899](https://github.com/havenhq/revideo/issues/899)) ([5eebab7](https://github.com/havenhq/revideo/commit/5eebab71d8061e233872e049e77b847f9fd077a1))
+* **2d:** remove circular dependencies ([#780](https://github.com/havenhq/revideo/issues/780)) ([cdf3af5](https://github.com/havenhq/revideo/commit/cdf3af500a58151ee3549c6e728751aab3e6f75c))
+* **2d:** smoothly play videos when presenting ([#600](https://github.com/havenhq/revideo/issues/600)) ([294fe6a](https://github.com/havenhq/revideo/commit/294fe6ac056ab074c77214fcf9035f53fac9258c)), closes [#578](https://github.com/havenhq/revideo/issues/578)
+* **2d:** some signal setters not returning owners ([#143](https://github.com/havenhq/revideo/issues/143)) ([09ab7f9](https://github.com/havenhq/revideo/commit/09ab7f96afcaae608399a653c0b4878ba9b467d4))
+* **2d:** stop code highlighting from jumping ([#230](https://github.com/havenhq/revideo/issues/230)) ([67ef1c4](https://github.com/havenhq/revideo/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
+* **2d:** stop mutating children ([#903](https://github.com/havenhq/revideo/issues/903)) ([f9552a8](https://github.com/havenhq/revideo/commit/f9552a8658ccde6c7b2466ad40b12cf28c6ec805))
+* **2d:** switch iframes to ShadowDOM ([#90](https://github.com/havenhq/revideo/issues/90)) ([86176be](https://github.com/havenhq/revideo/commit/86176be055c08aba59272afcda00ed586f6c7ad6))
+* **2d:** textDirection property for RTL/LTR text ([#404](https://github.com/havenhq/revideo/issues/404)) ([f240b1b](https://github.com/havenhq/revideo/commit/f240b1bd140a884f6901b7cfcb97ce3e9ce4b48d))
+* **2d:** textWrap not working in Firefox ([#541](https://github.com/havenhq/revideo/issues/541)) ([f10e057](https://github.com/havenhq/revideo/commit/f10e057fd13ed9dcc70ebc0ca63963708ec159c8)), closes [#517](https://github.com/havenhq/revideo/issues/517)
+* **2d:** wait for reused async resources ([#599](https://github.com/havenhq/revideo/issues/599)) ([280e065](https://github.com/havenhq/revideo/commit/280e065fe69e9a744b7b12eb4609e7d87f76bb63)), closes [#593](https://github.com/havenhq/revideo/issues/593)
+* account for italic fonts in cache ([#968](https://github.com/havenhq/revideo/issues/968)) ([abb0906](https://github.com/havenhq/revideo/commit/abb090695c4257d9877d0cb11954093c49149ddc)), closes [#934](https://github.com/havenhq/revideo/issues/934)
+* fix compound property setter ([#218](https://github.com/havenhq/revideo/issues/218)) ([6cd1b95](https://github.com/havenhq/revideo/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)), closes [#208](https://github.com/havenhq/revideo/issues/208) [#210](https://github.com/havenhq/revideo/issues/210)
+* fix scaffolding ([#93](https://github.com/havenhq/revideo/issues/93)) ([95c55ed](https://github.com/havenhq/revideo/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
+* plug memory leaks ([#385](https://github.com/havenhq/revideo/issues/385)) ([de0af00](https://github.com/havenhq/revideo/commit/de0af00a7d2e019e2a933791c62b7901755be7b0))
+* prevent consumePromises from halting ([#657](https://github.com/havenhq/revideo/issues/657)) ([363a189](https://github.com/havenhq/revideo/commit/363a189b0c7f5926c9d5ae00b58b48e8ed4d9b48))
+* previous scene being rendered twice ([#97](https://github.com/havenhq/revideo/issues/97)) ([90205bd](https://github.com/havenhq/revideo/commit/90205bdc1a086abe5f73b04cb4616c6af5ec4377))
+* restrict size of cache canvas ([#544](https://github.com/havenhq/revideo/issues/544)) ([49ec554](https://github.com/havenhq/revideo/commit/49ec55490718e503d9a39437ae13c189dc4fe9ea))
+* support color to null tweening ([#387](https://github.com/havenhq/revideo/issues/387)) ([02e9f22](https://github.com/havenhq/revideo/commit/02e9f22027a1c3a85ffcc259aeca913318fb6f54))
+* support legacy imports again ([#868](https://github.com/havenhq/revideo/issues/868)) ([77c4e2e](https://github.com/havenhq/revideo/commit/77c4e2eeb8b0f73bdef1f72e3d81f34c79748929))
+* support multiple async players ([#450](https://github.com/havenhq/revideo/issues/450)) ([d7ec469](https://github.com/havenhq/revideo/commit/d7ec469e747eefd909f4dd59dd713f5d86308222)), closes [#434](https://github.com/havenhq/revideo/issues/434)
+* typo on codeblock remove comments ([#368](https://github.com/havenhq/revideo/issues/368)) ([2025adc](https://github.com/havenhq/revideo/commit/2025adc6e7aa11d81b6f5f6989e8eae18cf86cb7))
+* **ui:** correctly drag time events ([#912](https://github.com/havenhq/revideo/issues/912)) ([81f6dd6](https://github.com/havenhq/revideo/commit/81f6dd6e485be451a50a695a146ed6b69e30bbc2))
+* **ui:** remember state of custom tabs ([#900](https://github.com/havenhq/revideo/issues/900)) ([eac45b8](https://github.com/havenhq/revideo/commit/eac45b88ed09fc7cddc3336e46d8697de5775b1f))
+* use correct scene sizes ([#146](https://github.com/havenhq/revideo/issues/146)) ([f279638](https://github.com/havenhq/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+
+
+### Code Refactoring
+
+* introduce improved names ([#425](https://github.com/havenhq/revideo/issues/425)) ([4a2188d](https://github.com/havenhq/revideo/commit/4a2188d339587fa658b2134befc3fe63c835c5d7))
+* remove legacy package ([6a84120](https://github.com/havenhq/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+
+
+### Features
+
+* **2d:** add antialiased signal to Shape ([#282](https://github.com/havenhq/revideo/issues/282)) ([7c6905d](https://github.com/havenhq/revideo/commit/7c6905d72c6c2f49e10f0a80704c0afe3504d01b))
+* **2d:** add arcLength helper methods to Curve ([#627](https://github.com/havenhq/revideo/issues/627)) ([3c7546e](https://github.com/havenhq/revideo/commit/3c7546e7a509deb6fff8f669c3df0a69b492bd2e))
+* **2d:** add Bézier nodes ([#603](https://github.com/havenhq/revideo/issues/603)) ([9841cfd](https://github.com/havenhq/revideo/commit/9841cfdc3947ca4e6d6e42ed21eae88e855f855d))
+* **2d:** add cardinal points ([#636](https://github.com/havenhq/revideo/issues/636)) ([2136a25](https://github.com/havenhq/revideo/commit/2136a2558a9ed968ee505e4e5cce33d989dfdc13)), closes [#391](https://github.com/havenhq/revideo/issues/391)
+* **2d:** add closed property for circle ([#378](https://github.com/havenhq/revideo/issues/378)) ([62a9605](https://github.com/havenhq/revideo/commit/62a9605d4c54e7bf2d2d44d47bf769f5b27378a5))
+* **2d:** add completion property for curves ([#635](https://github.com/havenhq/revideo/issues/635)) ([6577d6d](https://github.com/havenhq/revideo/commit/6577d6ddfaf779ba02f3862d2a357166138b99ca))
+* **2d:** add default computed values for signals ([#259](https://github.com/havenhq/revideo/issues/259)) ([18f61a6](https://github.com/havenhq/revideo/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
+* **2d:** add Icon Component ([#306](https://github.com/havenhq/revideo/issues/306)) ([3479631](https://github.com/havenhq/revideo/commit/3479631ef34e39f90a8d8de441317672be1840d9)), closes [#305](https://github.com/havenhq/revideo/issues/305)
+* **2d:** add LaTeX component ([#228](https://github.com/havenhq/revideo/issues/228)) ([4c26d2a](https://github.com/havenhq/revideo/commit/4c26d2aaf0c697486639aa917cd5c585d3d0ea74))
+* **2d:** add line counter for CodeBlock ([#802](https://github.com/havenhq/revideo/issues/802)) ([c3f9676](https://github.com/havenhq/revideo/commit/c3f9676b6984731a09a44ab0b1fcfc226975fa08))
+* **2d:** add methods for rearranging children ([#81](https://github.com/havenhq/revideo/issues/81)) ([63f6c1a](https://github.com/havenhq/revideo/commit/63f6c1aa51ac4ecd093151c8cd30910f2e72bcac))
+* **2d:** add moveBelow, moveAbove and moveTo methods to Node ([#365](https://github.com/havenhq/revideo/issues/365)) ([16752a3](https://github.com/havenhq/revideo/commit/16752a3b8ae7461b33d6208a9675729f374e8324))
+* **2d:** add option for preformatted text ([#147](https://github.com/havenhq/revideo/issues/147)) ([989be53](https://github.com/havenhq/revideo/commit/989be532d86642e1125bb7fa62a801b09c1b8f26))
+* **2d:** add Path component ([#700](https://github.com/havenhq/revideo/issues/700)) ([2128b6b](https://github.com/havenhq/revideo/commit/2128b6bf871cabe19e1abc749f18945c78c01f84))
+* **2d:** add playbackRate signal to Video component ([#831](https://github.com/havenhq/revideo/issues/831)) ([5902b82](https://github.com/havenhq/revideo/commit/5902b824b36400876be0ee970e2c6211299faf21)), closes [#711](https://github.com/havenhq/revideo/issues/711)
+* **2d:** add Polygon component ([#463](https://github.com/havenhq/revideo/issues/463)) ([15adb3e](https://github.com/havenhq/revideo/commit/15adb3e312a4998b44c0b9c5fe5b5236f51c71c9)), closes [#455](https://github.com/havenhq/revideo/issues/455)
+* **2d:** add querying helpers ([#852](https://github.com/havenhq/revideo/issues/852)) ([614de6b](https://github.com/havenhq/revideo/commit/614de6bd8542322d1db4b123b875f6fad85cc4eb))
+* **2d:** add Ray node ([#628](https://github.com/havenhq/revideo/issues/628)) ([649447c](https://github.com/havenhq/revideo/commit/649447cd5f2089afc64cc7bd4b0276e69d1e9a30))
+* **2d:** add save and restore methods to nodes ([#406](https://github.com/havenhq/revideo/issues/406)) ([870e194](https://github.com/havenhq/revideo/commit/870e1947d97382bc6d82857c077140bbef7cf7e8))
+* **2d:** add skew property ([#803](https://github.com/havenhq/revideo/issues/803)) ([eff7c7b](https://github.com/havenhq/revideo/commit/eff7c7be0c013139140b398350242457736d48c7))
+* **2d:** add smooth corners and sharpness to rect ([#310](https://github.com/havenhq/revideo/issues/310)) ([f7fbefd](https://github.com/havenhq/revideo/commit/f7fbefd27f7f6972cfb5a45a68e5d0aed9593ae4))
+* **2d:** add spline node ([#514](https://github.com/havenhq/revideo/issues/514)) ([3ce2111](https://github.com/havenhq/revideo/commit/3ce2111309e698450dc4c6e2ad47024995863e73))
+* **2d:** add start and end signals to Grid node ([#761](https://github.com/havenhq/revideo/issues/761)) ([e37ea80](https://github.com/havenhq/revideo/commit/e37ea806b94e93c6324d8e1b502468925b731e8e))
+* **2d:** add SVG component ([#763](https://github.com/havenhq/revideo/issues/763)) ([8eadc11](https://github.com/havenhq/revideo/commit/8eadc11937d4201545894f2f5b204d477a3f9094))
+* **2d:** add textAlign property ([#451](https://github.com/havenhq/revideo/issues/451)) ([3d15825](https://github.com/havenhq/revideo/commit/3d15825f3cc5a35ba081a31510741b824f3bc6ab)), closes [#303](https://github.com/havenhq/revideo/issues/303)
+* **2d:** add video component property getter ([#240](https://github.com/havenhq/revideo/issues/240)) ([59de5ab](https://github.com/havenhq/revideo/commit/59de5ab2c089589773a2f9ad7588eda7d72693a7))
+* **2d:** add z-index property to nodes ([#398](https://github.com/havenhq/revideo/issues/398)) ([4280af3](https://github.com/havenhq/revideo/commit/4280af3b4b7bd5970fe5e743949a0fcca2c314f3))
+* **2d:** always clip images and videos ([#773](https://github.com/havenhq/revideo/issues/773)) ([3938c59](https://github.com/havenhq/revideo/commit/3938c59394bfc42e5562504687d783ff306d7d32))
+* **2d:** clamp opacity value between 0 and 1 ([#835](https://github.com/havenhq/revideo/issues/835)) ([c54b2f8](https://github.com/havenhq/revideo/commit/c54b2f837a8e8b872df3610f4cc6caa94a728500)), closes [#830](https://github.com/havenhq/revideo/issues/830)
+* **2d:** code bounding box helpers ([#948](https://github.com/havenhq/revideo/issues/948)) ([0ffd56f](https://github.com/havenhq/revideo/commit/0ffd56f5f8076913e687e5b908311aa7832d8b7b))
+* **2d:** code range helpers ([#947](https://github.com/havenhq/revideo/issues/947)) ([044c9ac](https://github.com/havenhq/revideo/commit/044c9acd6ee7e4e337fb4d51286126f583a8da6f))
+* **2d:** code selection and modification ([#163](https://github.com/havenhq/revideo/issues/163)) ([e8e884a](https://github.com/havenhq/revideo/commit/e8e884a1a5574425dbf15272718911c12cfa2327))
+* **2d:** construct lines using signals ([#133](https://github.com/havenhq/revideo/issues/133)) ([2968a24](https://github.com/havenhq/revideo/commit/2968a2426564469fb4f4343fe71a6d30e95361f2))
+* **2d:** immediate restore ([#736](https://github.com/havenhq/revideo/issues/736)) ([634d51d](https://github.com/havenhq/revideo/commit/634d51d2afe8a536673c364874f8f3d1a450b846))
+* **2d:** improve property declarations ([27e7d26](https://github.com/havenhq/revideo/commit/27e7d267ee91bf1e8ca79686b6ec31347f9f4d41))
+* **2d:** improve Rect corner radius ([#120](https://github.com/havenhq/revideo/issues/120)) ([b471fe0](https://github.com/havenhq/revideo/commit/b471fe0e37c0a426d3af8299c9c3c22539e7df05))
+* **2d:** improve Video node ([#601](https://github.com/havenhq/revideo/issues/601)) ([3801d83](https://github.com/havenhq/revideo/commit/3801d83415bbdeeee5d6d53d0c18e5d9e78fba56))
+* **2d:** make `View2D` extend `Rect` ([#379](https://github.com/havenhq/revideo/issues/379)) ([93db5fc](https://github.com/havenhq/revideo/commit/93db5fc41617c0902e85fda90fbfc930c2b4634b))
+* **2d:** make Circle extend Curve ([#771](https://github.com/havenhq/revideo/issues/771)) ([4c8cf19](https://github.com/havenhq/revideo/commit/4c8cf1954093958eac507921dc18f67dd64b2052))
+* **2d:** make Polygon extend Curve ([#961](https://github.com/havenhq/revideo/issues/961)) ([739c9fc](https://github.com/havenhq/revideo/commit/739c9fccbc101f8b2eed680a11c00f317fdc4dd3))
+* **2d:** make Rect extend Curve ([#759](https://github.com/havenhq/revideo/issues/759)) ([9810212](https://github.com/havenhq/revideo/commit/9810212648824b9a2fa2ecd6b597e3319d20b325))
+* **2d:** nested Txt nodes ([#861](https://github.com/havenhq/revideo/issues/861)) ([f2786d0](https://github.com/havenhq/revideo/commit/f2786d0cd0d06065ca1e9eb9f6b4c11a74b6c283)), closes [#540](https://github.com/havenhq/revideo/issues/540)
+* **2d:** simplify layout prop ([c24cb12](https://github.com/havenhq/revideo/commit/c24cb12a22b7c85fdfb051917fa9ee1e0911717c))
+* **2d:** support HMR for images ([#641](https://github.com/havenhq/revideo/issues/641)) ([cf17520](https://github.com/havenhq/revideo/commit/cf17520aa8ddf19dcfc419c63cf7255892d45b71))
+* **2d:** support letter spacing in Code ([#955](https://github.com/havenhq/revideo/issues/955)) ([2a87c37](https://github.com/havenhq/revideo/commit/2a87c37c832de86c4b524b33fd68806627daec8b))
+* **2d:** support tweening in applyState ([#859](https://github.com/havenhq/revideo/issues/859)) ([b7ed2e2](https://github.com/havenhq/revideo/commit/b7ed2e24773227e5b576ff056eb23de9b9ff1676))
+* **2d:** support tweening Line points ([#853](https://github.com/havenhq/revideo/issues/853)) ([4bf37d7](https://github.com/havenhq/revideo/commit/4bf37d74d2e4bb9d9cc034aff121a32da9a6d146))
+* **2d:** unify desired sizes ([#118](https://github.com/havenhq/revideo/issues/118)) ([401a799](https://github.com/havenhq/revideo/commit/401a79946b034a96b9abff2f3fb5efd6cc9080f3))
+* **2d:** unify layout properties ([#355](https://github.com/havenhq/revideo/issues/355)) ([3cae97e](https://github.com/havenhq/revideo/commit/3cae97ea704d0533020fa87326dacadcc037d517)), closes [#352](https://github.com/havenhq/revideo/issues/352)
+* **2d:** warn about missing image source ([#817](https://github.com/havenhq/revideo/issues/817)) ([6dcdb5f](https://github.com/havenhq/revideo/commit/6dcdb5f3b83d4860b1557e4745972e0af68f92f3))
+* add advanced caching ([#69](https://github.com/havenhq/revideo/issues/69)) ([2a644c9](https://github.com/havenhq/revideo/commit/2a644c9315acfcc5280a5eacc9904df140a61e4f))
+* add base class for shapes ([#67](https://github.com/havenhq/revideo/issues/67)) ([d38c172](https://github.com/havenhq/revideo/commit/d38c1724e129c553739cbfc27c4e5cd8f737f067))
+* add basic logger ([#88](https://github.com/havenhq/revideo/issues/88)) ([3d82e86](https://github.com/havenhq/revideo/commit/3d82e863af3dc88b3709adbcd0b84e790d05c3b8)), closes [#17](https://github.com/havenhq/revideo/issues/17)
+* add basic transform to Node class ([#83](https://github.com/havenhq/revideo/issues/83)) ([9e114c8](https://github.com/havenhq/revideo/commit/9e114c8830a99c78e6a4fd9265b0e7552758af14))
+* add cloning ([#80](https://github.com/havenhq/revideo/issues/80)) ([47d7a0f](https://github.com/havenhq/revideo/commit/47d7a0fa5da9a03d8ed91557db651f6f960e28b1))
+* add CodeBlock component based on code-fns to 2D ([#78](https://github.com/havenhq/revideo/issues/78)) ([ad346f1](https://github.com/havenhq/revideo/commit/ad346f118d63b1e321ec315e1c70b925670124a1))
+* add coordinates to preview ([#737](https://github.com/havenhq/revideo/issues/737)) ([330c1f9](https://github.com/havenhq/revideo/commit/330c1f962fb920269301e7ee8a2c49cbfc723d85))
+* add default renderer ([#63](https://github.com/havenhq/revideo/issues/63)) ([9255490](https://github.com/havenhq/revideo/commit/92554900965fe088538f5e703dbab2fd84f904d7)), closes [#56](https://github.com/havenhq/revideo/issues/56) [#58](https://github.com/havenhq/revideo/issues/58)
+* add DEG2RAD and RAD2DEG constants ([#630](https://github.com/havenhq/revideo/issues/630)) ([01801e8](https://github.com/havenhq/revideo/commit/01801e8766058e75a6a020400650fb00f8f430cc))
+* add Grid node ([e1f83da](https://github.com/havenhq/revideo/commit/e1f83da1f43d20d392df4acb11e3df9cc457585d))
+* add inspection ([#82](https://github.com/havenhq/revideo/issues/82)) ([4d7f2ae](https://github.com/havenhq/revideo/commit/4d7f2aee6daeda1a2146b632dfdc28b455295776))
+* add markdown logs ([#138](https://github.com/havenhq/revideo/issues/138)) ([e42447a](https://github.com/havenhq/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+* add middle cardinal point ([#758](https://github.com/havenhq/revideo/issues/758)) ([b036eaf](https://github.com/havenhq/revideo/commit/b036eafc00381831c08267a78cf9d74973f4025a))
+* add missing flexbox properties ([#405](https://github.com/havenhq/revideo/issues/405)) ([4e78b4b](https://github.com/havenhq/revideo/commit/4e78b4b2fe4df42ce0a8da6fd41ad38b0104e7f5))
+* add missing layout props ([#72](https://github.com/havenhq/revideo/issues/72)) ([f808a56](https://github.com/havenhq/revideo/commit/f808a562b192fd03dba4b0d353284db344d6a80b))
+* add node spawners ([#149](https://github.com/havenhq/revideo/issues/149)) ([da18a4e](https://github.com/havenhq/revideo/commit/da18a4e24104022a84ecd6cec1666b520186058f))
+* add polyline ([#84](https://github.com/havenhq/revideo/issues/84)) ([4ceaf84](https://github.com/havenhq/revideo/commit/4ceaf842915ac43d81f292c58a4dc73a8d1bb8e9))
+* add random number generator ([#116](https://github.com/havenhq/revideo/issues/116)) ([d505312](https://github.com/havenhq/revideo/commit/d5053123eef308c7a2a61d92b6e76c637f4ed0b8)), closes [#14](https://github.com/havenhq/revideo/issues/14)
+* add reparent helper ([80b95a9](https://github.com/havenhq/revideo/commit/80b95a9ce89d4a2eeea7e467257486e961602d69))
+* add Text and Image components ([#70](https://github.com/havenhq/revideo/issues/70)) ([85c7dcd](https://github.com/havenhq/revideo/commit/85c7dcdb4f8ca2f0bfb03950c85a8d6f6652fcdf))
+* add video node ([#86](https://github.com/havenhq/revideo/issues/86)) ([f4aa654](https://github.com/havenhq/revideo/commit/f4aa65437a18cc85b00199f80cd5e04654c00c4b))
+* added a theme property to the CodeBlock component ([#279](https://github.com/havenhq/revideo/issues/279)) ([fe34fa8](https://github.com/havenhq/revideo/commit/fe34fa8ebfe66cd356fb1c3d85adedef11e03b45))
+* better children and spawners ([#858](https://github.com/havenhq/revideo/issues/858)) ([9b5c23d](https://github.com/havenhq/revideo/commit/9b5c23d2076180cf710656c817369a07b253e3ec))
+* better dependencies between packages ([#152](https://github.com/havenhq/revideo/issues/152)) ([a0a37b3](https://github.com/havenhq/revideo/commit/a0a37b3645fcb91206e65fd0a95b2f486b308c75))
+* better dependencies between packages ([#153](https://github.com/havenhq/revideo/issues/153)) ([59a73d4](https://github.com/havenhq/revideo/commit/59a73d49a7b92c416e1f836a0f53bb676e9f924b))
+* convert built-in types to webgl ([#929](https://github.com/havenhq/revideo/issues/929)) ([a0f0b7d](https://github.com/havenhq/revideo/commit/a0f0b7d8996547e1a316097422ec02bddeeccec6))
+* **core:** switch to vitest ([#99](https://github.com/havenhq/revideo/issues/99)) ([762eeb0](https://github.com/havenhq/revideo/commit/762eeb0a99c2f378d20dbd147f815ba6736099d9)), closes [#48](https://github.com/havenhq/revideo/issues/48)
+* **core:** tree shaking ([#523](https://github.com/havenhq/revideo/issues/523)) ([65fec78](https://github.com/havenhq/revideo/commit/65fec7825fda33812b13f57bfeb1d82193a5d190))
+* **docs:** fiddle editor ([#542](https://github.com/havenhq/revideo/issues/542)) ([3c68fef](https://github.com/havenhq/revideo/commit/3c68fefdf7bf375ee9345aba7dbf9e5ff35e3c3d))
+* export everything from entry points ([#710](https://github.com/havenhq/revideo/issues/710)) ([3c885d9](https://github.com/havenhq/revideo/commit/3c885d9083b52fbbaccf1e2560ae50817949bc52))
+* filter reordering ([#119](https://github.com/havenhq/revideo/issues/119)) ([2398d0f](https://github.com/havenhq/revideo/commit/2398d0f9d57f36b47c9c66a988ca5607e9a3a30e))
+* implement absolute scale setter ([842079a](https://github.com/havenhq/revideo/commit/842079a6547af4032719c85837df3db7c1c6d30a))
+* improve async signals ([#156](https://github.com/havenhq/revideo/issues/156)) ([db27b9d](https://github.com/havenhq/revideo/commit/db27b9d5fb69a88f42afd98c86c4a1cdceb88ea1))
+* improve error logs ([#953](https://github.com/havenhq/revideo/issues/953)) ([3b528cc](https://github.com/havenhq/revideo/commit/3b528cce13a3440c97641d1095ce09e737e89960))
+* improve image error handling ([#847](https://github.com/havenhq/revideo/issues/847)) ([db09d53](https://github.com/havenhq/revideo/commit/db09d5305a3c0507b035e3cd347eaa65b23d7d2e))
+* introduce basic caching ([#68](https://github.com/havenhq/revideo/issues/68)) ([6420d36](https://github.com/havenhq/revideo/commit/6420d362d0e4ae058f55b6ff6bb2a3a32dec559b))
+* introduce editor plugins ([#879](https://github.com/havenhq/revideo/issues/879)) ([2b72007](https://github.com/havenhq/revideo/commit/2b720074d45fc254dc40b534785b591ae44a3f37))
+* merge properties and signals ([#124](https://github.com/havenhq/revideo/issues/124)) ([da3ba83](https://github.com/havenhq/revideo/commit/da3ba83d82ee74f5a5c3631b07597f08cdf9e8e4))
+* minor improvements ([403c7c2](https://github.com/havenhq/revideo/commit/403c7c27ad969880a14c498ec6cefb9e7e7b7544))
+* minor improvements ([#77](https://github.com/havenhq/revideo/issues/77)) ([7c6e584](https://github.com/havenhq/revideo/commit/7c6e584aca353c9af55f0acb61b32b5f99727dba))
+* navigate to scene and node source ([#144](https://github.com/havenhq/revideo/issues/144)) ([86d495d](https://github.com/havenhq/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+* new animator ([#91](https://github.com/havenhq/revideo/issues/91)) ([d85f2f8](https://github.com/havenhq/revideo/commit/d85f2f8a54c0f8bbfbc451884385f30e5b3ec206))
+* new Code node ([#946](https://github.com/havenhq/revideo/issues/946)) ([26e55a3](https://github.com/havenhq/revideo/commit/26e55a37c416fb1313c8aadf40eed2824b45d330))
+* new playback architecture ([#402](https://github.com/havenhq/revideo/issues/402)) ([bbe3e2a](https://github.com/havenhq/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)), closes [#166](https://github.com/havenhq/revideo/issues/166)
+* signal error handling ([#89](https://github.com/havenhq/revideo/issues/89)) ([472ac65](https://github.com/havenhq/revideo/commit/472ac65938b804a6b698c8522ec0c3b6bdbcf1b1))
+* simplify size access ([#65](https://github.com/havenhq/revideo/issues/65)) ([3315e64](https://github.com/havenhq/revideo/commit/3315e64641e9778bc48ea3fb707e3c0eeb581dfe))
+* simplify size access further ([#66](https://github.com/havenhq/revideo/issues/66)) ([9091a5e](https://github.com/havenhq/revideo/commit/9091a5e05d8fadf72c50832c7c4467ac4424b72c))
+* switch to signals ([#64](https://github.com/havenhq/revideo/issues/64)) ([d22d237](https://github.com/havenhq/revideo/commit/d22d23728597e6fa82ea5c5a99a6c0a56819bded))
+* turn Layout into node ([#75](https://github.com/havenhq/revideo/issues/75)) ([cdf8dc0](https://github.com/havenhq/revideo/commit/cdf8dc0a35522482dee2dd78a69606b79f52246e))
+* **ui:** add custom presentation overlays ([#884](https://github.com/havenhq/revideo/issues/884)) ([4696d3c](https://github.com/havenhq/revideo/commit/4696d3c8cb8b68e3475406359f9cf6b875b1c838)), closes [#825](https://github.com/havenhq/revideo/issues/825)
+* **ui:** custom inspectors ([#913](https://github.com/havenhq/revideo/issues/913)) ([6c54424](https://github.com/havenhq/revideo/commit/6c544248a2bd733f2d42676a0ed60c93b79ee574))
+* **ui:** scene graph ([#909](https://github.com/havenhq/revideo/issues/909)) ([bf85c5b](https://github.com/havenhq/revideo/commit/bf85c5b4a339719e79da1b87b1aed4492166ce79))
+* **ui:** scene graph icons ([#914](https://github.com/havenhq/revideo/issues/914)) ([e92ddef](https://github.com/havenhq/revideo/commit/e92ddef34860f5e710ff0f1a310758ec0ca95bcb))
+* unify core types ([#71](https://github.com/havenhq/revideo/issues/71)) ([9c5853d](https://github.com/havenhq/revideo/commit/9c5853d8bc65204693c38109a25d1fefd44241b7))
+* unify references and signals ([#137](https://github.com/havenhq/revideo/issues/137)) ([063aede](https://github.com/havenhq/revideo/commit/063aede0842f948d2c6704c6edd426e954bb4668))
+* upgrade code-fns for new theme options and lazy loading ([#401](https://github.com/havenhq/revideo/issues/401)) ([8965ab1](https://github.com/havenhq/revideo/commit/8965ab1bef8b6ae919c8001d0527f5793293b285)), closes [#396](https://github.com/havenhq/revideo/issues/396) [#322](https://github.com/havenhq/revideo/issues/322)
+* use ES modules in fiddles ([#712](https://github.com/havenhq/revideo/issues/712)) ([dbe2ad5](https://github.com/havenhq/revideo/commit/dbe2ad5644219c5a98d38c6557abfb66d793c821))
+* **vite-plugin:** add CORS Proxy ([#357](https://github.com/havenhq/revideo/issues/357)) ([a3c5822](https://github.com/havenhq/revideo/commit/a3c58228b7d3dab08fc27414d19870d35773b280)), closes [#338](https://github.com/havenhq/revideo/issues/338)
+* webgl shaders ([#920](https://github.com/havenhq/revideo/issues/920)) ([849216e](https://github.com/havenhq/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+* world space cache ([#498](https://github.com/havenhq/revideo/issues/498)) ([633e9e1](https://github.com/havenhq/revideo/commit/633e9e140dfbbe397df6ddc1f96ed30782ddce94)), closes [#342](https://github.com/havenhq/revideo/issues/342)
+
+
+### Reverts
+
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/havenhq/revideo/issues/908)) ([86c5170](https://github.com/havenhq/revideo/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
+* feat: upgrade code-fns for new theme options and lazy loading ([#435](https://github.com/havenhq/revideo/issues/435)) ([3f5e439](https://github.com/havenhq/revideo/commit/3f5e43968f7add7c6322c9c8358d3b6fc178c2fe))
+
+
+### BREAKING CHANGES
+
+* multiple name changes
+
+To avoid collisions, names of certain classes have changed:
+- `Text => Txt`
+- `Image => Img`
+- `Rect (type) => BBox`
+
+Cache related methods of `Node` have changed:
+- `getCacheRect => getCacheBBox`
+- `cacheRect => cacheBBox`
+- `fullCacheRect => fullCacheBBox`
+
+The `CodeBlock` property has changed:
+- `CodeBlock.selectionOpacity => CodeBlock.unselectedOpacity`
+* `makeProject` no longer accepts some settings.
+
+Settings such as `background` and `audioOffset` are now stored in the project
+meta file.
+* remove legacy package
+
+
+
+
+
 ## [3.14.2](https://github.com/revideo/revideo/compare/v3.14.1...v3.14.2) (2024-02-08)
 
 **Note:** Version bump only for package @revideo/2d

--- a/packages/2d/CHANGELOG.md
+++ b/packages/2d/CHANGELOG.md
@@ -3,118 +3,118 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.14.2](https://github.com/motion-canvas/motion-canvas/compare/v3.14.1...v3.14.2) (2024-02-08)
+## [3.14.2](https://github.com/revideo/revideo/compare/v3.14.1...v3.14.2) (2024-02-08)
 
-**Note:** Version bump only for package @motion-canvas/2d
-
-
+**Note:** Version bump only for package @revideo/2d
 
 
 
-## [3.14.1](https://github.com/motion-canvas/motion-canvas/compare/v3.14.0...v3.14.1) (2024-02-06)
+
+
+## [3.14.1](https://github.com/revideo/revideo/compare/v3.14.0...v3.14.1) (2024-02-06)
 
 
 ### Bug Fixes
 
-* **2d:** account for spawners in scene graph ([#935](https://github.com/motion-canvas/motion-canvas/issues/935)) ([ca325f5](https://github.com/motion-canvas/motion-canvas/commit/ca325f5ad0ae987e76106f5e65fef3ed7b3ca08d))
+* **2d:** account for spawners in scene graph ([#935](https://github.com/revideo/revideo/issues/935)) ([ca325f5](https://github.com/revideo/revideo/commit/ca325f5ad0ae987e76106f5e65fef3ed7b3ca08d))
 
 
 
 
 
-# [3.14.0](https://github.com/motion-canvas/motion-canvas/compare/v3.13.0...v3.14.0) (2024-02-04)
+# [3.14.0](https://github.com/revideo/revideo/compare/v3.13.0...v3.14.0) (2024-02-04)
 
 
 ### Features
 
-* convert built-in types to webgl ([#929](https://github.com/motion-canvas/motion-canvas/issues/929)) ([a0f0b7d](https://github.com/motion-canvas/motion-canvas/commit/a0f0b7d8996547e1a316097422ec02bddeeccec6))
-* webgl shaders ([#920](https://github.com/motion-canvas/motion-canvas/issues/920)) ([849216e](https://github.com/motion-canvas/motion-canvas/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+* convert built-in types to webgl ([#929](https://github.com/revideo/revideo/issues/929)) ([a0f0b7d](https://github.com/revideo/revideo/commit/a0f0b7d8996547e1a316097422ec02bddeeccec6))
+* webgl shaders ([#920](https://github.com/revideo/revideo/issues/920)) ([849216e](https://github.com/revideo/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
 
 
 
 
 
-# [3.13.0](https://github.com/motion-canvas/motion-canvas/compare/v3.12.4...v3.13.0) (2024-01-10)
+# [3.13.0](https://github.com/revideo/revideo/compare/v3.12.4...v3.13.0) (2024-01-10)
 
 
 ### Bug Fixes
 
-* **2d:** minor fixes ([#915](https://github.com/motion-canvas/motion-canvas/issues/915)) ([63cfc9e](https://github.com/motion-canvas/motion-canvas/commit/63cfc9e033f2c2ac6d6ed2a0d8f615fcf642ab59))
-* **ui:** correctly drag time events ([#912](https://github.com/motion-canvas/motion-canvas/issues/912)) ([81f6dd6](https://github.com/motion-canvas/motion-canvas/commit/81f6dd6e485be451a50a695a146ed6b69e30bbc2))
+* **2d:** minor fixes ([#915](https://github.com/revideo/revideo/issues/915)) ([63cfc9e](https://github.com/revideo/revideo/commit/63cfc9e033f2c2ac6d6ed2a0d8f615fcf642ab59))
+* **ui:** correctly drag time events ([#912](https://github.com/revideo/revideo/issues/912)) ([81f6dd6](https://github.com/revideo/revideo/commit/81f6dd6e485be451a50a695a146ed6b69e30bbc2))
 
 
 ### Features
 
-* **ui:** custom inspectors ([#913](https://github.com/motion-canvas/motion-canvas/issues/913)) ([6c54424](https://github.com/motion-canvas/motion-canvas/commit/6c544248a2bd733f2d42676a0ed60c93b79ee574))
-* **ui:** scene graph ([#909](https://github.com/motion-canvas/motion-canvas/issues/909)) ([bf85c5b](https://github.com/motion-canvas/motion-canvas/commit/bf85c5b4a339719e79da1b87b1aed4492166ce79))
-* **ui:** scene graph icons ([#914](https://github.com/motion-canvas/motion-canvas/issues/914)) ([e92ddef](https://github.com/motion-canvas/motion-canvas/commit/e92ddef34860f5e710ff0f1a310758ec0ca95bcb))
+* **ui:** custom inspectors ([#913](https://github.com/revideo/revideo/issues/913)) ([6c54424](https://github.com/revideo/revideo/commit/6c544248a2bd733f2d42676a0ed60c93b79ee574))
+* **ui:** scene graph ([#909](https://github.com/revideo/revideo/issues/909)) ([bf85c5b](https://github.com/revideo/revideo/commit/bf85c5b4a339719e79da1b87b1aed4492166ce79))
+* **ui:** scene graph icons ([#914](https://github.com/revideo/revideo/issues/914)) ([e92ddef](https://github.com/revideo/revideo/commit/e92ddef34860f5e710ff0f1a310758ec0ca95bcb))
 
 
 
 
 
-## [3.12.4](https://github.com/motion-canvas/motion-canvas/compare/v3.12.3...v3.12.4) (2024-01-05)
+## [3.12.4](https://github.com/revideo/revideo/compare/v3.12.3...v3.12.4) (2024-01-05)
 
 
 ### Bug Fixes
 
-* **2d:** fix height when tweening text ([#905](https://github.com/motion-canvas/motion-canvas/issues/905)) ([1c6a796](https://github.com/motion-canvas/motion-canvas/commit/1c6a7965be137c1ab69741cdd1e9aaa6df4208c4))
+* **2d:** fix height when tweening text ([#905](https://github.com/revideo/revideo/issues/905)) ([1c6a796](https://github.com/revideo/revideo/commit/1c6a7965be137c1ab69741cdd1e9aaa6df4208c4))
 
 
 ### Reverts
 
-* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/motion-canvas/motion-canvas/issues/908)) ([86c5170](https://github.com/motion-canvas/motion-canvas/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
+* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/revideo/revideo/issues/908)) ([86c5170](https://github.com/revideo/revideo/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
 
 
 
 
 
-## [3.12.3](https://github.com/motion-canvas/motion-canvas/compare/v3.12.2...v3.12.3) (2024-01-04)
-
-
-### Bug Fixes
-
-* **2d:** prevent src warnings in Icon and Latex ([#899](https://github.com/motion-canvas/motion-canvas/issues/899)) ([5eebab7](https://github.com/motion-canvas/motion-canvas/commit/5eebab71d8061e233872e049e77b847f9fd077a1))
-* **2d:** stop mutating children ([#903](https://github.com/motion-canvas/motion-canvas/issues/903)) ([f9552a8](https://github.com/motion-canvas/motion-canvas/commit/f9552a8658ccde6c7b2466ad40b12cf28c6ec805))
-* **ui:** remember state of custom tabs ([#900](https://github.com/motion-canvas/motion-canvas/issues/900)) ([eac45b8](https://github.com/motion-canvas/motion-canvas/commit/eac45b88ed09fc7cddc3336e46d8697de5775b1f))
-
-
-
-
-
-## [3.12.1](https://github.com/motion-canvas/motion-canvas/compare/v3.12.0...v3.12.1) (2023-12-31)
-
-**Note:** Version bump only for package @motion-canvas/2d
-
-
-
-
-
-# [3.12.0](https://github.com/motion-canvas/motion-canvas/compare/v3.11.0...v3.12.0) (2023-12-31)
+## [3.12.3](https://github.com/revideo/revideo/compare/v3.12.2...v3.12.3) (2024-01-04)
 
 
 ### Bug Fixes
 
-* **2d:** account for offset in cardinal points ([#883](https://github.com/motion-canvas/motion-canvas/issues/883)) ([24da258](https://github.com/motion-canvas/motion-canvas/commit/24da258f5937087b363eeb9146a9d22747b02e70)), closes [#882](https://github.com/motion-canvas/motion-canvas/issues/882)
-* **2d:** add missing middle property ([#891](https://github.com/motion-canvas/motion-canvas/issues/891)) ([61e2e96](https://github.com/motion-canvas/motion-canvas/commit/61e2e96e3b8f37a68ebdddb432baba04858fd4f3))
-* **2d:** calculate Txt cache bbox from contents ([#836](https://github.com/motion-canvas/motion-canvas/issues/836)) ([33e1a12](https://github.com/motion-canvas/motion-canvas/commit/33e1a1296f21d26e9ed45ae92132825dca17054d)), closes [#465](https://github.com/motion-canvas/motion-canvas/issues/465)
-* **2d:** fix line jitter under certain conditions ([#863](https://github.com/motion-canvas/motion-canvas/issues/863)) ([fb110a2](https://github.com/motion-canvas/motion-canvas/commit/fb110a2f3583fc040bf2c39560934162bd146d9b))
-* **2d:** fix tweening cardinal points ([#829](https://github.com/motion-canvas/motion-canvas/issues/829)) ([cc16737](https://github.com/motion-canvas/motion-canvas/commit/cc16737cd59081582fbb488a880e8d3c11c14918))
-* support legacy imports again ([#868](https://github.com/motion-canvas/motion-canvas/issues/868)) ([77c4e2e](https://github.com/motion-canvas/motion-canvas/commit/77c4e2eeb8b0f73bdef1f72e3d81f34c79748929))
+* **2d:** prevent src warnings in Icon and Latex ([#899](https://github.com/revideo/revideo/issues/899)) ([5eebab7](https://github.com/revideo/revideo/commit/5eebab71d8061e233872e049e77b847f9fd077a1))
+* **2d:** stop mutating children ([#903](https://github.com/revideo/revideo/issues/903)) ([f9552a8](https://github.com/revideo/revideo/commit/f9552a8658ccde6c7b2466ad40b12cf28c6ec805))
+* **ui:** remember state of custom tabs ([#900](https://github.com/revideo/revideo/issues/900)) ([eac45b8](https://github.com/revideo/revideo/commit/eac45b88ed09fc7cddc3336e46d8697de5775b1f))
+
+
+
+
+
+## [3.12.1](https://github.com/revideo/revideo/compare/v3.12.0...v3.12.1) (2023-12-31)
+
+**Note:** Version bump only for package @revideo/2d
+
+
+
+
+
+# [3.12.0](https://github.com/revideo/revideo/compare/v3.11.0...v3.12.0) (2023-12-31)
+
+
+### Bug Fixes
+
+* **2d:** account for offset in cardinal points ([#883](https://github.com/revideo/revideo/issues/883)) ([24da258](https://github.com/revideo/revideo/commit/24da258f5937087b363eeb9146a9d22747b02e70)), closes [#882](https://github.com/revideo/revideo/issues/882)
+* **2d:** add missing middle property ([#891](https://github.com/revideo/revideo/issues/891)) ([61e2e96](https://github.com/revideo/revideo/commit/61e2e96e3b8f37a68ebdddb432baba04858fd4f3))
+* **2d:** calculate Txt cache bbox from contents ([#836](https://github.com/revideo/revideo/issues/836)) ([33e1a12](https://github.com/revideo/revideo/commit/33e1a1296f21d26e9ed45ae92132825dca17054d)), closes [#465](https://github.com/revideo/revideo/issues/465)
+* **2d:** fix line jitter under certain conditions ([#863](https://github.com/revideo/revideo/issues/863)) ([fb110a2](https://github.com/revideo/revideo/commit/fb110a2f3583fc040bf2c39560934162bd146d9b))
+* **2d:** fix tweening cardinal points ([#829](https://github.com/revideo/revideo/issues/829)) ([cc16737](https://github.com/revideo/revideo/commit/cc16737cd59081582fbb488a880e8d3c11c14918))
+* support legacy imports again ([#868](https://github.com/revideo/revideo/issues/868)) ([77c4e2e](https://github.com/revideo/revideo/commit/77c4e2eeb8b0f73bdef1f72e3d81f34c79748929))
 
 
 ### Features
 
-* **2d:** add playbackRate signal to Video component ([#831](https://github.com/motion-canvas/motion-canvas/issues/831)) ([5902b82](https://github.com/motion-canvas/motion-canvas/commit/5902b824b36400876be0ee970e2c6211299faf21)), closes [#711](https://github.com/motion-canvas/motion-canvas/issues/711)
-* **2d:** add querying helpers ([#852](https://github.com/motion-canvas/motion-canvas/issues/852)) ([614de6b](https://github.com/motion-canvas/motion-canvas/commit/614de6bd8542322d1db4b123b875f6fad85cc4eb))
-* **2d:** clamp opacity value between 0 and 1 ([#835](https://github.com/motion-canvas/motion-canvas/issues/835)) ([c54b2f8](https://github.com/motion-canvas/motion-canvas/commit/c54b2f837a8e8b872df3610f4cc6caa94a728500)), closes [#830](https://github.com/motion-canvas/motion-canvas/issues/830)
-* **2d:** nested Txt nodes ([#861](https://github.com/motion-canvas/motion-canvas/issues/861)) ([f2786d0](https://github.com/motion-canvas/motion-canvas/commit/f2786d0cd0d06065ca1e9eb9f6b4c11a74b6c283)), closes [#540](https://github.com/motion-canvas/motion-canvas/issues/540)
-* **2d:** support tweening in applyState ([#859](https://github.com/motion-canvas/motion-canvas/issues/859)) ([b7ed2e2](https://github.com/motion-canvas/motion-canvas/commit/b7ed2e24773227e5b576ff056eb23de9b9ff1676))
-* **2d:** support tweening Line points ([#853](https://github.com/motion-canvas/motion-canvas/issues/853)) ([4bf37d7](https://github.com/motion-canvas/motion-canvas/commit/4bf37d74d2e4bb9d9cc034aff121a32da9a6d146))
-* better children and spawners ([#858](https://github.com/motion-canvas/motion-canvas/issues/858)) ([9b5c23d](https://github.com/motion-canvas/motion-canvas/commit/9b5c23d2076180cf710656c817369a07b253e3ec))
-* improve image error handling ([#847](https://github.com/motion-canvas/motion-canvas/issues/847)) ([db09d53](https://github.com/motion-canvas/motion-canvas/commit/db09d5305a3c0507b035e3cd347eaa65b23d7d2e))
-* introduce editor plugins ([#879](https://github.com/motion-canvas/motion-canvas/issues/879)) ([2b72007](https://github.com/motion-canvas/motion-canvas/commit/2b720074d45fc254dc40b534785b591ae44a3f37))
-* **ui:** add custom presentation overlays ([#884](https://github.com/motion-canvas/motion-canvas/issues/884)) ([4696d3c](https://github.com/motion-canvas/motion-canvas/commit/4696d3c8cb8b68e3475406359f9cf6b875b1c838)), closes [#825](https://github.com/motion-canvas/motion-canvas/issues/825)
+* **2d:** add playbackRate signal to Video component ([#831](https://github.com/revideo/revideo/issues/831)) ([5902b82](https://github.com/revideo/revideo/commit/5902b824b36400876be0ee970e2c6211299faf21)), closes [#711](https://github.com/revideo/revideo/issues/711)
+* **2d:** add querying helpers ([#852](https://github.com/revideo/revideo/issues/852)) ([614de6b](https://github.com/revideo/revideo/commit/614de6bd8542322d1db4b123b875f6fad85cc4eb))
+* **2d:** clamp opacity value between 0 and 1 ([#835](https://github.com/revideo/revideo/issues/835)) ([c54b2f8](https://github.com/revideo/revideo/commit/c54b2f837a8e8b872df3610f4cc6caa94a728500)), closes [#830](https://github.com/revideo/revideo/issues/830)
+* **2d:** nested Txt nodes ([#861](https://github.com/revideo/revideo/issues/861)) ([f2786d0](https://github.com/revideo/revideo/commit/f2786d0cd0d06065ca1e9eb9f6b4c11a74b6c283)), closes [#540](https://github.com/revideo/revideo/issues/540)
+* **2d:** support tweening in applyState ([#859](https://github.com/revideo/revideo/issues/859)) ([b7ed2e2](https://github.com/revideo/revideo/commit/b7ed2e24773227e5b576ff056eb23de9b9ff1676))
+* **2d:** support tweening Line points ([#853](https://github.com/revideo/revideo/issues/853)) ([4bf37d7](https://github.com/revideo/revideo/commit/4bf37d74d2e4bb9d9cc034aff121a32da9a6d146))
+* better children and spawners ([#858](https://github.com/revideo/revideo/issues/858)) ([9b5c23d](https://github.com/revideo/revideo/commit/9b5c23d2076180cf710656c817369a07b253e3ec))
+* improve image error handling ([#847](https://github.com/revideo/revideo/issues/847)) ([db09d53](https://github.com/revideo/revideo/commit/db09d5305a3c0507b035e3cd347eaa65b23d7d2e))
+* introduce editor plugins ([#879](https://github.com/revideo/revideo/issues/879)) ([2b72007](https://github.com/revideo/revideo/commit/2b720074d45fc254dc40b534785b591ae44a3f37))
+* **ui:** add custom presentation overlays ([#884](https://github.com/revideo/revideo/issues/884)) ([4696d3c](https://github.com/revideo/revideo/commit/4696d3c8cb8b68e3475406359f9cf6b875b1c838)), closes [#825](https://github.com/revideo/revideo/issues/825)
 
 
 
@@ -125,430 +125,430 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.11.0](https://github.com/motion-canvas/motion-canvas/compare/v3.10.1...v3.11.0) (2023-10-13)
+# [3.11.0](https://github.com/revideo/revideo/compare/v3.10.1...v3.11.0) (2023-10-13)
 
 ### Bug Fixes
 
 - **2d:** add missing Curve properties to Circle
-  ([#805](https://github.com/motion-canvas/motion-canvas/issues/805))
-  ([38c7900](https://github.com/motion-canvas/motion-canvas/commit/38c79000403d7c3c99dde9e4c825a448d5f55054))
+  ([#805](https://github.com/revideo/revideo/issues/805))
+  ([38c7900](https://github.com/revideo/revideo/commit/38c79000403d7c3c99dde9e4c825a448d5f55054))
 - **2d:** point arrow heads in correct direction
-  ([#792](https://github.com/motion-canvas/motion-canvas/issues/792))
-  ([52ed52e](https://github.com/motion-canvas/motion-canvas/commit/52ed52e963cc69a066a0353680acaca35b9c937a)),
-  closes [#783](https://github.com/motion-canvas/motion-canvas/issues/783)
+  ([#792](https://github.com/revideo/revideo/issues/792))
+  ([52ed52e](https://github.com/revideo/revideo/commit/52ed52e963cc69a066a0353680acaca35b9c937a)),
+  closes [#783](https://github.com/revideo/revideo/issues/783)
 
 ### Features
 
 - **2d:** add line counter for CodeBlock
-  ([#802](https://github.com/motion-canvas/motion-canvas/issues/802))
-  ([c3f9676](https://github.com/motion-canvas/motion-canvas/commit/c3f9676b6984731a09a44ab0b1fcfc226975fa08))
+  ([#802](https://github.com/revideo/revideo/issues/802))
+  ([c3f9676](https://github.com/revideo/revideo/commit/c3f9676b6984731a09a44ab0b1fcfc226975fa08))
 - **2d:** add skew property
-  ([#803](https://github.com/motion-canvas/motion-canvas/issues/803))
-  ([eff7c7b](https://github.com/motion-canvas/motion-canvas/commit/eff7c7be0c013139140b398350242457736d48c7))
+  ([#803](https://github.com/revideo/revideo/issues/803))
+  ([eff7c7b](https://github.com/revideo/revideo/commit/eff7c7be0c013139140b398350242457736d48c7))
 - **2d:** add SVG component
-  ([#763](https://github.com/motion-canvas/motion-canvas/issues/763))
-  ([8eadc11](https://github.com/motion-canvas/motion-canvas/commit/8eadc11937d4201545894f2f5b204d477a3f9094))
+  ([#763](https://github.com/revideo/revideo/issues/763))
+  ([8eadc11](https://github.com/revideo/revideo/commit/8eadc11937d4201545894f2f5b204d477a3f9094))
 - **2d:** warn about missing image source
-  ([#817](https://github.com/motion-canvas/motion-canvas/issues/817))
-  ([6dcdb5f](https://github.com/motion-canvas/motion-canvas/commit/6dcdb5f3b83d4860b1557e4745972e0af68f92f3))
+  ([#817](https://github.com/revideo/revideo/issues/817))
+  ([6dcdb5f](https://github.com/revideo/revideo/commit/6dcdb5f3b83d4860b1557e4745972e0af68f92f3))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.10.1](https://github.com/motion-canvas/motion-canvas/compare/v3.10.0...v3.10.1) (2023-07-25)
+## [3.10.1](https://github.com/revideo/revideo/compare/v3.10.0...v3.10.1) (2023-07-25)
 
 ### Bug Fixes
 
 - **2d:** improve Curve hitbox
-  ([#778](https://github.com/motion-canvas/motion-canvas/issues/778))
-  ([8af723c](https://github.com/motion-canvas/motion-canvas/commit/8af723c0322de39d2defe0363bba03f4f9542f08))
+  ([#778](https://github.com/revideo/revideo/issues/778))
+  ([8af723c](https://github.com/revideo/revideo/commit/8af723c0322de39d2defe0363bba03f4f9542f08))
 - **2d:** remove circular dependencies
-  ([#780](https://github.com/motion-canvas/motion-canvas/issues/780))
-  ([cdf3af5](https://github.com/motion-canvas/motion-canvas/commit/cdf3af500a58151ee3549c6e728751aab3e6f75c))
+  ([#780](https://github.com/revideo/revideo/issues/780))
+  ([cdf3af5](https://github.com/revideo/revideo/commit/cdf3af500a58151ee3549c6e728751aab3e6f75c))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.10.0](https://github.com/motion-canvas/motion-canvas/compare/v3.9.0...v3.10.0) (2023-07-23)
+# [3.10.0](https://github.com/revideo/revideo/compare/v3.9.0...v3.10.0) (2023-07-23)
 
 ### Features
 
 - **2d:** add Path component
-  ([#700](https://github.com/motion-canvas/motion-canvas/issues/700))
-  ([2128b6b](https://github.com/motion-canvas/motion-canvas/commit/2128b6bf871cabe19e1abc749f18945c78c01f84))
+  ([#700](https://github.com/revideo/revideo/issues/700))
+  ([2128b6b](https://github.com/revideo/revideo/commit/2128b6bf871cabe19e1abc749f18945c78c01f84))
 - **2d:** add start and end signals to Grid node
-  ([#761](https://github.com/motion-canvas/motion-canvas/issues/761))
-  ([e37ea80](https://github.com/motion-canvas/motion-canvas/commit/e37ea806b94e93c6324d8e1b502468925b731e8e))
+  ([#761](https://github.com/revideo/revideo/issues/761))
+  ([e37ea80](https://github.com/revideo/revideo/commit/e37ea806b94e93c6324d8e1b502468925b731e8e))
 - **2d:** always clip images and videos
-  ([#773](https://github.com/motion-canvas/motion-canvas/issues/773))
-  ([3938c59](https://github.com/motion-canvas/motion-canvas/commit/3938c59394bfc42e5562504687d783ff306d7d32))
+  ([#773](https://github.com/revideo/revideo/issues/773))
+  ([3938c59](https://github.com/revideo/revideo/commit/3938c59394bfc42e5562504687d783ff306d7d32))
 - **2d:** immediate restore
-  ([#736](https://github.com/motion-canvas/motion-canvas/issues/736))
-  ([634d51d](https://github.com/motion-canvas/motion-canvas/commit/634d51d2afe8a536673c364874f8f3d1a450b846))
+  ([#736](https://github.com/revideo/revideo/issues/736))
+  ([634d51d](https://github.com/revideo/revideo/commit/634d51d2afe8a536673c364874f8f3d1a450b846))
 - **2d:** make Circle extend Curve
-  ([#771](https://github.com/motion-canvas/motion-canvas/issues/771))
-  ([4c8cf19](https://github.com/motion-canvas/motion-canvas/commit/4c8cf1954093958eac507921dc18f67dd64b2052))
+  ([#771](https://github.com/revideo/revideo/issues/771))
+  ([4c8cf19](https://github.com/revideo/revideo/commit/4c8cf1954093958eac507921dc18f67dd64b2052))
 - **2d:** make Rect extend Curve
-  ([#759](https://github.com/motion-canvas/motion-canvas/issues/759))
-  ([9810212](https://github.com/motion-canvas/motion-canvas/commit/9810212648824b9a2fa2ecd6b597e3319d20b325))
+  ([#759](https://github.com/revideo/revideo/issues/759))
+  ([9810212](https://github.com/revideo/revideo/commit/9810212648824b9a2fa2ecd6b597e3319d20b325))
 - add coordinates to preview
-  ([#737](https://github.com/motion-canvas/motion-canvas/issues/737))
-  ([330c1f9](https://github.com/motion-canvas/motion-canvas/commit/330c1f962fb920269301e7ee8a2c49cbfc723d85))
+  ([#737](https://github.com/revideo/revideo/issues/737))
+  ([330c1f9](https://github.com/revideo/revideo/commit/330c1f962fb920269301e7ee8a2c49cbfc723d85))
 - add middle cardinal point
-  ([#758](https://github.com/motion-canvas/motion-canvas/issues/758))
-  ([b036eaf](https://github.com/motion-canvas/motion-canvas/commit/b036eafc00381831c08267a78cf9d74973f4025a))
+  ([#758](https://github.com/revideo/revideo/issues/758))
+  ([b036eaf](https://github.com/revideo/revideo/commit/b036eafc00381831c08267a78cf9d74973f4025a))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.9.0](https://github.com/motion-canvas/motion-canvas/compare/v3.8.0...v3.9.0) (2023-05-29)
+# [3.9.0](https://github.com/revideo/revideo/compare/v3.8.0...v3.9.0) (2023-05-29)
 
 ### Bug Fixes
 
 - **2d:** fix package.json entry
-  ([#720](https://github.com/motion-canvas/motion-canvas/issues/720))
-  ([12e9bf6](https://github.com/motion-canvas/motion-canvas/commit/12e9bf6f40ab7afc02e2f55260544f3864920ded))
+  ([#720](https://github.com/revideo/revideo/issues/720))
+  ([12e9bf6](https://github.com/revideo/revideo/commit/12e9bf6f40ab7afc02e2f55260544f3864920ded))
 
 ### Features
 
 - export everything from entry points
-  ([#710](https://github.com/motion-canvas/motion-canvas/issues/710))
-  ([3c885d9](https://github.com/motion-canvas/motion-canvas/commit/3c885d9083b52fbbaccf1e2560ae50817949bc52))
+  ([#710](https://github.com/revideo/revideo/issues/710))
+  ([3c885d9](https://github.com/revideo/revideo/commit/3c885d9083b52fbbaccf1e2560ae50817949bc52))
 - use ES modules in fiddles
-  ([#712](https://github.com/motion-canvas/motion-canvas/issues/712))
-  ([dbe2ad5](https://github.com/motion-canvas/motion-canvas/commit/dbe2ad5644219c5a98d38c6557abfb66d793c821))
+  ([#712](https://github.com/revideo/revideo/issues/712))
+  ([dbe2ad5](https://github.com/revideo/revideo/commit/dbe2ad5644219c5a98d38c6557abfb66d793c821))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.8.0](https://github.com/motion-canvas/motion-canvas/compare/v3.7.0...v3.8.0) (2023-05-13)
+# [3.8.0](https://github.com/revideo/revideo/compare/v3.7.0...v3.8.0) (2023-05-13)
 
 ### Bug Fixes
 
 - **2d:** correctly support external image urls
-  ([#678](https://github.com/motion-canvas/motion-canvas/issues/678))
-  ([a08556b](https://github.com/motion-canvas/motion-canvas/commit/a08556b6e2822a55db593f610ea4dd6cb8494adb)),
-  closes [#677](https://github.com/motion-canvas/motion-canvas/issues/677)
+  ([#678](https://github.com/revideo/revideo/issues/678))
+  ([a08556b](https://github.com/revideo/revideo/commit/a08556b6e2822a55db593f610ea4dd6cb8494adb)),
+  closes [#677](https://github.com/revideo/revideo/issues/677)
 - **2d:** ignore children with disabled layout
-  ([#669](https://github.com/motion-canvas/motion-canvas/issues/669))
-  ([b98c462](https://github.com/motion-canvas/motion-canvas/commit/b98c4625c3634495e86ca23d19355035e457db06)),
-  closes [#580](https://github.com/motion-canvas/motion-canvas/issues/580)
+  ([#669](https://github.com/revideo/revideo/issues/669))
+  ([b98c462](https://github.com/revideo/revideo/commit/b98c4625c3634495e86ca23d19355035e457db06)),
+  closes [#580](https://github.com/revideo/revideo/issues/580)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.7.0](https://github.com/motion-canvas/motion-canvas/compare/v3.6.2...v3.7.0) (2023-05-10)
+# [3.7.0](https://github.com/revideo/revideo/compare/v3.6.2...v3.7.0) (2023-05-10)
 
-**Note:** Version bump only for package @motion-canvas/2d
+**Note:** Version bump only for package @revideo/2d
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.6.2](https://github.com/motion-canvas/motion-canvas/compare/v3.6.1...v3.6.2) (2023-05-09)
+## [3.6.2](https://github.com/revideo/revideo/compare/v3.6.1...v3.6.2) (2023-05-09)
 
 ### Bug Fixes
 
 - **2d:** fix types
-  ([#659](https://github.com/motion-canvas/motion-canvas/issues/659))
-  ([a32af29](https://github.com/motion-canvas/motion-canvas/commit/a32af29ef3bd2e5dbf08697ebfee53230fceadc1))
+  ([#659](https://github.com/revideo/revideo/issues/659))
+  ([a32af29](https://github.com/revideo/revideo/commit/a32af29ef3bd2e5dbf08697ebfee53230fceadc1))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.6.1](https://github.com/motion-canvas/motion-canvas/compare/v3.6.0...v3.6.1) (2023-05-08)
+## [3.6.1](https://github.com/revideo/revideo/compare/v3.6.0...v3.6.1) (2023-05-08)
 
 ### Bug Fixes
 
 - prevent consumePromises from halting
-  ([#657](https://github.com/motion-canvas/motion-canvas/issues/657))
-  ([363a189](https://github.com/motion-canvas/motion-canvas/commit/363a189b0c7f5926c9d5ae00b58b48e8ed4d9b48))
+  ([#657](https://github.com/revideo/revideo/issues/657))
+  ([363a189](https://github.com/revideo/revideo/commit/363a189b0c7f5926c9d5ae00b58b48e8ed4d9b48))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.6.0](https://github.com/motion-canvas/motion-canvas/compare/v3.5.1...v3.6.0) (2023-05-08)
+# [3.6.0](https://github.com/revideo/revideo/compare/v3.5.1...v3.6.0) (2023-05-08)
 
 ### Bug Fixes
 
 - **2d:** correctly append Txt nodes to view
-  ([#644](https://github.com/motion-canvas/motion-canvas/issues/644))
-  ([24bb51a](https://github.com/motion-canvas/motion-canvas/commit/24bb51aa04778c33ce327926b27332efaa554e5f))
+  ([#644](https://github.com/revideo/revideo/issues/644))
+  ([24bb51a](https://github.com/revideo/revideo/commit/24bb51aa04778c33ce327926b27332efaa554e5f))
 - **2d:** fix cyclic dependency in cardinal points
-  ([#645](https://github.com/motion-canvas/motion-canvas/issues/645))
-  ([def23f9](https://github.com/motion-canvas/motion-canvas/commit/def23f925ee7200c8740ecd51c7f6117d67b6ef8))
+  ([#645](https://github.com/revideo/revideo/issues/645))
+  ([def23f9](https://github.com/revideo/revideo/commit/def23f925ee7200c8740ecd51c7f6117d67b6ef8))
 
 ### Features
 
 - **2d:** add arcLength helper methods to Curve
-  ([#627](https://github.com/motion-canvas/motion-canvas/issues/627))
-  ([3c7546e](https://github.com/motion-canvas/motion-canvas/commit/3c7546e7a509deb6fff8f669c3df0a69b492bd2e))
+  ([#627](https://github.com/revideo/revideo/issues/627))
+  ([3c7546e](https://github.com/revideo/revideo/commit/3c7546e7a509deb6fff8f669c3df0a69b492bd2e))
 - **2d:** add cardinal points
-  ([#636](https://github.com/motion-canvas/motion-canvas/issues/636))
-  ([2136a25](https://github.com/motion-canvas/motion-canvas/commit/2136a2558a9ed968ee505e4e5cce33d989dfdc13)),
-  closes [#391](https://github.com/motion-canvas/motion-canvas/issues/391)
+  ([#636](https://github.com/revideo/revideo/issues/636))
+  ([2136a25](https://github.com/revideo/revideo/commit/2136a2558a9ed968ee505e4e5cce33d989dfdc13)),
+  closes [#391](https://github.com/revideo/revideo/issues/391)
 - **2d:** add completion property for curves
-  ([#635](https://github.com/motion-canvas/motion-canvas/issues/635))
-  ([6577d6d](https://github.com/motion-canvas/motion-canvas/commit/6577d6ddfaf779ba02f3862d2a357166138b99ca))
+  ([#635](https://github.com/revideo/revideo/issues/635))
+  ([6577d6d](https://github.com/revideo/revideo/commit/6577d6ddfaf779ba02f3862d2a357166138b99ca))
 - **2d:** add Ray node
-  ([#628](https://github.com/motion-canvas/motion-canvas/issues/628))
-  ([649447c](https://github.com/motion-canvas/motion-canvas/commit/649447cd5f2089afc64cc7bd4b0276e69d1e9a30))
+  ([#628](https://github.com/revideo/revideo/issues/628))
+  ([649447c](https://github.com/revideo/revideo/commit/649447cd5f2089afc64cc7bd4b0276e69d1e9a30))
 - **2d:** support HMR for images
-  ([#641](https://github.com/motion-canvas/motion-canvas/issues/641))
-  ([cf17520](https://github.com/motion-canvas/motion-canvas/commit/cf17520aa8ddf19dcfc419c63cf7255892d45b71))
+  ([#641](https://github.com/revideo/revideo/issues/641))
+  ([cf17520](https://github.com/revideo/revideo/commit/cf17520aa8ddf19dcfc419c63cf7255892d45b71))
 - add DEG2RAD and RAD2DEG constants
-  ([#630](https://github.com/motion-canvas/motion-canvas/issues/630))
-  ([01801e8](https://github.com/motion-canvas/motion-canvas/commit/01801e8766058e75a6a020400650fb00f8f430cc))
+  ([#630](https://github.com/revideo/revideo/issues/630))
+  ([01801e8](https://github.com/revideo/revideo/commit/01801e8766058e75a6a020400650fb00f8f430cc))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.5.1](https://github.com/motion-canvas/motion-canvas/compare/v3.5.0...v3.5.1) (2023-04-08)
+## [3.5.1](https://github.com/revideo/revideo/compare/v3.5.0...v3.5.1) (2023-04-08)
 
 ### Bug Fixes
 
 - **2d:** fix curve arrow alignment when animating start signal
-  ([#615](https://github.com/motion-canvas/motion-canvas/issues/615))
-  ([2fefc40](https://github.com/motion-canvas/motion-canvas/commit/2fefc4026050159ba204c7629832ad83e8bfa51b))
+  ([#615](https://github.com/revideo/revideo/issues/615))
+  ([2fefc40](https://github.com/revideo/revideo/commit/2fefc4026050159ba204c7629832ad83e8bfa51b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.5.0](https://github.com/motion-canvas/motion-canvas/compare/v3.4.0...v3.5.0) (2023-04-06)
+# [3.5.0](https://github.com/revideo/revideo/compare/v3.4.0...v3.5.0) (2023-04-06)
 
 ### Bug Fixes
 
 - **2d:** calculate arrow orientations for curves correctly
-  ([#597](https://github.com/motion-canvas/motion-canvas/issues/597))
-  ([1626811](https://github.com/motion-canvas/motion-canvas/commit/1626811ec4cd1bd2a3d43e393ced40a7da462c3a))
+  ([#597](https://github.com/revideo/revideo/issues/597))
+  ([1626811](https://github.com/revideo/revideo/commit/1626811ec4cd1bd2a3d43e393ced40a7da462c3a))
 - **2d:** smoothly play videos when presenting
-  ([#600](https://github.com/motion-canvas/motion-canvas/issues/600))
-  ([294fe6a](https://github.com/motion-canvas/motion-canvas/commit/294fe6ac056ab074c77214fcf9035f53fac9258c)),
-  closes [#578](https://github.com/motion-canvas/motion-canvas/issues/578)
+  ([#600](https://github.com/revideo/revideo/issues/600))
+  ([294fe6a](https://github.com/revideo/revideo/commit/294fe6ac056ab074c77214fcf9035f53fac9258c)),
+  closes [#578](https://github.com/revideo/revideo/issues/578)
 - **2d:** wait for reused async resources
-  ([#599](https://github.com/motion-canvas/motion-canvas/issues/599))
-  ([280e065](https://github.com/motion-canvas/motion-canvas/commit/280e065fe69e9a744b7b12eb4609e7d87f76bb63)),
-  closes [#593](https://github.com/motion-canvas/motion-canvas/issues/593)
+  ([#599](https://github.com/revideo/revideo/issues/599))
+  ([280e065](https://github.com/revideo/revideo/commit/280e065fe69e9a744b7b12eb4609e7d87f76bb63)),
+  closes [#593](https://github.com/revideo/revideo/issues/593)
 
 ### Features
 
 - **2d:** add Bézier nodes
-  ([#603](https://github.com/motion-canvas/motion-canvas/issues/603))
-  ([9841cfd](https://github.com/motion-canvas/motion-canvas/commit/9841cfdc3947ca4e6d6e42ed21eae88e855f855d))
+  ([#603](https://github.com/revideo/revideo/issues/603))
+  ([9841cfd](https://github.com/revideo/revideo/commit/9841cfdc3947ca4e6d6e42ed21eae88e855f855d))
 - **2d:** improve Video node
-  ([#601](https://github.com/motion-canvas/motion-canvas/issues/601))
-  ([3801d83](https://github.com/motion-canvas/motion-canvas/commit/3801d83415bbdeeee5d6d53d0c18e5d9e78fba56))
+  ([#601](https://github.com/revideo/revideo/issues/601))
+  ([3801d83](https://github.com/revideo/revideo/commit/3801d83415bbdeeee5d6d53d0c18e5d9e78fba56))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.4.0](https://github.com/motion-canvas/motion-canvas/compare/v3.3.4...v3.4.0) (2023-03-28)
+# [3.4.0](https://github.com/revideo/revideo/compare/v3.3.4...v3.4.0) (2023-03-28)
 
 ### Bug Fixes
 
 - **2d:** clone size correctly
-  ([#562](https://github.com/motion-canvas/motion-canvas/issues/562))
-  ([cdd3df1](https://github.com/motion-canvas/motion-canvas/commit/cdd3df1bff25b04b905e289264831d8d328caaab)),
-  closes [#559](https://github.com/motion-canvas/motion-canvas/issues/559)
+  ([#562](https://github.com/revideo/revideo/issues/562))
+  ([cdd3df1](https://github.com/revideo/revideo/commit/cdd3df1bff25b04b905e289264831d8d328caaab)),
+  closes [#559](https://github.com/revideo/revideo/issues/559)
 - **2d:** fix CodeBlock types
-  ([#563](https://github.com/motion-canvas/motion-canvas/issues/563))
-  ([25160fa](https://github.com/motion-canvas/motion-canvas/commit/25160fa4d92af88429110356e42f6e3b4f88a90f)),
-  closes [#560](https://github.com/motion-canvas/motion-canvas/issues/560)
+  ([#563](https://github.com/revideo/revideo/issues/563))
+  ([25160fa](https://github.com/revideo/revideo/commit/25160fa4d92af88429110356e42f6e3b4f88a90f)),
+  closes [#560](https://github.com/revideo/revideo/issues/560)
 
 ### Features
 
 - **2d:** add spline node
-  ([#514](https://github.com/motion-canvas/motion-canvas/issues/514))
-  ([3ce2111](https://github.com/motion-canvas/motion-canvas/commit/3ce2111309e698450dc4c6e2ad47024995863e73))
+  ([#514](https://github.com/revideo/revideo/issues/514))
+  ([3ce2111](https://github.com/revideo/revideo/commit/3ce2111309e698450dc4c6e2ad47024995863e73))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.3.4](https://github.com/motion-canvas/motion-canvas/compare/v3.3.3...v3.3.4) (2023-03-19)
+## [3.3.4](https://github.com/revideo/revideo/compare/v3.3.3...v3.3.4) (2023-03-19)
 
 ### Bug Fixes
 
 - **2d:** fix circle segment
-  ([#557](https://github.com/motion-canvas/motion-canvas/issues/557))
-  ([adebff4](https://github.com/motion-canvas/motion-canvas/commit/adebff492b76a512d79151b00adf1b383d25c5b5))
+  ([#557](https://github.com/revideo/revideo/issues/557))
+  ([adebff4](https://github.com/revideo/revideo/commit/adebff492b76a512d79151b00adf1b383d25c5b5))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.3.3](https://github.com/motion-canvas/motion-canvas/compare/v3.3.2...v3.3.3) (2023-03-18)
+## [3.3.3](https://github.com/revideo/revideo/compare/v3.3.2...v3.3.3) (2023-03-18)
 
 ### Bug Fixes
 
 - **2d:** fix nested cache canvases
-  ([#554](https://github.com/motion-canvas/motion-canvas/issues/554))
-  ([e601441](https://github.com/motion-canvas/motion-canvas/commit/e6014413b215af6fb1a7953f8db83893d4025f0b)),
-  closes [#551](https://github.com/motion-canvas/motion-canvas/issues/551)
+  ([#554](https://github.com/revideo/revideo/issues/554))
+  ([e601441](https://github.com/revideo/revideo/commit/e6014413b215af6fb1a7953f8db83893d4025f0b)),
+  closes [#551](https://github.com/revideo/revideo/issues/551)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.3.2](https://github.com/motion-canvas/motion-canvas/compare/v3.3.1...v3.3.2) (2023-03-18)
+## [3.3.2](https://github.com/revideo/revideo/compare/v3.3.1...v3.3.2) (2023-03-18)
 
 ### Bug Fixes
 
 - **2d:** add missing Fragment export
-  ([#553](https://github.com/motion-canvas/motion-canvas/issues/553))
-  ([229afb4](https://github.com/motion-canvas/motion-canvas/commit/229afb4fe7d95f09b480ab4a813f8dff549f381f))
+  ([#553](https://github.com/revideo/revideo/issues/553))
+  ([229afb4](https://github.com/revideo/revideo/commit/229afb4fe7d95f09b480ab4a813f8dff549f381f))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.3.1](https://github.com/motion-canvas/motion-canvas/compare/v3.3.0...v3.3.1) (2023-03-18)
+## [3.3.1](https://github.com/revideo/revideo/compare/v3.3.0...v3.3.1) (2023-03-18)
 
 ### Bug Fixes
 
 - **2d:** add missing jsx dev runtime
-  ([#547](https://github.com/motion-canvas/motion-canvas/issues/547))
-  ([d61cb7d](https://github.com/motion-canvas/motion-canvas/commit/d61cb7dd24ab66ae17d5bd6f5ccb34c4fd1e7569)),
-  closes [#545](https://github.com/motion-canvas/motion-canvas/issues/545)
+  ([#547](https://github.com/revideo/revideo/issues/547))
+  ([d61cb7d](https://github.com/revideo/revideo/commit/d61cb7dd24ab66ae17d5bd6f5ccb34c4fd1e7569)),
+  closes [#545](https://github.com/revideo/revideo/issues/545)
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.3.0](https://github.com/motion-canvas/motion-canvas/compare/v3.2.1...v3.3.0) (2023-03-18)
+# [3.3.0](https://github.com/revideo/revideo/compare/v3.2.1...v3.3.0) (2023-03-18)
 
 ### Bug Fixes
 
 - **2d:** better error handling
-  ([#524](https://github.com/motion-canvas/motion-canvas/issues/524))
-  ([b7475ba](https://github.com/motion-canvas/motion-canvas/commit/b7475ba5ff35d37ee198577d1205d6ecd6fd2092))
+  ([#524](https://github.com/revideo/revideo/issues/524))
+  ([b7475ba](https://github.com/revideo/revideo/commit/b7475ba5ff35d37ee198577d1205d6ecd6fd2092))
 - **2d:** fix Txt decorators
-  ([#526](https://github.com/motion-canvas/motion-canvas/issues/526))
-  ([25b30ed](https://github.com/motion-canvas/motion-canvas/commit/25b30ed3861f46d72147335480912ce5f564be79))
+  ([#526](https://github.com/revideo/revideo/issues/526))
+  ([25b30ed](https://github.com/revideo/revideo/commit/25b30ed3861f46d72147335480912ce5f564be79))
 - **2d:** textWrap not working in Firefox
-  ([#541](https://github.com/motion-canvas/motion-canvas/issues/541))
-  ([f10e057](https://github.com/motion-canvas/motion-canvas/commit/f10e057fd13ed9dcc70ebc0ca63963708ec159c8)),
-  closes [#517](https://github.com/motion-canvas/motion-canvas/issues/517)
+  ([#541](https://github.com/revideo/revideo/issues/541))
+  ([f10e057](https://github.com/revideo/revideo/commit/f10e057fd13ed9dcc70ebc0ca63963708ec159c8)),
+  closes [#517](https://github.com/revideo/revideo/issues/517)
 - restrict size of cache canvas
-  ([#544](https://github.com/motion-canvas/motion-canvas/issues/544))
-  ([49ec554](https://github.com/motion-canvas/motion-canvas/commit/49ec55490718e503d9a39437ae13c189dc4fe9ea))
+  ([#544](https://github.com/revideo/revideo/issues/544))
+  ([49ec554](https://github.com/revideo/revideo/commit/49ec55490718e503d9a39437ae13c189dc4fe9ea))
 
 ### Features
 
 - **core:** tree shaking
-  ([#523](https://github.com/motion-canvas/motion-canvas/issues/523))
-  ([65fec78](https://github.com/motion-canvas/motion-canvas/commit/65fec7825fda33812b13f57bfeb1d82193a5d190))
+  ([#523](https://github.com/revideo/revideo/issues/523))
+  ([65fec78](https://github.com/revideo/revideo/commit/65fec7825fda33812b13f57bfeb1d82193a5d190))
 - **docs:** fiddle editor
-  ([#542](https://github.com/motion-canvas/motion-canvas/issues/542))
-  ([3c68fef](https://github.com/motion-canvas/motion-canvas/commit/3c68fefdf7bf375ee9345aba7dbf9e5ff35e3c3d))
+  ([#542](https://github.com/revideo/revideo/issues/542))
+  ([3c68fef](https://github.com/revideo/revideo/commit/3c68fefdf7bf375ee9345aba7dbf9e5ff35e3c3d))
 
-# [3.2.0](https://github.com/motion-canvas/motion-canvas/compare/v3.1.0...v3.2.0) (2023-03-10)
+# [3.2.0](https://github.com/revideo/revideo/compare/v3.1.0...v3.2.0) (2023-03-10)
 
 ### Bug Fixes
 
 - **2d:** fix line arc length
-  ([#503](https://github.com/motion-canvas/motion-canvas/issues/503))
-  ([4f1cd59](https://github.com/motion-canvas/motion-canvas/commit/4f1cd59e6bcba0b16b36be88b28a60ae46d4d9ab)),
-  closes [#497](https://github.com/motion-canvas/motion-canvas/issues/497)
+  ([#503](https://github.com/revideo/revideo/issues/503))
+  ([4f1cd59](https://github.com/revideo/revideo/commit/4f1cd59e6bcba0b16b36be88b28a60ae46d4d9ab)),
+  closes [#497](https://github.com/revideo/revideo/issues/497)
 
 ### Features
 
 - **2d:** add Polygon component
-  ([#463](https://github.com/motion-canvas/motion-canvas/issues/463))
-  ([15adb3e](https://github.com/motion-canvas/motion-canvas/commit/15adb3e312a4998b44c0b9c5fe5b5236f51c71c9)),
-  closes [#455](https://github.com/motion-canvas/motion-canvas/issues/455)
+  ([#463](https://github.com/revideo/revideo/issues/463))
+  ([15adb3e](https://github.com/revideo/revideo/commit/15adb3e312a4998b44c0b9c5fe5b5236f51c71c9)),
+  closes [#455](https://github.com/revideo/revideo/issues/455)
 - world space cache
-  ([#498](https://github.com/motion-canvas/motion-canvas/issues/498))
-  ([633e9e1](https://github.com/motion-canvas/motion-canvas/commit/633e9e140dfbbe397df6ddc1f96ed30782ddce94)),
-  closes [#342](https://github.com/motion-canvas/motion-canvas/issues/342)
+  ([#498](https://github.com/revideo/revideo/issues/498))
+  ([633e9e1](https://github.com/revideo/revideo/commit/633e9e140dfbbe397df6ddc1f96ed30782ddce94)),
+  closes [#342](https://github.com/revideo/revideo/issues/342)
 
-# [3.1.0](https://github.com/motion-canvas/motion-canvas/compare/v3.0.2...v3.1.0) (2023-03-07)
+# [3.1.0](https://github.com/revideo/revideo/compare/v3.0.2...v3.1.0) (2023-03-07)
 
 ### Bug Fixes
 
 - **2d:** fix cache bbox for lines
-  ([#467](https://github.com/motion-canvas/motion-canvas/issues/467))
-  ([9fd1444](https://github.com/motion-canvas/motion-canvas/commit/9fd144417bb0b6301da6c522a988775f5ff142ac)),
-  closes [#466](https://github.com/motion-canvas/motion-canvas/issues/466)
+  ([#467](https://github.com/revideo/revideo/issues/467))
+  ([9fd1444](https://github.com/revideo/revideo/commit/9fd144417bb0b6301da6c522a988775f5ff142ac)),
+  closes [#466](https://github.com/revideo/revideo/issues/466)
 - **2d:** fix letterSpacing
-  ([#448](https://github.com/motion-canvas/motion-canvas/issues/448))
-  ([bb5ffc4](https://github.com/motion-canvas/motion-canvas/commit/bb5ffc48efa82b9db818e8e52aa35e9c2ad8ce89)),
-  closes [#447](https://github.com/motion-canvas/motion-canvas/issues/447)
+  ([#448](https://github.com/revideo/revideo/issues/448))
+  ([bb5ffc4](https://github.com/revideo/revideo/commit/bb5ffc48efa82b9db818e8e52aa35e9c2ad8ce89)),
+  closes [#447](https://github.com/revideo/revideo/issues/447)
 - support multiple async players
-  ([#450](https://github.com/motion-canvas/motion-canvas/issues/450))
-  ([d7ec469](https://github.com/motion-canvas/motion-canvas/commit/d7ec469e747eefd909f4dd59dd713f5d86308222)),
-  closes [#434](https://github.com/motion-canvas/motion-canvas/issues/434)
+  ([#450](https://github.com/revideo/revideo/issues/450))
+  ([d7ec469](https://github.com/revideo/revideo/commit/d7ec469e747eefd909f4dd59dd713f5d86308222)),
+  closes [#434](https://github.com/revideo/revideo/issues/434)
 
 ### Features
 
 - **2d:** add textAlign property
-  ([#451](https://github.com/motion-canvas/motion-canvas/issues/451))
-  ([3d15825](https://github.com/motion-canvas/motion-canvas/commit/3d15825f3cc5a35ba081a31510741b824f3bc6ab)),
-  closes [#303](https://github.com/motion-canvas/motion-canvas/issues/303)
+  ([#451](https://github.com/revideo/revideo/issues/451))
+  ([3d15825](https://github.com/revideo/revideo/commit/3d15825f3cc5a35ba081a31510741b824f3bc6ab)),
+  closes [#303](https://github.com/revideo/revideo/issues/303)
 
-## [3.0.2](https://github.com/motion-canvas/motion-canvas/compare/v3.0.1...v3.0.2) (2023-02-27)
+## [3.0.2](https://github.com/revideo/revideo/compare/v3.0.1...v3.0.2) (2023-02-27)
 
 ### Bug Fixes
 
 - **2d:** correct layout defaults
-  ([#442](https://github.com/motion-canvas/motion-canvas/issues/442))
-  ([c116c35](https://github.com/motion-canvas/motion-canvas/commit/c116c355179ba3b2487634fb82b9a5bc2ea266bf))
+  ([#442](https://github.com/revideo/revideo/issues/442))
+  ([c116c35](https://github.com/revideo/revideo/commit/c116c355179ba3b2487634fb82b9a5bc2ea266bf))
 
-# [3.0.0](https://github.com/motion-canvas/motion-canvas/compare/v2.6.0...v3.0.0) (2023-02-27)
+# [3.0.0](https://github.com/revideo/revideo/compare/v2.6.0...v3.0.0) (2023-02-27)
 
 ### Bug Fixes
 
 - **2d:** fix initial value of endOffset
-  ([#433](https://github.com/motion-canvas/motion-canvas/issues/433))
-  ([9fe82b3](https://github.com/motion-canvas/motion-canvas/commit/9fe82b3d21ba0150a2378e541a4652ca707c2d15))
+  ([#433](https://github.com/revideo/revideo/issues/433))
+  ([9fe82b3](https://github.com/revideo/revideo/commit/9fe82b3d21ba0150a2378e541a4652ca707c2d15))
 - **2d:** textDirection property for RTL/LTR text
-  ([#404](https://github.com/motion-canvas/motion-canvas/issues/404))
-  ([f240b1b](https://github.com/motion-canvas/motion-canvas/commit/f240b1bd140a884f6901b7cfcb97ce3e9ce4b48d))
+  ([#404](https://github.com/revideo/revideo/issues/404))
+  ([f240b1b](https://github.com/revideo/revideo/commit/f240b1bd140a884f6901b7cfcb97ce3e9ce4b48d))
 
 ### Code Refactoring
 
 - introduce improved names
-  ([#425](https://github.com/motion-canvas/motion-canvas/issues/425))
-  ([4a2188d](https://github.com/motion-canvas/motion-canvas/commit/4a2188d339587fa658b2134befc3fe63c835c5d7))
+  ([#425](https://github.com/revideo/revideo/issues/425))
+  ([4a2188d](https://github.com/revideo/revideo/commit/4a2188d339587fa658b2134befc3fe63c835c5d7))
 
 ### Features
 
 - new playback architecture
-  ([#402](https://github.com/motion-canvas/motion-canvas/issues/402))
-  ([bbe3e2a](https://github.com/motion-canvas/motion-canvas/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)),
-  closes [#166](https://github.com/motion-canvas/motion-canvas/issues/166)
+  ([#402](https://github.com/revideo/revideo/issues/402))
+  ([bbe3e2a](https://github.com/revideo/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)),
+  closes [#166](https://github.com/revideo/revideo/issues/166)
 
 ### Reverts
 
 - feat: upgrade code-fns for new theme options and lazy loading
-  ([#435](https://github.com/motion-canvas/motion-canvas/issues/435))
-  ([3f5e439](https://github.com/motion-canvas/motion-canvas/commit/3f5e43968f7add7c6322c9c8358d3b6fc178c2fe))
+  ([#435](https://github.com/revideo/revideo/issues/435))
+  ([3f5e439](https://github.com/revideo/revideo/commit/3f5e43968f7add7c6322c9c8358d3b6fc178c2fe))
 
 ### BREAKING CHANGES
 
@@ -575,329 +575,329 @@ The `CodeBlock` property has changed:
 Settings such as `background` and `audioOffset` are now stored in the project
 meta file.
 
-# [2.6.0](https://github.com/motion-canvas/motion-canvas/compare/v2.5.0...v2.6.0) (2023-02-24)
+# [2.6.0](https://github.com/revideo/revideo/compare/v2.5.0...v2.6.0) (2023-02-24)
 
 ### Bug Fixes
 
 - **2d:** handle division by zero in lines
-  ([#407](https://github.com/motion-canvas/motion-canvas/issues/407))
-  ([a17871a](https://github.com/motion-canvas/motion-canvas/commit/a17871a2ce63dd5bb32bc719037327c4e9dde217))
+  ([#407](https://github.com/revideo/revideo/issues/407))
+  ([a17871a](https://github.com/revideo/revideo/commit/a17871a2ce63dd5bb32bc719037327c4e9dde217))
 
 ### Features
 
 - **2d:** add Icon Component
-  ([#306](https://github.com/motion-canvas/motion-canvas/issues/306))
-  ([3479631](https://github.com/motion-canvas/motion-canvas/commit/3479631ef34e39f90a8d8de441317672be1840d9)),
-  closes [#305](https://github.com/motion-canvas/motion-canvas/issues/305)
+  ([#306](https://github.com/revideo/revideo/issues/306))
+  ([3479631](https://github.com/revideo/revideo/commit/3479631ef34e39f90a8d8de441317672be1840d9)),
+  closes [#305](https://github.com/revideo/revideo/issues/305)
 - **2d:** add save and restore methods to nodes
-  ([#406](https://github.com/motion-canvas/motion-canvas/issues/406))
-  ([870e194](https://github.com/motion-canvas/motion-canvas/commit/870e1947d97382bc6d82857c077140bbef7cf7e8))
+  ([#406](https://github.com/revideo/revideo/issues/406))
+  ([870e194](https://github.com/revideo/revideo/commit/870e1947d97382bc6d82857c077140bbef7cf7e8))
 - **2d:** add z-index property to nodes
-  ([#398](https://github.com/motion-canvas/motion-canvas/issues/398))
-  ([4280af3](https://github.com/motion-canvas/motion-canvas/commit/4280af3b4b7bd5970fe5e743949a0fcca2c314f3))
+  ([#398](https://github.com/revideo/revideo/issues/398))
+  ([4280af3](https://github.com/revideo/revideo/commit/4280af3b4b7bd5970fe5e743949a0fcca2c314f3))
 - add missing flexbox properties
-  ([#405](https://github.com/motion-canvas/motion-canvas/issues/405))
-  ([4e78b4b](https://github.com/motion-canvas/motion-canvas/commit/4e78b4b2fe4df42ce0a8da6fd41ad38b0104e7f5))
+  ([#405](https://github.com/revideo/revideo/issues/405))
+  ([4e78b4b](https://github.com/revideo/revideo/commit/4e78b4b2fe4df42ce0a8da6fd41ad38b0104e7f5))
 - upgrade code-fns for new theme options and lazy loading
-  ([#401](https://github.com/motion-canvas/motion-canvas/issues/401))
-  ([8965ab1](https://github.com/motion-canvas/motion-canvas/commit/8965ab1bef8b6ae919c8001d0527f5793293b285)),
-  closes [#396](https://github.com/motion-canvas/motion-canvas/issues/396)
-  [#322](https://github.com/motion-canvas/motion-canvas/issues/322)
+  ([#401](https://github.com/revideo/revideo/issues/401))
+  ([8965ab1](https://github.com/revideo/revideo/commit/8965ab1bef8b6ae919c8001d0527f5793293b285)),
+  closes [#396](https://github.com/revideo/revideo/issues/396)
+  [#322](https://github.com/revideo/revideo/issues/322)
 - **vite-plugin:** add CORS Proxy
-  ([#357](https://github.com/motion-canvas/motion-canvas/issues/357))
-  ([a3c5822](https://github.com/motion-canvas/motion-canvas/commit/a3c58228b7d3dab08fc27414d19870d35773b280)),
-  closes [#338](https://github.com/motion-canvas/motion-canvas/issues/338)
+  ([#357](https://github.com/revideo/revideo/issues/357))
+  ([a3c5822](https://github.com/revideo/revideo/commit/a3c58228b7d3dab08fc27414d19870d35773b280)),
+  closes [#338](https://github.com/revideo/revideo/issues/338)
 
-# [2.5.0](https://github.com/motion-canvas/motion-canvas/compare/v2.4.0...v2.5.0) (2023-02-20)
+# [2.5.0](https://github.com/revideo/revideo/compare/v2.4.0...v2.5.0) (2023-02-20)
 
 ### Bug Fixes
 
 - **2d:** fix signal initialization
-  ([#382](https://github.com/motion-canvas/motion-canvas/issues/382))
-  ([ea36e79](https://github.com/motion-canvas/motion-canvas/commit/ea36e791a20bfd1b491ffa9917be686c51bc3899))
+  ([#382](https://github.com/revideo/revideo/issues/382))
+  ([ea36e79](https://github.com/revideo/revideo/commit/ea36e791a20bfd1b491ffa9917be686c51bc3899))
 - **2d:** handle floating point errors in acos
-  ([#381](https://github.com/motion-canvas/motion-canvas/issues/381))
-  ([5bca8fd](https://github.com/motion-canvas/motion-canvas/commit/5bca8fd0bbdcf28f2793c124b7d6b0afd560c4b8))
+  ([#381](https://github.com/revideo/revideo/issues/381))
+  ([5bca8fd](https://github.com/revideo/revideo/commit/5bca8fd0bbdcf28f2793c124b7d6b0afd560c4b8))
 - plug memory leaks
-  ([#385](https://github.com/motion-canvas/motion-canvas/issues/385))
-  ([de0af00](https://github.com/motion-canvas/motion-canvas/commit/de0af00a7d2e019e2a933791c62b7901755be7b0))
+  ([#385](https://github.com/revideo/revideo/issues/385))
+  ([de0af00](https://github.com/revideo/revideo/commit/de0af00a7d2e019e2a933791c62b7901755be7b0))
 - support color to null tweening
-  ([#387](https://github.com/motion-canvas/motion-canvas/issues/387))
-  ([02e9f22](https://github.com/motion-canvas/motion-canvas/commit/02e9f22027a1c3a85ffcc259aeca913318fb6f54))
+  ([#387](https://github.com/revideo/revideo/issues/387))
+  ([02e9f22](https://github.com/revideo/revideo/commit/02e9f22027a1c3a85ffcc259aeca913318fb6f54))
 
 ### Features
 
 - **2d:** add closed property for circle
-  ([#378](https://github.com/motion-canvas/motion-canvas/issues/378))
-  ([62a9605](https://github.com/motion-canvas/motion-canvas/commit/62a9605d4c54e7bf2d2d44d47bf769f5b27378a5))
+  ([#378](https://github.com/revideo/revideo/issues/378))
+  ([62a9605](https://github.com/revideo/revideo/commit/62a9605d4c54e7bf2d2d44d47bf769f5b27378a5))
 - **2d:** make `View2D` extend `Rect`
-  ([#379](https://github.com/motion-canvas/motion-canvas/issues/379))
-  ([93db5fc](https://github.com/motion-canvas/motion-canvas/commit/93db5fc41617c0902e85fda90fbfc930c2b4634b))
+  ([#379](https://github.com/revideo/revideo/issues/379))
+  ([93db5fc](https://github.com/revideo/revideo/commit/93db5fc41617c0902e85fda90fbfc930c2b4634b))
 
-# [2.4.0](https://github.com/motion-canvas/motion-canvas/compare/v2.3.0...v2.4.0) (2023-02-18)
+# [2.4.0](https://github.com/revideo/revideo/compare/v2.3.0...v2.4.0) (2023-02-18)
 
 ### Bug Fixes
 
 - **2d:** fix Gradient and Pattern signals
-  ([#376](https://github.com/motion-canvas/motion-canvas/issues/376))
-  ([6e0dc8a](https://github.com/motion-canvas/motion-canvas/commit/6e0dc8af8d19f93fd6a42addca2b3a2958b4dd33))
+  ([#376](https://github.com/revideo/revideo/issues/376))
+  ([6e0dc8a](https://github.com/revideo/revideo/commit/6e0dc8af8d19f93fd6a42addca2b3a2958b4dd33))
 - **2d:** fix layout calculation for nodes not explicitly added to view
-  ([#331](https://github.com/motion-canvas/motion-canvas/issues/331))
-  ([528e2d5](https://github.com/motion-canvas/motion-canvas/commit/528e2d5a0abec99819e022d2848b256ece9f869a))
+  ([#331](https://github.com/revideo/revideo/issues/331))
+  ([528e2d5](https://github.com/revideo/revideo/commit/528e2d5a0abec99819e022d2848b256ece9f869a))
 - **2d:** format whitespaces according to HTML
-  ([#372](https://github.com/motion-canvas/motion-canvas/issues/372))
-  ([83fb565](https://github.com/motion-canvas/motion-canvas/commit/83fb565742d98f060c0400c8cbaf9961b69f34d0)),
-  closes [#370](https://github.com/motion-canvas/motion-canvas/issues/370)
+  ([#372](https://github.com/revideo/revideo/issues/372))
+  ([83fb565](https://github.com/revideo/revideo/commit/83fb565742d98f060c0400c8cbaf9961b69f34d0)),
+  closes [#370](https://github.com/revideo/revideo/issues/370)
 - typo on codeblock remove comments
-  ([#368](https://github.com/motion-canvas/motion-canvas/issues/368))
-  ([2025adc](https://github.com/motion-canvas/motion-canvas/commit/2025adc6e7aa11d81b6f5f6989e8eae18cf86cb7))
+  ([#368](https://github.com/revideo/revideo/issues/368))
+  ([2025adc](https://github.com/revideo/revideo/commit/2025adc6e7aa11d81b6f5f6989e8eae18cf86cb7))
 
 ### Features
 
 - **2d:** add default computed values for signals
-  ([#259](https://github.com/motion-canvas/motion-canvas/issues/259))
-  ([18f61a6](https://github.com/motion-canvas/motion-canvas/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
+  ([#259](https://github.com/revideo/revideo/issues/259))
+  ([18f61a6](https://github.com/revideo/revideo/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
 - **2d:** add moveBelow, moveAbove and moveTo methods to Node
-  ([#365](https://github.com/motion-canvas/motion-canvas/issues/365))
-  ([16752a3](https://github.com/motion-canvas/motion-canvas/commit/16752a3b8ae7461b33d6208a9675729f374e8324))
+  ([#365](https://github.com/revideo/revideo/issues/365))
+  ([16752a3](https://github.com/revideo/revideo/commit/16752a3b8ae7461b33d6208a9675729f374e8324))
 - **2d:** unify layout properties
-  ([#355](https://github.com/motion-canvas/motion-canvas/issues/355))
-  ([3cae97e](https://github.com/motion-canvas/motion-canvas/commit/3cae97ea704d0533020fa87326dacadcc037d517)),
-  closes [#352](https://github.com/motion-canvas/motion-canvas/issues/352)
+  ([#355](https://github.com/revideo/revideo/issues/355))
+  ([3cae97e](https://github.com/revideo/revideo/commit/3cae97ea704d0533020fa87326dacadcc037d517)),
+  closes [#352](https://github.com/revideo/revideo/issues/352)
 
-# [2.3.0](https://github.com/motion-canvas/motion-canvas/compare/v2.2.0...v2.3.0) (2023-02-11)
+# [2.3.0](https://github.com/revideo/revideo/compare/v2.2.0...v2.3.0) (2023-02-11)
 
 ### Bug Fixes
 
 - **2d:** make Text respect textWrap=pre
-  ([#287](https://github.com/motion-canvas/motion-canvas/issues/287))
-  ([cb07f4b](https://github.com/motion-canvas/motion-canvas/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
+  ([#287](https://github.com/revideo/revideo/issues/287))
+  ([cb07f4b](https://github.com/revideo/revideo/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
 
 ### Features
 
 - **2d:** add antialiased signal to Shape
-  ([#282](https://github.com/motion-canvas/motion-canvas/issues/282))
-  ([7c6905d](https://github.com/motion-canvas/motion-canvas/commit/7c6905d72c6c2f49e10f0a80704c0afe3504d01b))
+  ([#282](https://github.com/revideo/revideo/issues/282))
+  ([7c6905d](https://github.com/revideo/revideo/commit/7c6905d72c6c2f49e10f0a80704c0afe3504d01b))
 - **2d:** add LaTeX component
-  ([#228](https://github.com/motion-canvas/motion-canvas/issues/228))
-  ([4c26d2a](https://github.com/motion-canvas/motion-canvas/commit/4c26d2aaf0c697486639aa917cd5c585d3d0ea74))
+  ([#228](https://github.com/revideo/revideo/issues/228))
+  ([4c26d2a](https://github.com/revideo/revideo/commit/4c26d2aaf0c697486639aa917cd5c585d3d0ea74))
 - **2d:** add smooth corners and sharpness to rect
-  ([#310](https://github.com/motion-canvas/motion-canvas/issues/310))
-  ([f7fbefd](https://github.com/motion-canvas/motion-canvas/commit/f7fbefd27f7f6972cfb5a45a68e5d0aed9593ae4))
+  ([#310](https://github.com/revideo/revideo/issues/310))
+  ([f7fbefd](https://github.com/revideo/revideo/commit/f7fbefd27f7f6972cfb5a45a68e5d0aed9593ae4))
 - added a theme property to the CodeBlock component
-  ([#279](https://github.com/motion-canvas/motion-canvas/issues/279))
-  ([fe34fa8](https://github.com/motion-canvas/motion-canvas/commit/fe34fa8ebfe66cd356fb1c3d85adedef11e03b45))
+  ([#279](https://github.com/revideo/revideo/issues/279))
+  ([fe34fa8](https://github.com/revideo/revideo/commit/fe34fa8ebfe66cd356fb1c3d85adedef11e03b45))
 
-# [2.2.0](https://github.com/motion-canvas/motion-canvas/compare/v2.1.0...v2.2.0) (2023-02-09)
+# [2.2.0](https://github.com/revideo/revideo/compare/v2.1.0...v2.2.0) (2023-02-09)
 
 ### Features
 
 - **2d:** add video component property getter
-  ([#240](https://github.com/motion-canvas/motion-canvas/issues/240))
-  ([59de5ab](https://github.com/motion-canvas/motion-canvas/commit/59de5ab2c089589773a2f9ad7588eda7d72693a7))
+  ([#240](https://github.com/revideo/revideo/issues/240))
+  ([59de5ab](https://github.com/revideo/revideo/commit/59de5ab2c089589773a2f9ad7588eda7d72693a7))
 
-# [2.1.0](https://github.com/motion-canvas/motion-canvas/compare/v2.0.0...v2.1.0) (2023-02-07)
+# [2.1.0](https://github.com/revideo/revideo/compare/v2.0.0...v2.1.0) (2023-02-07)
 
 ### Bug Fixes
 
 - **2d:** fix font ligatures in CodeBlock
-  ([#231](https://github.com/motion-canvas/motion-canvas/issues/231))
-  ([11ee3fe](https://github.com/motion-canvas/motion-canvas/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
+  ([#231](https://github.com/revideo/revideo/issues/231))
+  ([11ee3fe](https://github.com/revideo/revideo/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
 - **2d:** fix Line cache
-  ([#232](https://github.com/motion-canvas/motion-canvas/issues/232))
-  ([a953b64](https://github.com/motion-canvas/motion-canvas/commit/a953b64540c020657845efc84d4179142a7a0974)),
-  closes [#205](https://github.com/motion-canvas/motion-canvas/issues/205)
+  ([#232](https://github.com/revideo/revideo/issues/232))
+  ([a953b64](https://github.com/revideo/revideo/commit/a953b64540c020657845efc84d4179142a7a0974)),
+  closes [#205](https://github.com/revideo/revideo/issues/205)
 - **2d:** handle lines with no points
-  ([#233](https://github.com/motion-canvas/motion-canvas/issues/233))
-  ([8108474](https://github.com/motion-canvas/motion-canvas/commit/81084743dfad7b6419760796fda825047909d4d4)),
-  closes [#212](https://github.com/motion-canvas/motion-canvas/issues/212)
+  ([#233](https://github.com/revideo/revideo/issues/233))
+  ([8108474](https://github.com/revideo/revideo/commit/81084743dfad7b6419760796fda825047909d4d4)),
+  closes [#212](https://github.com/revideo/revideo/issues/212)
 - **2d:** improve Rect radius
-  ([#221](https://github.com/motion-canvas/motion-canvas/issues/221))
-  ([3437e42](https://github.com/motion-canvas/motion-canvas/commit/3437e42713a3f4a8d44d246ee01e2eb23b61e06a)),
-  closes [#207](https://github.com/motion-canvas/motion-canvas/issues/207)
+  ([#221](https://github.com/revideo/revideo/issues/221))
+  ([3437e42](https://github.com/revideo/revideo/commit/3437e42713a3f4a8d44d246ee01e2eb23b61e06a)),
+  closes [#207](https://github.com/revideo/revideo/issues/207)
 - **2d:** stop code highlighting from jumping
-  ([#230](https://github.com/motion-canvas/motion-canvas/issues/230))
-  ([67ef1c4](https://github.com/motion-canvas/motion-canvas/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
+  ([#230](https://github.com/revideo/revideo/issues/230))
+  ([67ef1c4](https://github.com/revideo/revideo/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
 - fix compound property setter
-  ([#218](https://github.com/motion-canvas/motion-canvas/issues/218))
-  ([6cd1b95](https://github.com/motion-canvas/motion-canvas/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)),
-  closes [#208](https://github.com/motion-canvas/motion-canvas/issues/208)
-  [#210](https://github.com/motion-canvas/motion-canvas/issues/210)
+  ([#218](https://github.com/revideo/revideo/issues/218))
+  ([6cd1b95](https://github.com/revideo/revideo/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)),
+  closes [#208](https://github.com/revideo/revideo/issues/208)
+  [#210](https://github.com/revideo/revideo/issues/210)
 
 # 2.0.0 (2023-02-04)
 
 ### Bug Fixes
 
 - **2d:** add missing shape export
-  ([#111](https://github.com/motion-canvas/motion-canvas/issues/111))
-  ([02a1fa7](https://github.com/motion-canvas/motion-canvas/commit/02a1fa7ea62155e498809f2e57ff29a18c82ac12))
+  ([#111](https://github.com/revideo/revideo/issues/111))
+  ([02a1fa7](https://github.com/revideo/revideo/commit/02a1fa7ea62155e498809f2e57ff29a18c82ac12))
 - **2d:** fix import order
-  ([#94](https://github.com/motion-canvas/motion-canvas/issues/94))
-  ([bcc0bcf](https://github.com/motion-canvas/motion-canvas/commit/bcc0bcffae47855bd8f7ab06454aaebe93c4aa24)),
-  closes [#76](https://github.com/motion-canvas/motion-canvas/issues/76)
+  ([#94](https://github.com/revideo/revideo/issues/94))
+  ([bcc0bcf](https://github.com/revideo/revideo/commit/bcc0bcffae47855bd8f7ab06454aaebe93c4aa24)),
+  closes [#76](https://github.com/revideo/revideo/issues/76)
 - **2d:** fix Line overview crashing
-  ([#142](https://github.com/motion-canvas/motion-canvas/issues/142))
-  ([6bd5fd9](https://github.com/motion-canvas/motion-canvas/commit/6bd5fd941e583e44f5d920ecd20215efb1eed58a))
+  ([#142](https://github.com/revideo/revideo/issues/142))
+  ([6bd5fd9](https://github.com/revideo/revideo/commit/6bd5fd941e583e44f5d920ecd20215efb1eed58a))
 - **2d:** some signal setters not returning owners
-  ([#143](https://github.com/motion-canvas/motion-canvas/issues/143))
-  ([09ab7f9](https://github.com/motion-canvas/motion-canvas/commit/09ab7f96afcaae608399a653c0b4878ba9b467d4))
+  ([#143](https://github.com/revideo/revideo/issues/143))
+  ([09ab7f9](https://github.com/revideo/revideo/commit/09ab7f96afcaae608399a653c0b4878ba9b467d4))
 - **2d:** switch iframes to ShadowDOM
-  ([#90](https://github.com/motion-canvas/motion-canvas/issues/90))
-  ([86176be](https://github.com/motion-canvas/motion-canvas/commit/86176be055c08aba59272afcda00ed586f6c7ad6))
+  ([#90](https://github.com/revideo/revideo/issues/90))
+  ([86176be](https://github.com/revideo/revideo/commit/86176be055c08aba59272afcda00ed586f6c7ad6))
 - fix scaffolding
-  ([#93](https://github.com/motion-canvas/motion-canvas/issues/93))
-  ([95c55ed](https://github.com/motion-canvas/motion-canvas/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
+  ([#93](https://github.com/revideo/revideo/issues/93))
+  ([95c55ed](https://github.com/revideo/revideo/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
 - previous scene being rendered twice
-  ([#97](https://github.com/motion-canvas/motion-canvas/issues/97))
-  ([90205bd](https://github.com/motion-canvas/motion-canvas/commit/90205bdc1a086abe5f73b04cb4616c6af5ec4377))
+  ([#97](https://github.com/revideo/revideo/issues/97))
+  ([90205bd](https://github.com/revideo/revideo/commit/90205bdc1a086abe5f73b04cb4616c6af5ec4377))
 - use correct scene sizes
-  ([#146](https://github.com/motion-canvas/motion-canvas/issues/146))
-  ([f279638](https://github.com/motion-canvas/motion-canvas/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+  ([#146](https://github.com/revideo/revideo/issues/146))
+  ([f279638](https://github.com/revideo/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
 
 ### Code Refactoring
 
 - remove legacy package
-  ([6a84120](https://github.com/motion-canvas/motion-canvas/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+  ([6a84120](https://github.com/revideo/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
 
 ### Features
 
 - **2d:** add methods for rearranging children
-  ([#81](https://github.com/motion-canvas/motion-canvas/issues/81))
-  ([63f6c1a](https://github.com/motion-canvas/motion-canvas/commit/63f6c1aa51ac4ecd093151c8cd30910f2e72bcac))
+  ([#81](https://github.com/revideo/revideo/issues/81))
+  ([63f6c1a](https://github.com/revideo/revideo/commit/63f6c1aa51ac4ecd093151c8cd30910f2e72bcac))
 - **2d:** add option for preformatted text
-  ([#147](https://github.com/motion-canvas/motion-canvas/issues/147))
-  ([989be53](https://github.com/motion-canvas/motion-canvas/commit/989be532d86642e1125bb7fa62a801b09c1b8f26))
+  ([#147](https://github.com/revideo/revideo/issues/147))
+  ([989be53](https://github.com/revideo/revideo/commit/989be532d86642e1125bb7fa62a801b09c1b8f26))
 - **2d:** code selection and modification
-  ([#163](https://github.com/motion-canvas/motion-canvas/issues/163))
-  ([e8e884a](https://github.com/motion-canvas/motion-canvas/commit/e8e884a1a5574425dbf15272718911c12cfa2327))
+  ([#163](https://github.com/revideo/revideo/issues/163))
+  ([e8e884a](https://github.com/revideo/revideo/commit/e8e884a1a5574425dbf15272718911c12cfa2327))
 - **2d:** construct lines using signals
-  ([#133](https://github.com/motion-canvas/motion-canvas/issues/133))
-  ([2968a24](https://github.com/motion-canvas/motion-canvas/commit/2968a2426564469fb4f4343fe71a6d30e95361f2))
+  ([#133](https://github.com/revideo/revideo/issues/133))
+  ([2968a24](https://github.com/revideo/revideo/commit/2968a2426564469fb4f4343fe71a6d30e95361f2))
 - **2d:** improve property declarations
-  ([27e7d26](https://github.com/motion-canvas/motion-canvas/commit/27e7d267ee91bf1e8ca79686b6ec31347f9f4d41))
+  ([27e7d26](https://github.com/revideo/revideo/commit/27e7d267ee91bf1e8ca79686b6ec31347f9f4d41))
 - **2d:** improve Rect corner radius
-  ([#120](https://github.com/motion-canvas/motion-canvas/issues/120))
-  ([b471fe0](https://github.com/motion-canvas/motion-canvas/commit/b471fe0e37c0a426d3af8299c9c3c22539e7df05))
+  ([#120](https://github.com/revideo/revideo/issues/120))
+  ([b471fe0](https://github.com/revideo/revideo/commit/b471fe0e37c0a426d3af8299c9c3c22539e7df05))
 - **2d:** simplify layout prop
-  ([c24cb12](https://github.com/motion-canvas/motion-canvas/commit/c24cb12a22b7c85fdfb051917fa9ee1e0911717c))
+  ([c24cb12](https://github.com/revideo/revideo/commit/c24cb12a22b7c85fdfb051917fa9ee1e0911717c))
 - **2d:** unify desired sizes
-  ([#118](https://github.com/motion-canvas/motion-canvas/issues/118))
-  ([401a799](https://github.com/motion-canvas/motion-canvas/commit/401a79946b034a96b9abff2f3fb5efd6cc9080f3))
+  ([#118](https://github.com/revideo/revideo/issues/118))
+  ([401a799](https://github.com/revideo/revideo/commit/401a79946b034a96b9abff2f3fb5efd6cc9080f3))
 - add advanced caching
-  ([#69](https://github.com/motion-canvas/motion-canvas/issues/69))
-  ([2a644c9](https://github.com/motion-canvas/motion-canvas/commit/2a644c9315acfcc5280a5eacc9904df140a61e4f))
+  ([#69](https://github.com/revideo/revideo/issues/69))
+  ([2a644c9](https://github.com/revideo/revideo/commit/2a644c9315acfcc5280a5eacc9904df140a61e4f))
 - add base class for shapes
-  ([#67](https://github.com/motion-canvas/motion-canvas/issues/67))
-  ([d38c172](https://github.com/motion-canvas/motion-canvas/commit/d38c1724e129c553739cbfc27c4e5cd8f737f067))
+  ([#67](https://github.com/revideo/revideo/issues/67))
+  ([d38c172](https://github.com/revideo/revideo/commit/d38c1724e129c553739cbfc27c4e5cd8f737f067))
 - add basic logger
-  ([#88](https://github.com/motion-canvas/motion-canvas/issues/88))
-  ([3d82e86](https://github.com/motion-canvas/motion-canvas/commit/3d82e863af3dc88b3709adbcd0b84e790d05c3b8)),
-  closes [#17](https://github.com/motion-canvas/motion-canvas/issues/17)
+  ([#88](https://github.com/revideo/revideo/issues/88))
+  ([3d82e86](https://github.com/revideo/revideo/commit/3d82e863af3dc88b3709adbcd0b84e790d05c3b8)),
+  closes [#17](https://github.com/revideo/revideo/issues/17)
 - add basic transform to Node class
-  ([#83](https://github.com/motion-canvas/motion-canvas/issues/83))
-  ([9e114c8](https://github.com/motion-canvas/motion-canvas/commit/9e114c8830a99c78e6a4fd9265b0e7552758af14))
-- add cloning ([#80](https://github.com/motion-canvas/motion-canvas/issues/80))
-  ([47d7a0f](https://github.com/motion-canvas/motion-canvas/commit/47d7a0fa5da9a03d8ed91557db651f6f960e28b1))
+  ([#83](https://github.com/revideo/revideo/issues/83))
+  ([9e114c8](https://github.com/revideo/revideo/commit/9e114c8830a99c78e6a4fd9265b0e7552758af14))
+- add cloning ([#80](https://github.com/revideo/revideo/issues/80))
+  ([47d7a0f](https://github.com/revideo/revideo/commit/47d7a0fa5da9a03d8ed91557db651f6f960e28b1))
 - add CodeBlock component based on code-fns to 2D
-  ([#78](https://github.com/motion-canvas/motion-canvas/issues/78))
-  ([ad346f1](https://github.com/motion-canvas/motion-canvas/commit/ad346f118d63b1e321ec315e1c70b925670124a1))
+  ([#78](https://github.com/revideo/revideo/issues/78))
+  ([ad346f1](https://github.com/revideo/revideo/commit/ad346f118d63b1e321ec315e1c70b925670124a1))
 - add default renderer
-  ([#63](https://github.com/motion-canvas/motion-canvas/issues/63))
-  ([9255490](https://github.com/motion-canvas/motion-canvas/commit/92554900965fe088538f5e703dbab2fd84f904d7)),
-  closes [#56](https://github.com/motion-canvas/motion-canvas/issues/56)
-  [#58](https://github.com/motion-canvas/motion-canvas/issues/58)
+  ([#63](https://github.com/revideo/revideo/issues/63))
+  ([9255490](https://github.com/revideo/revideo/commit/92554900965fe088538f5e703dbab2fd84f904d7)),
+  closes [#56](https://github.com/revideo/revideo/issues/56)
+  [#58](https://github.com/revideo/revideo/issues/58)
 - add Grid node
-  ([e1f83da](https://github.com/motion-canvas/motion-canvas/commit/e1f83da1f43d20d392df4acb11e3df9cc457585d))
+  ([e1f83da](https://github.com/revideo/revideo/commit/e1f83da1f43d20d392df4acb11e3df9cc457585d))
 - add inspection
-  ([#82](https://github.com/motion-canvas/motion-canvas/issues/82))
-  ([4d7f2ae](https://github.com/motion-canvas/motion-canvas/commit/4d7f2aee6daeda1a2146b632dfdc28b455295776))
+  ([#82](https://github.com/revideo/revideo/issues/82))
+  ([4d7f2ae](https://github.com/revideo/revideo/commit/4d7f2aee6daeda1a2146b632dfdc28b455295776))
 - add markdown logs
-  ([#138](https://github.com/motion-canvas/motion-canvas/issues/138))
-  ([e42447a](https://github.com/motion-canvas/motion-canvas/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+  ([#138](https://github.com/revideo/revideo/issues/138))
+  ([e42447a](https://github.com/revideo/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
 - add missing layout props
-  ([#72](https://github.com/motion-canvas/motion-canvas/issues/72))
-  ([f808a56](https://github.com/motion-canvas/motion-canvas/commit/f808a562b192fd03dba4b0d353284db344d6a80b))
+  ([#72](https://github.com/revideo/revideo/issues/72))
+  ([f808a56](https://github.com/revideo/revideo/commit/f808a562b192fd03dba4b0d353284db344d6a80b))
 - add node spawners
-  ([#149](https://github.com/motion-canvas/motion-canvas/issues/149))
-  ([da18a4e](https://github.com/motion-canvas/motion-canvas/commit/da18a4e24104022a84ecd6cec1666b520186058f))
-- add polyline ([#84](https://github.com/motion-canvas/motion-canvas/issues/84))
-  ([4ceaf84](https://github.com/motion-canvas/motion-canvas/commit/4ceaf842915ac43d81f292c58a4dc73a8d1bb8e9))
+  ([#149](https://github.com/revideo/revideo/issues/149))
+  ([da18a4e](https://github.com/revideo/revideo/commit/da18a4e24104022a84ecd6cec1666b520186058f))
+- add polyline ([#84](https://github.com/revideo/revideo/issues/84))
+  ([4ceaf84](https://github.com/revideo/revideo/commit/4ceaf842915ac43d81f292c58a4dc73a8d1bb8e9))
 - add random number generator
-  ([#116](https://github.com/motion-canvas/motion-canvas/issues/116))
-  ([d505312](https://github.com/motion-canvas/motion-canvas/commit/d5053123eef308c7a2a61d92b6e76c637f4ed0b8)),
-  closes [#14](https://github.com/motion-canvas/motion-canvas/issues/14)
+  ([#116](https://github.com/revideo/revideo/issues/116))
+  ([d505312](https://github.com/revideo/revideo/commit/d5053123eef308c7a2a61d92b6e76c637f4ed0b8)),
+  closes [#14](https://github.com/revideo/revideo/issues/14)
 - add reparent helper
-  ([80b95a9](https://github.com/motion-canvas/motion-canvas/commit/80b95a9ce89d4a2eeea7e467257486e961602d69))
+  ([80b95a9](https://github.com/revideo/revideo/commit/80b95a9ce89d4a2eeea7e467257486e961602d69))
 - add Text and Image components
-  ([#70](https://github.com/motion-canvas/motion-canvas/issues/70))
-  ([85c7dcd](https://github.com/motion-canvas/motion-canvas/commit/85c7dcdb4f8ca2f0bfb03950c85a8d6f6652fcdf))
+  ([#70](https://github.com/revideo/revideo/issues/70))
+  ([85c7dcd](https://github.com/revideo/revideo/commit/85c7dcdb4f8ca2f0bfb03950c85a8d6f6652fcdf))
 - add video node
-  ([#86](https://github.com/motion-canvas/motion-canvas/issues/86))
-  ([f4aa654](https://github.com/motion-canvas/motion-canvas/commit/f4aa65437a18cc85b00199f80cd5e04654c00c4b))
+  ([#86](https://github.com/revideo/revideo/issues/86))
+  ([f4aa654](https://github.com/revideo/revideo/commit/f4aa65437a18cc85b00199f80cd5e04654c00c4b))
 - better dependencies between packages
-  ([#152](https://github.com/motion-canvas/motion-canvas/issues/152))
-  ([a0a37b3](https://github.com/motion-canvas/motion-canvas/commit/a0a37b3645fcb91206e65fd0a95b2f486b308c75))
+  ([#152](https://github.com/revideo/revideo/issues/152))
+  ([a0a37b3](https://github.com/revideo/revideo/commit/a0a37b3645fcb91206e65fd0a95b2f486b308c75))
 - better dependencies between packages
-  ([#153](https://github.com/motion-canvas/motion-canvas/issues/153))
-  ([59a73d4](https://github.com/motion-canvas/motion-canvas/commit/59a73d49a7b92c416e1f836a0f53bb676e9f924b))
+  ([#153](https://github.com/revideo/revideo/issues/153))
+  ([59a73d4](https://github.com/revideo/revideo/commit/59a73d49a7b92c416e1f836a0f53bb676e9f924b))
 - **core:** switch to vitest
-  ([#99](https://github.com/motion-canvas/motion-canvas/issues/99))
-  ([762eeb0](https://github.com/motion-canvas/motion-canvas/commit/762eeb0a99c2f378d20dbd147f815ba6736099d9)),
-  closes [#48](https://github.com/motion-canvas/motion-canvas/issues/48)
+  ([#99](https://github.com/revideo/revideo/issues/99))
+  ([762eeb0](https://github.com/revideo/revideo/commit/762eeb0a99c2f378d20dbd147f815ba6736099d9)),
+  closes [#48](https://github.com/revideo/revideo/issues/48)
 - filter reordering
-  ([#119](https://github.com/motion-canvas/motion-canvas/issues/119))
-  ([2398d0f](https://github.com/motion-canvas/motion-canvas/commit/2398d0f9d57f36b47c9c66a988ca5607e9a3a30e))
+  ([#119](https://github.com/revideo/revideo/issues/119))
+  ([2398d0f](https://github.com/revideo/revideo/commit/2398d0f9d57f36b47c9c66a988ca5607e9a3a30e))
 - implement absolute scale setter
-  ([842079a](https://github.com/motion-canvas/motion-canvas/commit/842079a6547af4032719c85837df3db7c1c6d30a))
+  ([842079a](https://github.com/revideo/revideo/commit/842079a6547af4032719c85837df3db7c1c6d30a))
 - improve async signals
-  ([#156](https://github.com/motion-canvas/motion-canvas/issues/156))
-  ([db27b9d](https://github.com/motion-canvas/motion-canvas/commit/db27b9d5fb69a88f42afd98c86c4a1cdceb88ea1))
+  ([#156](https://github.com/revideo/revideo/issues/156))
+  ([db27b9d](https://github.com/revideo/revideo/commit/db27b9d5fb69a88f42afd98c86c4a1cdceb88ea1))
 - introduce basic caching
-  ([#68](https://github.com/motion-canvas/motion-canvas/issues/68))
-  ([6420d36](https://github.com/motion-canvas/motion-canvas/commit/6420d362d0e4ae058f55b6ff6bb2a3a32dec559b))
+  ([#68](https://github.com/revideo/revideo/issues/68))
+  ([6420d36](https://github.com/revideo/revideo/commit/6420d362d0e4ae058f55b6ff6bb2a3a32dec559b))
 - merge properties and signals
-  ([#124](https://github.com/motion-canvas/motion-canvas/issues/124))
-  ([da3ba83](https://github.com/motion-canvas/motion-canvas/commit/da3ba83d82ee74f5a5c3631b07597f08cdf9e8e4))
+  ([#124](https://github.com/revideo/revideo/issues/124))
+  ([da3ba83](https://github.com/revideo/revideo/commit/da3ba83d82ee74f5a5c3631b07597f08cdf9e8e4))
 - minor improvements
-  ([403c7c2](https://github.com/motion-canvas/motion-canvas/commit/403c7c27ad969880a14c498ec6cefb9e7e7b7544))
+  ([403c7c2](https://github.com/revideo/revideo/commit/403c7c27ad969880a14c498ec6cefb9e7e7b7544))
 - minor improvements
-  ([#77](https://github.com/motion-canvas/motion-canvas/issues/77))
-  ([7c6e584](https://github.com/motion-canvas/motion-canvas/commit/7c6e584aca353c9af55f0acb61b32b5f99727dba))
+  ([#77](https://github.com/revideo/revideo/issues/77))
+  ([7c6e584](https://github.com/revideo/revideo/commit/7c6e584aca353c9af55f0acb61b32b5f99727dba))
 - navigate to scene and node source
-  ([#144](https://github.com/motion-canvas/motion-canvas/issues/144))
-  ([86d495d](https://github.com/motion-canvas/motion-canvas/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
-- new animator ([#91](https://github.com/motion-canvas/motion-canvas/issues/91))
-  ([d85f2f8](https://github.com/motion-canvas/motion-canvas/commit/d85f2f8a54c0f8bbfbc451884385f30e5b3ec206))
+  ([#144](https://github.com/revideo/revideo/issues/144))
+  ([86d495d](https://github.com/revideo/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+- new animator ([#91](https://github.com/revideo/revideo/issues/91))
+  ([d85f2f8](https://github.com/revideo/revideo/commit/d85f2f8a54c0f8bbfbc451884385f30e5b3ec206))
 - signal error handling
-  ([#89](https://github.com/motion-canvas/motion-canvas/issues/89))
-  ([472ac65](https://github.com/motion-canvas/motion-canvas/commit/472ac65938b804a6b698c8522ec0c3b6bdbcf1b1))
+  ([#89](https://github.com/revideo/revideo/issues/89))
+  ([472ac65](https://github.com/revideo/revideo/commit/472ac65938b804a6b698c8522ec0c3b6bdbcf1b1))
 - simplify size access
-  ([#65](https://github.com/motion-canvas/motion-canvas/issues/65))
-  ([3315e64](https://github.com/motion-canvas/motion-canvas/commit/3315e64641e9778bc48ea3fb707e3c0eeb581dfe))
+  ([#65](https://github.com/revideo/revideo/issues/65))
+  ([3315e64](https://github.com/revideo/revideo/commit/3315e64641e9778bc48ea3fb707e3c0eeb581dfe))
 - simplify size access further
-  ([#66](https://github.com/motion-canvas/motion-canvas/issues/66))
-  ([9091a5e](https://github.com/motion-canvas/motion-canvas/commit/9091a5e05d8fadf72c50832c7c4467ac4424b72c))
+  ([#66](https://github.com/revideo/revideo/issues/66))
+  ([9091a5e](https://github.com/revideo/revideo/commit/9091a5e05d8fadf72c50832c7c4467ac4424b72c))
 - switch to signals
-  ([#64](https://github.com/motion-canvas/motion-canvas/issues/64))
-  ([d22d237](https://github.com/motion-canvas/motion-canvas/commit/d22d23728597e6fa82ea5c5a99a6c0a56819bded))
+  ([#64](https://github.com/revideo/revideo/issues/64))
+  ([d22d237](https://github.com/revideo/revideo/commit/d22d23728597e6fa82ea5c5a99a6c0a56819bded))
 - turn Layout into node
-  ([#75](https://github.com/motion-canvas/motion-canvas/issues/75))
-  ([cdf8dc0](https://github.com/motion-canvas/motion-canvas/commit/cdf8dc0a35522482dee2dd78a69606b79f52246e))
+  ([#75](https://github.com/revideo/revideo/issues/75))
+  ([cdf8dc0](https://github.com/revideo/revideo/commit/cdf8dc0a35522482dee2dd78a69606b79f52246e))
 - unify core types
-  ([#71](https://github.com/motion-canvas/motion-canvas/issues/71))
-  ([9c5853d](https://github.com/motion-canvas/motion-canvas/commit/9c5853d8bc65204693c38109a25d1fefd44241b7))
+  ([#71](https://github.com/revideo/revideo/issues/71))
+  ([9c5853d](https://github.com/revideo/revideo/commit/9c5853d8bc65204693c38109a25d1fefd44241b7))
 - unify references and signals
-  ([#137](https://github.com/motion-canvas/motion-canvas/issues/137))
-  ([063aede](https://github.com/motion-canvas/motion-canvas/commit/063aede0842f948d2c6704c6edd426e954bb4668))
+  ([#137](https://github.com/revideo/revideo/issues/137))
+  ([063aede](https://github.com/revideo/revideo/commit/063aede0842f948d2c6704c6edd426e954bb4668))
 
 ### Reverts
 
 - ci(release): 1.0.1 [skip ci]
-  ([#175](https://github.com/motion-canvas/motion-canvas/issues/175))
-  ([161a046](https://github.com/motion-canvas/motion-canvas/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+  ([#175](https://github.com/revideo/revideo/issues/175))
+  ([161a046](https://github.com/revideo/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
 - ci(release): 2.0.0 [skip ci]
-  ([#176](https://github.com/motion-canvas/motion-canvas/issues/176))
-  ([551096b](https://github.com/motion-canvas/motion-canvas/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+  ([#176](https://github.com/revideo/revideo/issues/176))
+  ([551096b](https://github.com/revideo/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
 
 ### BREAKING CHANGES
 

--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/2d",
-  "version": "3.14.2",
+  "version": "0.1.0",
   "description": "A 2D renderer for revideo",
   "author": "revideo",
   "homepage": "https://re.video/",
@@ -28,9 +28,9 @@
     "tsconfig.project.json"
   ],
   "devDependencies": {
-    "@revideo/internal": "0.0.0",
-    "@revideo/ui": "^3.14.2",
     "@preact/signals": "^1.2.1",
+    "@revideo/internal": "0.0.0",
+    "@revideo/ui": "^0.1.0",
     "clsx": "^2.0.0",
     "jsdom": "^22.1.0",
     "preact": "^10.19.2",
@@ -40,7 +40,7 @@
     "@codemirror/language": "^6.10.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
-    "@revideo/core": "^3.14.1",
+    "@revideo/core": "^0.1.0",
     "code-fns": "^0.8.2",
     "mathjax-full": "^3.2.2",
     "parse-svg-path": "^0.1.2"

--- a/packages/2d/package.json
+++ b/packages/2d/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@motion-canvas/2d",
+  "name": "@revideo/2d",
   "version": "3.14.2",
-  "description": "A 2D renderer for Motion Canvas",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "description": "A 2D renderer for revideo",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",
@@ -19,7 +19,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/motion-canvas/motion-canvas.git"
+    "url": "git+https://github.com/havenhq/revideo.git"
   },
   "files": [
     "lib",
@@ -28,8 +28,8 @@
     "tsconfig.project.json"
   ],
   "devDependencies": {
-    "@motion-canvas/internal": "0.0.0",
-    "@motion-canvas/ui": "^3.14.2",
+    "@revideo/internal": "0.0.0",
+    "@revideo/ui": "^3.14.2",
     "@preact/signals": "^1.2.1",
     "clsx": "^2.0.0",
     "jsdom": "^22.1.0",
@@ -40,7 +40,7 @@
     "@codemirror/language": "^6.10.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",
-    "@motion-canvas/core": "^3.14.1",
+    "@revideo/core": "^3.14.1",
     "code-fns": "^0.8.2",
     "mathjax-full": "^3.2.2",
     "parse-svg-path": "^0.1.2"

--- a/packages/2d/rollup.config.mjs
+++ b/packages/2d/rollup.config.mjs
@@ -1,4 +1,4 @@
-import typescript from '@motion-canvas/internal/rollup/typescript.mjs';
+import typescript from '@revideo/internal/rollup/typescript.mjs';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
@@ -14,9 +14,9 @@ export default [
     plugins: [
       {
         resolveId(id) {
-          if (id.startsWith('@motion-canvas/core')) {
+          if (id.startsWith('@revideo/core')) {
             return {
-              id: '@motion-canvas/core',
+              id: '@revideo/core',
               external: true,
             };
           }

--- a/packages/2d/rollup.editor.mjs
+++ b/packages/2d/rollup.editor.mjs
@@ -1,4 +1,4 @@
-import typescript from '@motion-canvas/internal/rollup/typescript.mjs';
+import typescript from '@revideo/internal/rollup/typescript.mjs';
 import resolve from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 
@@ -10,7 +10,7 @@ export default [
       sourcemap: true,
       dir: './editor',
     },
-    external: [/^@motion-canvas/, /^@?preact/, './index.css'],
+    external: [/^@revideo/, /^@?preact/, './index.css'],
     plugins: [
       resolve(),
       postcss({

--- a/packages/2d/src/editor/NodeInspectorConfig.tsx
+++ b/packages/2d/src/editor/NodeInspectorConfig.tsx
@@ -1,3 +1,4 @@
+import {useComputed} from '@preact/signals';
 import {
   AutoField,
   Button,
@@ -9,8 +10,7 @@ import {
   UnknownField,
   findAndOpenFirstUserFile,
   useApplication,
-} from '@motion-canvas/ui';
-import {useComputed} from '@preact/signals';
+} from '@revideo/ui';
 import {NodeInspectorKey, usePluginState} from './Provider';
 
 function Component() {

--- a/packages/2d/src/editor/PreviewOverlayConfig.tsx
+++ b/packages/2d/src/editor/PreviewOverlayConfig.tsx
@@ -1,11 +1,11 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {
   MouseButton,
   OverlayWrapper,
   PluginOverlayConfig,
   useViewportContext,
   useViewportMatrix,
-} from '@motion-canvas/ui';
+} from '@revideo/ui';
 import {ComponentChildren} from 'preact';
 import {usePluginState} from './Provider';
 

--- a/packages/2d/src/editor/Provider.tsx
+++ b/packages/2d/src/editor/Provider.tsx
@@ -1,6 +1,3 @@
-import {Scene2D} from '@motion-canvas/2d';
-import {SceneRenderEvent} from '@motion-canvas/core';
-import {useApplication, useCurrentScene} from '@motion-canvas/ui';
 import {
   ReadonlySignal,
   Signal,
@@ -8,6 +5,9 @@ import {
   signal,
   useSignalEffect,
 } from '@preact/signals';
+import {Scene2D} from '@revideo/2d';
+import {SceneRenderEvent} from '@revideo/core';
+import {useApplication, useCurrentScene} from '@revideo/ui';
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useMemo} from 'preact/hooks';
 
@@ -22,7 +22,7 @@ export interface PluginState {
 
 const PluginContext = createContext<PluginState | null>(null);
 
-export const NodeInspectorKey = '@motion-canvas/2d/node-inspector';
+export const NodeInspectorKey = '@revideo/2d/node-inspector';
 
 export function usePluginState() {
   return useContext(PluginContext)!;

--- a/packages/2d/src/editor/SceneGraphTabConfig.tsx
+++ b/packages/2d/src/editor/SceneGraphTabConfig.tsx
@@ -8,7 +8,7 @@ import {
   useApplication,
   usePanels,
   useReducedMotion,
-} from '@motion-canvas/ui';
+} from '@revideo/ui';
 
 import {useSignalEffect} from '@preact/signals';
 import {useEffect, useRef} from 'preact/hooks';

--- a/packages/2d/src/editor/index.ts
+++ b/packages/2d/src/editor/index.ts
@@ -1,6 +1,6 @@
 import './index.css';
 
-import {makeEditorPlugin} from '@motion-canvas/ui';
+import {makeEditorPlugin} from '@revideo/ui';
 import {NodeInspectorConfig} from './NodeInspectorConfig';
 import {PreviewOverlayConfig} from './PreviewOverlayConfig';
 import {Provider} from './Provider';
@@ -8,7 +8,7 @@ import {SceneGraphTabConfig} from './SceneGraphTabConfig';
 
 export default makeEditorPlugin(() => {
   return {
-    name: '@motion-canvas/2d',
+    name: '@revideo/2d',
     provider: Provider,
     previewOverlay: PreviewOverlayConfig,
     tabs: [SceneGraphTabConfig],

--- a/packages/2d/src/editor/tree/NodeElement.tsx
+++ b/packages/2d/src/editor/tree/NodeElement.tsx
@@ -1,5 +1,5 @@
-import {NODE_NAME, Node} from '@motion-canvas/2d';
 import {useComputed, useSignal, useSignalEffect} from '@preact/signals';
+import {NODE_NAME, Node} from '@revideo/2d';
 import {useRef} from 'preact/hooks';
 import {usePluginState} from '../Provider';
 import {IconMap} from '../icons/IconMap';

--- a/packages/2d/src/editor/tree/TreeElement.tsx
+++ b/packages/2d/src/editor/tree/TreeElement.tsx
@@ -1,5 +1,5 @@
-import {Collapse, Toggle} from '@motion-canvas/ui';
 import {Signal} from '@preact/signals';
+import {Collapse, Toggle} from '@revideo/ui';
 import {clsx} from 'clsx';
 import {ComponentChildren, JSX} from 'preact';
 import {Ref} from 'preact/hooks';

--- a/packages/2d/src/editor/tsconfig.json
+++ b/packages/2d/src/editor/tsconfig.json
@@ -4,7 +4,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "paths": {
-      "@motion-canvas/2d": ["../lib"]
+      "@revideo/2d": ["../lib"]
     }
   },
   "references": [{"path": "../lib/tsconfig.json"}],

--- a/packages/2d/src/lib/code/CodeCursor.ts
+++ b/packages/2d/src/lib/code/CodeCursor.ts
@@ -5,7 +5,7 @@ import {
   SerializedVector2,
   unwrap,
   Vector2,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {Code} from '../components';
 import {CodeFragment, parseCodeFragment} from './CodeFragment';
 import {CodeHighlighter} from './CodeHighlighter';

--- a/packages/2d/src/lib/code/CodeScope.ts
+++ b/packages/2d/src/lib/code/CodeScope.ts
@@ -1,4 +1,4 @@
-import {SignalValue, unwrap} from '@motion-canvas/core';
+import {SignalValue, unwrap} from '@revideo/core';
 import {PossibleCodeFragment} from './CodeFragment';
 import {isCodeMetrics} from './CodeMetrics';
 

--- a/packages/2d/src/lib/code/CodeSignal.ts
+++ b/packages/2d/src/lib/code/CodeSignal.ts
@@ -8,7 +8,7 @@ import {
   ThreadGenerator,
   TimingFunction,
   unwrap,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {Code} from '../components';
 import {addInitializer, getPropertyMetaOrCreate} from '../decorators';
 import {defaultDiffer} from './CodeDiffer';

--- a/packages/2d/src/lib/code/LezerHighlighter.ts
+++ b/packages/2d/src/lib/code/LezerHighlighter.ts
@@ -1,7 +1,7 @@
 import {HighlightStyle} from '@codemirror/language';
 import {Parser, SyntaxNode, Tree} from '@lezer/common';
 import {highlightTree} from '@lezer/highlight';
-import {useLogger} from '@motion-canvas/core';
+import {useLogger} from '@revideo/core';
 import {CodeHighlighter, HighlightResult} from './CodeHighlighter';
 import {defaultTokenize} from './CodeTokenizer';
 

--- a/packages/2d/src/lib/components/Audio.ts
+++ b/packages/2d/src/lib/components/Audio.ts
@@ -1,4 +1,4 @@
-import {DependencyContext, PlaybackState, viaProxy} from '@motion-canvas/core';
+import {DependencyContext, PlaybackState, viaProxy} from '@revideo/core';
 import {computed, nodeName} from '../decorators';
 import {Media, MediaProps} from './Media';
 

--- a/packages/2d/src/lib/components/Bezier.ts
+++ b/packages/2d/src/lib/components/Bezier.ts
@@ -1,4 +1,4 @@
-import {BBox, SerializedVector2, Vector2} from '@motion-canvas/core';
+import {BBox, SerializedVector2, Vector2} from '@revideo/core';
 import {CurveProfile} from '../curves';
 import {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed} from '../decorators';

--- a/packages/2d/src/lib/components/Circle.ts
+++ b/packages/2d/src/lib/components/Circle.ts
@@ -4,7 +4,7 @@ import {
   SerializedVector2,
   SignalValue,
   SimpleSignal,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {CurveProfile, getCircleProfile} from '../curves';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {DesiredLength} from '../partials';
@@ -39,7 +39,7 @@ export interface CircleProps extends CurveProps {
  * @preview
  * ```tsx editor
  * // snippet Simple circle
- * import {makeScene2D, Circle} from '@motion-canvas/2d';
+ * import {makeScene2D, Circle} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   view.add(
@@ -51,7 +51,7 @@ export interface CircleProps extends CurveProps {
  * });
  *
  * // snippet Ellipse
- * import {makeScene2D, Circle} from '@motion-canvas/2d';
+ * import {makeScene2D, Circle} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   view.add(
@@ -64,8 +64,8 @@ export interface CircleProps extends CurveProps {
  * });
  *
  * // snippet Sector (pie chart):
- * import {makeScene2D, Circle} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D, Circle} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const ref = createRef<Circle>();
@@ -84,8 +84,8 @@ export interface CircleProps extends CurveProps {
  * });
  *
  * // snippet Arc:
- * import {makeScene2D, Circle} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D, Circle} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const ref = createRef<Circle>();
@@ -104,8 +104,8 @@ export interface CircleProps extends CurveProps {
  * });
  *
  * // snippet Curve properties:
- * import {makeScene2D, Circle} from '@motion-canvas/2d';
- * import {all, createRef, easeInCubic, easeOutCubic} from '@motion-canvas/core';
+ * import {makeScene2D, Circle} from '@revideo/2d';
+ * import {all, createRef, easeInCubic, easeOutCubic} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const ref = createRef<Circle>();

--- a/packages/2d/src/lib/components/Code.ts
+++ b/packages/2d/src/lib/components/Code.ts
@@ -12,7 +12,7 @@ import {
   TimingFunction,
   unwrap,
   Vector2,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   CodeCursor,
   CodeFragmentDrawingInfo,
@@ -101,8 +101,8 @@ export interface CodeProps extends ShapeProps {
  * @preview
  * ```tsx editor
  * import {parser} from '@lezer/javascript';
- * import {Code, LezerHighlighter, makeScene2D} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {Code, LezerHighlighter, makeScene2D} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   LezerHighlighter.registerParser(parser);

--- a/packages/2d/src/lib/components/CodeBlock.ts
+++ b/packages/2d/src/lib/components/CodeBlock.ts
@@ -16,7 +16,7 @@ import {
   tween,
   useLogger,
   waitFor,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   Code,
   CodeStyle,

--- a/packages/2d/src/lib/components/CubicBezier.ts
+++ b/packages/2d/src/lib/components/CubicBezier.ts
@@ -1,4 +1,4 @@
-import {PossibleVector2, SignalValue, Vector2Signal} from '@motion-canvas/core';
+import {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
 import {CubicBezierSegment} from '../curves';
 import {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed, vector2Signal} from '../decorators';
@@ -29,8 +29,8 @@ export interface CubicBezierProps extends CurveProps {
  *
  * @preview
  * ```tsx editor
- * import {makeScene2D, CubicBezier} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D, CubicBezier} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const bezier = createRef<CubicBezier>();

--- a/packages/2d/src/lib/components/Curve.ts
+++ b/packages/2d/src/lib/components/Curve.ts
@@ -5,7 +5,7 @@ import {
   SimpleSignal,
   Vector2,
   clamp,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {CurveDrawingInfo} from '../curves/CurveDrawingInfo';
 import {CurvePoint} from '../curves/CurvePoint';
 import {CurveProfile} from '../curves/CurveProfile';

--- a/packages/2d/src/lib/components/Grid.ts
+++ b/packages/2d/src/lib/components/Grid.ts
@@ -4,7 +4,7 @@ import {
   SimpleSignal,
   Vector2Signal,
   map,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {initial, nodeName, signal, vector2Signal} from '../decorators';
 import {Shape, ShapeProps} from './Shape';
 
@@ -28,8 +28,8 @@ export interface GridProps extends ShapeProps {
  *
  * @preview
  * ```tsx editor
- * import {Grid, makeScene2D} from '@motion-canvas/2d';
- * import {all, createRef} from '@motion-canvas/core';
+ * import {Grid, makeScene2D} from '@revideo/2d';
+ * import {all, createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const grid = createRef<Grid>();

--- a/packages/2d/src/lib/components/Icon.ts
+++ b/packages/2d/src/lib/components/Icon.ts
@@ -4,7 +4,7 @@ import {
   SignalValue,
   SimpleSignal,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {colorSignal, computed, initial, signal} from '../decorators';
 import {Img, ImgProps} from './Img';
 

--- a/packages/2d/src/lib/components/Img.ts
+++ b/packages/2d/src/lib/components/Img.ts
@@ -10,7 +10,7 @@ import {
   Vector2,
   useLogger,
   viaProxy,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {DesiredLength} from '../partials';
 import {drawImage} from '../utils';
@@ -37,10 +37,10 @@ export interface ImgProps extends RectProps {
  *
  * @preview
  * ```tsx editor
- * import {Img} from '@motion-canvas/2d';
- * import {all, waitFor} from '@motion-canvas/core';
- * import {createRef} from '@motion-canvas/core';
- * import {makeScene2D} from '@motion-canvas/2d';
+ * import {Img} from '@revideo/2d';
+ * import {all, waitFor} from '@revideo/core';
+ * import {createRef} from '@revideo/core';
+ * import {makeScene2D} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   const ref = createRef<Img>();
@@ -71,7 +71,7 @@ export class Img extends Rect {
 
   static {
     if (import.meta.hot) {
-      import.meta.hot.on('motion-canvas:assets', ({urls}) => {
+      import.meta.hot.on('revideo:assets', ({urls}) => {
         for (const url of urls) {
           if (Img.pool[url]) {
             delete Img.pool[url];

--- a/packages/2d/src/lib/components/Knot.ts
+++ b/packages/2d/src/lib/components/Knot.ts
@@ -4,7 +4,7 @@ import {
   SignalValue,
   Vector2,
   Vector2Signal,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {KnotInfo} from '../curves';
 import {
   cloneable,

--- a/packages/2d/src/lib/components/Latex.ts
+++ b/packages/2d/src/lib/components/Latex.ts
@@ -3,7 +3,7 @@ import {
   SignalValue,
   SimpleSignal,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {liteAdaptor} from 'mathjax-full/js/adaptors/liteAdaptor';
 import {RegisterHTMLHandler} from 'mathjax-full/js/handlers/html';
 import {TeX} from 'mathjax-full/js/input/tex';
@@ -34,7 +34,7 @@ export interface LatexProps extends ImgProps {
  *
  * @preview
  * ```tsx editor
- * import {Latex, makeScene2D} from '@motion-canvas/2d';
+ * import {Latex, makeScene2D} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   view.add(

--- a/packages/2d/src/lib/components/Layout.ts
+++ b/packages/2d/src/lib/components/Layout.ts
@@ -19,7 +19,7 @@ import {
   tween,
   Vector2,
   Vector2Signal,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   addInitializer,
   cloneable,

--- a/packages/2d/src/lib/components/Line.ts
+++ b/packages/2d/src/lib/components/Line.ts
@@ -11,7 +11,7 @@ import {
   unwrap,
   useLogger,
   Vector2,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {CurveProfile, getPolylineProfile} from '../curves';
 import {
   calculateLerpDistance,
@@ -45,7 +45,7 @@ export interface LineProps extends CurveProps {
  * @preview
  * ```tsx editor
  * // snippet Simple line
- * import {makeScene2D, Line} from '@motion-canvas/2d';
+ * import {makeScene2D, Line} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   view.add(
@@ -64,7 +64,7 @@ export interface LineProps extends CurveProps {
  * });
  *
  * // snippet Polygon
- * import {makeScene2D, Line} from '@motion-canvas/2d';
+ * import {makeScene2D, Line} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   view.add(
@@ -82,8 +82,8 @@ export interface LineProps extends CurveProps {
  * });
  *
  * // snippet Using signals
- * import {makeScene2D, Line} from '@motion-canvas/2d';
- * import {createSignal} from '@motion-canvas/core';
+ * import {makeScene2D, Line} from '@revideo/2d';
+ * import {createSignal} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const tip = createSignal(-150);
@@ -105,8 +105,8 @@ export interface LineProps extends CurveProps {
  * });
  *
  * // snippet Tweening points
- * import {makeScene2D, Line} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D, Line} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const line = createRef<Line>();

--- a/packages/2d/src/lib/components/Media.ts
+++ b/packages/2d/src/lib/components/Media.ts
@@ -6,7 +6,7 @@ import {
   isReactive,
   useLogger,
   useThread,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed, initial, signal} from '../decorators';
 import {Rect, RectProps} from './Rect';
 import reactivePlaybackRate from './__logs__/reactive-playback-rate.md';

--- a/packages/2d/src/lib/components/Node.ts
+++ b/packages/2d/src/lib/components/Node.ts
@@ -30,7 +30,7 @@ import {
   transformScalar,
   unwrap,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   NODE_NAME,
   cloneable,

--- a/packages/2d/src/lib/components/Path.ts
+++ b/packages/2d/src/lib/components/Path.ts
@@ -8,7 +8,7 @@ import {
   TimingFunction,
   tween,
   Vector2,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {CurveProfile} from '../curves';
 import {createCurveProfileLerp} from '../curves/createCurveProfileLerp';
 import {getPathProfile} from '../curves/getPathProfile';

--- a/packages/2d/src/lib/components/Polygon.ts
+++ b/packages/2d/src/lib/components/Polygon.ts
@@ -4,7 +4,7 @@ import {
   SignalValue,
   SimpleSignal,
   Vector2,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {CurveProfile, getPolylineProfile} from '../curves';
 import {computed, initial, signal} from '../decorators';
 import {DesiredLength} from '../partials';
@@ -41,8 +41,8 @@ export interface PolygonProps extends CurveProps {
  * @preview
  * ```tsx editor
  * // snippet Polygon
- * import {makeScene2D, Polygon} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D, Polygon} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const ref = createRef<Polygon>();
@@ -59,7 +59,7 @@ export interface PolygonProps extends CurveProps {
  * });
  *
  * // snippet Pentagon outline
- * import {makeScene2D, Polygon} from '@motion-canvas/2d';
+ * import {makeScene2D, Polygon} from '@revideo/2d';
  *
  * export default makeScene2D(function* (view) {
  *   view.add(

--- a/packages/2d/src/lib/components/QuadBezier.ts
+++ b/packages/2d/src/lib/components/QuadBezier.ts
@@ -1,4 +1,4 @@
-import {PossibleVector2, SignalValue, Vector2Signal} from '@motion-canvas/core';
+import {PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
 import {QuadBezierSegment} from '../curves';
 import {PolynomialSegment} from '../curves/PolynomialSegment';
 import {computed, vector2Signal} from '../decorators';
@@ -25,8 +25,8 @@ export interface QuadBezierProps extends CurveProps {
  *
  * @preview
  * ```tsx editor
- * import {makeScene2D, QuadBezier} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D, QuadBezier} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const bezier = createRef<QuadBezier>();

--- a/packages/2d/src/lib/components/Ray.ts
+++ b/packages/2d/src/lib/components/Ray.ts
@@ -1,9 +1,4 @@
-import {
-  BBox,
-  PossibleVector2,
-  SignalValue,
-  Vector2Signal,
-} from '@motion-canvas/core';
+import {BBox, PossibleVector2, SignalValue, Vector2Signal} from '@revideo/core';
 import {CurveProfile, LineSegment} from '../curves';
 import {nodeName, vector2Signal} from '../decorators';
 import {arc, drawLine, drawPivot} from '../utils';
@@ -30,9 +25,9 @@ export interface RayProps extends CurveProps {
  *
  * @preview
  * ```tsx editor
- * import {makeScene2D} from '@motion-canvas/2d';
- * import {Ray} from '@motion-canvas/2d';
- * import {createRef} from '@motion-canvas/core';
+ * import {makeScene2D} from '@revideo/2d';
+ * import {Ray} from '@revideo/2d';
+ * import {createRef} from '@revideo/core';
  *
  * export default makeScene2D(function* (view) {
  *   const ray = createRef<Ray>();

--- a/packages/2d/src/lib/components/Rect.ts
+++ b/packages/2d/src/lib/components/Rect.ts
@@ -5,7 +5,7 @@ import {
   SignalValue,
   SimpleSignal,
   SpacingSignal,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {getRectProfile} from '../curves/getRectProfile';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {spacingSignal} from '../decorators/spacingSignal';

--- a/packages/2d/src/lib/components/SVG.ts
+++ b/packages/2d/src/lib/components/SVG.ts
@@ -17,7 +17,7 @@ import {
   threadable,
   tween,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed, signal} from '../decorators';
 import {DesiredLength, PossibleCanvasStyle} from '../partials';
 import {applyTransformDiff, getTransformDiff} from '../utils/diff';

--- a/packages/2d/src/lib/components/Shape.ts
+++ b/packages/2d/src/lib/components/Shape.ts
@@ -7,7 +7,7 @@ import {
   linear,
   map,
   threadable,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {
   CanvasStyleSignal,

--- a/packages/2d/src/lib/components/Spline.ts
+++ b/packages/2d/src/lib/components/Spline.ts
@@ -7,7 +7,7 @@ import {
   Vector2,
   unwrap,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   CubicBezierSegment,
   CurveProfile,

--- a/packages/2d/src/lib/components/Txt.test.tsx
+++ b/packages/2d/src/lib/components/Txt.test.tsx
@@ -1,4 +1,4 @@
-import {linear, waitFor} from '@motion-canvas/core';
+import {linear, waitFor} from '@revideo/core';
 import {describe, expect, it, vi} from 'vitest';
 import {Txt} from './Txt';
 import {TxtLeaf} from './TxtLeaf';

--- a/packages/2d/src/lib/components/Txt.ts
+++ b/packages/2d/src/lib/components/Txt.ts
@@ -8,7 +8,7 @@ import {
   all,
   capitalize,
   threadable,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {is} from '../utils';
 import {Node} from './Node';

--- a/packages/2d/src/lib/components/TxtLeaf.ts
+++ b/packages/2d/src/lib/components/TxtLeaf.ts
@@ -5,7 +5,7 @@ import {
   capitalize,
   lazy,
   textLerp,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   computed,
   initial,

--- a/packages/2d/src/lib/components/Video.ts
+++ b/packages/2d/src/lib/components/Video.ts
@@ -6,7 +6,7 @@ import {
   SignalValue,
   SimpleSignal,
   viaProxy,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed, initial, nodeName, signal} from '../decorators';
 import {DesiredLength} from '../partials';
 import {drawImage} from '../utils';

--- a/packages/2d/src/lib/components/View2D.ts
+++ b/packages/2d/src/lib/components/View2D.ts
@@ -1,4 +1,4 @@
-import {PlaybackState, SimpleSignal, lazy} from '@motion-canvas/core';
+import {PlaybackState, SimpleSignal, lazy} from '@revideo/core';
 import {initial, signal} from '../decorators';
 import {nodeName} from '../decorators/nodeName';
 import {useScene2D} from '../scenes/useScene2D';
@@ -12,7 +12,7 @@ export interface View2DProps extends RectProps {
 @nodeName('View2D')
 export class View2D extends Rect {
   @lazy(() => {
-    const frameID = 'motion-canvas-2d-frame';
+    const frameID = 'revideo-2d-frame';
     let frame = document.querySelector<HTMLDivElement>(`#${frameID}`);
     if (!frame) {
       frame = document.createElement('div');

--- a/packages/2d/src/lib/components/__tests__/children.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/children.test.tsx
@@ -1,4 +1,4 @@
-import {createRef, createSignal, range} from '@motion-canvas/core';
+import {createRef, createSignal, range} from '@revideo/core';
 import {describe, expect, it} from 'vitest';
 import {useScene2D} from '../../scenes';
 import {Node} from '../Node';

--- a/packages/2d/src/lib/components/__tests__/clone.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/clone.test.tsx
@@ -1,4 +1,4 @@
-import {Vector2, createSignal, range} from '@motion-canvas/core';
+import {Vector2, createSignal, range} from '@revideo/core';
 import {describe, expect, it} from 'vitest';
 import {Circle} from '../Circle';
 import {Node} from '../Node';

--- a/packages/2d/src/lib/components/__tests__/generatorTest.ts
+++ b/packages/2d/src/lib/components/__tests__/generatorTest.ts
@@ -1,4 +1,4 @@
-import {ThreadGeneratorFactory, threads} from '@motion-canvas/core';
+import {ThreadGeneratorFactory, threads} from '@revideo/core';
 import {useScene2D} from '../../scenes';
 import {View2D} from '../View2D';
 

--- a/packages/2d/src/lib/components/__tests__/mockScene2D.ts
+++ b/packages/2d/src/lib/components/__tests__/mockScene2D.ts
@@ -9,8 +9,8 @@ import {
   endScene,
   startPlayback,
   startScene,
-} from '@motion-canvas/core';
-import {ReadOnlyTimeEvents} from '@motion-canvas/core/lib/scenes/timeEvents';
+} from '@revideo/core';
+import {ReadOnlyTimeEvents} from '@revideo/core/lib/scenes/timeEvents';
 import {afterAll, beforeAll, beforeEach} from 'vitest';
 import {Scene2D, makeScene2D} from '../../scenes';
 import {View2D} from '../View2D';

--- a/packages/2d/src/lib/components/__tests__/query.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/query.test.tsx
@@ -1,4 +1,4 @@
-import {createRef, createRefArray} from '@motion-canvas/core';
+import {createRef, createRefArray} from '@revideo/core';
 import {describe, expect, it} from 'vitest';
 import {useScene2D} from '../../scenes';
 import {is} from '../../utils';

--- a/packages/2d/src/lib/components/__tests__/state.test.tsx
+++ b/packages/2d/src/lib/components/__tests__/state.test.tsx
@@ -1,4 +1,4 @@
-import {createSignal, join, waitFor} from '@motion-canvas/core';
+import {createSignal, join, waitFor} from '@revideo/core';
 import {describe, expect, it} from 'vitest';
 import {Circle} from '../Circle';
 import {generatorTest} from './generatorTest';

--- a/packages/2d/src/lib/components/types.ts
+++ b/packages/2d/src/lib/components/types.ts
@@ -1,4 +1,4 @@
-import type {ReferenceReceiver} from '@motion-canvas/core';
+import type {ReferenceReceiver} from '@revideo/core';
 import type {Node} from './Node';
 
 export type ComponentChild =

--- a/packages/2d/src/lib/curves/ArcSegment.ts
+++ b/packages/2d/src/lib/curves/ArcSegment.ts
@@ -1,4 +1,4 @@
-import {BBox, DEG2RAD, Matrix2D, Vector2, lazy} from '@motion-canvas/core';
+import {BBox, DEG2RAD, Matrix2D, Vector2, lazy} from '@revideo/core';
 import {View2D} from '../components/View2D';
 import {CurvePoint} from './CurvePoint';
 import {Segment} from './Segment';

--- a/packages/2d/src/lib/curves/CircleSegment.ts
+++ b/packages/2d/src/lib/curves/CircleSegment.ts
@@ -1,4 +1,4 @@
-import {Vector2, clamp} from '@motion-canvas/core';
+import {Vector2, clamp} from '@revideo/core';
 import {CurvePoint} from './CurvePoint';
 import {Segment} from './Segment';
 

--- a/packages/2d/src/lib/curves/CubicBezierSegment.ts
+++ b/packages/2d/src/lib/curves/CubicBezierSegment.ts
@@ -1,4 +1,4 @@
-import {Vector2, lazy} from '@motion-canvas/core';
+import {Vector2, lazy} from '@revideo/core';
 import {bezierCurveTo} from '../utils';
 import {Polynomial2D} from './Polynomial2D';
 import {PolynomialSegment} from './PolynomialSegment';

--- a/packages/2d/src/lib/curves/CurveDrawingInfo.ts
+++ b/packages/2d/src/lib/curves/CurveDrawingInfo.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 
 export interface CurveDrawingInfo {
   path: Path2D;

--- a/packages/2d/src/lib/curves/CurvePoint.ts
+++ b/packages/2d/src/lib/curves/CurvePoint.ts
@@ -1,4 +1,4 @@
-import type {Vector2} from '@motion-canvas/core';
+import type {Vector2} from '@revideo/core';
 
 export interface CurvePoint {
   position: Vector2;

--- a/packages/2d/src/lib/curves/KnotInfo.ts
+++ b/packages/2d/src/lib/curves/KnotInfo.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 
 export type KnotAutoHandles = {start: number; end: number};
 

--- a/packages/2d/src/lib/curves/LineSegment.ts
+++ b/packages/2d/src/lib/curves/LineSegment.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {lineTo, moveTo} from '../utils';
 import {CurvePoint} from './CurvePoint';
 import {Segment} from './Segment';

--- a/packages/2d/src/lib/curves/Polynomial.ts
+++ b/packages/2d/src/lib/curves/Polynomial.ts
@@ -1,4 +1,4 @@
-import {clamp} from '@motion-canvas/core';
+import {clamp} from '@revideo/core';
 
 /**
  * A polynomial in the form ax^3 + bx^2 + cx + d up to a cubic polynomial.

--- a/packages/2d/src/lib/curves/Polynomial2D.ts
+++ b/packages/2d/src/lib/curves/Polynomial2D.ts
@@ -1,4 +1,4 @@
-import {BBox, Vector2} from '@motion-canvas/core';
+import {BBox, Vector2} from '@revideo/core';
 
 import {Polynomial} from './Polynomial';
 

--- a/packages/2d/src/lib/curves/PolynomialSegment.ts
+++ b/packages/2d/src/lib/curves/PolynomialSegment.ts
@@ -1,4 +1,4 @@
-import {BBox, Vector2} from '@motion-canvas/core';
+import {BBox, Vector2} from '@revideo/core';
 import {moveTo} from '../utils';
 import {CurvePoint} from './CurvePoint';
 import {Polynomial2D} from './Polynomial2D';

--- a/packages/2d/src/lib/curves/QuadBezierSegment.ts
+++ b/packages/2d/src/lib/curves/QuadBezierSegment.ts
@@ -1,4 +1,4 @@
-import {Vector2, lazy} from '@motion-canvas/core';
+import {Vector2, lazy} from '@revideo/core';
 import {quadraticCurveTo} from '../utils';
 import {Polynomial2D} from './Polynomial2D';
 import {PolynomialSegment} from './PolynomialSegment';

--- a/packages/2d/src/lib/curves/Segment.ts
+++ b/packages/2d/src/lib/curves/Segment.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {CurvePoint} from './CurvePoint';
 
 export abstract class Segment {

--- a/packages/2d/src/lib/curves/UniformPolynomialCurveSampler.ts
+++ b/packages/2d/src/lib/curves/UniformPolynomialCurveSampler.ts
@@ -1,4 +1,4 @@
-import {Vector2, clamp, remap} from '@motion-canvas/core';
+import {Vector2, clamp, remap} from '@revideo/core';
 import {CurvePoint} from './CurvePoint';
 import {PolynomialSegment} from './PolynomialSegment';
 

--- a/packages/2d/src/lib/curves/createCurveProfileLerp.ts
+++ b/packages/2d/src/lib/curves/createCurveProfileLerp.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';
 import {getPointAtDistance} from './getPointAtDistance';

--- a/packages/2d/src/lib/curves/getBezierSplineProfile.ts
+++ b/packages/2d/src/lib/curves/getBezierSplineProfile.ts
@@ -1,4 +1,4 @@
-import {Vector2, clamp} from '@motion-canvas/core';
+import {Vector2, clamp} from '@revideo/core';
 import {CubicBezierSegment} from './CubicBezierSegment';
 import {CurveProfile} from './CurveProfile';
 import {KnotInfo} from './KnotInfo';

--- a/packages/2d/src/lib/curves/getCircleProfile.ts
+++ b/packages/2d/src/lib/curves/getCircleProfile.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {ArcSegment} from './ArcSegment';
 import {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';

--- a/packages/2d/src/lib/curves/getPathProfile.ts
+++ b/packages/2d/src/lib/curves/getPathProfile.ts
@@ -1,4 +1,4 @@
-import {Vector2, clamp} from '@motion-canvas/core';
+import {Vector2, clamp} from '@revideo/core';
 import parse, {PathCommand} from 'parse-svg-path';
 import {ArcSegment} from './ArcSegment';
 import {CubicBezierSegment} from './CubicBezierSegment';

--- a/packages/2d/src/lib/curves/getPointAtDistance.ts
+++ b/packages/2d/src/lib/curves/getPointAtDistance.ts
@@ -1,4 +1,4 @@
-import {Vector2, clamp} from '@motion-canvas/core';
+import {Vector2, clamp} from '@revideo/core';
 import {CurvePoint} from './CurvePoint';
 import {CurveProfile} from './CurveProfile';
 

--- a/packages/2d/src/lib/curves/getPolylineProfile.test.ts
+++ b/packages/2d/src/lib/curves/getPolylineProfile.test.ts
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {describe, expect, test} from 'vitest';
 import {getPolylineProfile} from './getPolylineProfile';
 

--- a/packages/2d/src/lib/curves/getPolylineProfile.ts
+++ b/packages/2d/src/lib/curves/getPolylineProfile.ts
@@ -1,4 +1,4 @@
-import {Vector2, clamp} from '@motion-canvas/core';
+import {Vector2, clamp} from '@revideo/core';
 import {CircleSegment} from './CircleSegment';
 import {CurveProfile} from './CurveProfile';
 import {LineSegment} from './LineSegment';

--- a/packages/2d/src/lib/curves/getRectProfile.ts
+++ b/packages/2d/src/lib/curves/getRectProfile.ts
@@ -1,4 +1,4 @@
-import {BBox, Spacing, Vector2} from '@motion-canvas/core';
+import {BBox, Spacing, Vector2} from '@revideo/core';
 import {adjustRectRadius} from '../utils';
 import {CircleSegment} from './CircleSegment';
 import {CubicBezierSegment} from './CubicBezierSegment';

--- a/packages/2d/src/lib/decorators/canvasStyleSignal.ts
+++ b/packages/2d/src/lib/decorators/canvasStyleSignal.ts
@@ -1,4 +1,4 @@
-import {Color, Signal} from '@motion-canvas/core';
+import {Color, Signal} from '@revideo/core';
 import type {CanvasStyle, PossibleCanvasStyle} from '../partials';
 import {canvasStyleParser} from '../utils';
 import {initial, interpolation, parser, signal} from './signal';

--- a/packages/2d/src/lib/decorators/colorSignal.ts
+++ b/packages/2d/src/lib/decorators/colorSignal.ts
@@ -1,4 +1,4 @@
-import {Color} from '@motion-canvas/core';
+import {Color} from '@revideo/core';
 import {signal, wrapper} from './signal';
 
 export function colorSignal(): PropertyDecorator {

--- a/packages/2d/src/lib/decorators/compound.ts
+++ b/packages/2d/src/lib/decorators/compound.ts
@@ -5,7 +5,7 @@ import {
   map,
   modify,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {makeSignalExtensions} from '../utils/makeSignalExtensions';
 import {addInitializer} from './initializers';
 import {getPropertyMetaOrCreate} from './signal';

--- a/packages/2d/src/lib/decorators/computed.ts
+++ b/packages/2d/src/lib/decorators/computed.ts
@@ -1,4 +1,4 @@
-import {createComputed} from '@motion-canvas/core';
+import {createComputed} from '@revideo/core';
 import {addInitializer} from './initializers';
 
 /**

--- a/packages/2d/src/lib/decorators/defaultStyle.ts
+++ b/packages/2d/src/lib/decorators/defaultStyle.ts
@@ -1,4 +1,4 @@
-import {capitalize} from '@motion-canvas/core';
+import {capitalize} from '@revideo/core';
 import {Layout} from '../components';
 
 export function defaultStyle<T>(

--- a/packages/2d/src/lib/decorators/filtersSignal.ts
+++ b/packages/2d/src/lib/decorators/filtersSignal.ts
@@ -9,7 +9,7 @@ import {
   deepLerp,
   easeInOutCubic,
   unwrap,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {FILTERS, Filter, FilterName} from '../partials';
 import {addInitializer} from './initializers';
 import {getPropertyMetaOrCreate} from './signal';

--- a/packages/2d/src/lib/decorators/initializers.ts
+++ b/packages/2d/src/lib/decorators/initializers.ts
@@ -1,4 +1,4 @@
-const INITIALIZERS = Symbol.for('@motion-canvas/2d/decorators/initializers');
+const INITIALIZERS = Symbol.for('@revideo/2d/decorators/initializers');
 
 export type Initializer<T> = (instance: T, context?: any) => void;
 

--- a/packages/2d/src/lib/decorators/nodeName.ts
+++ b/packages/2d/src/lib/decorators/nodeName.ts
@@ -1,7 +1,7 @@
 /**
  * @internal
  */
-export const NODE_NAME = Symbol.for('@motion-canvas/2d/nodeName');
+export const NODE_NAME = Symbol.for('@revideo/2d/nodeName');
 
 /**
  * @internal

--- a/packages/2d/src/lib/decorators/signal.test.ts
+++ b/packages/2d/src/lib/decorators/signal.test.ts
@@ -1,4 +1,4 @@
-import {DEFAULT, SimpleSignal} from '@motion-canvas/core';
+import {DEFAULT, SimpleSignal} from '@revideo/core';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {initial, initializeSignals, parser, signal} from './signal';
 

--- a/packages/2d/src/lib/decorators/signal.ts
+++ b/packages/2d/src/lib/decorators/signal.ts
@@ -6,7 +6,7 @@ import {
   SignalValue,
   TimingFunction,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {makeSignalExtensions} from '../utils/makeSignalExtensions';
 import {addInitializer, initialize} from './initializers';
 
@@ -29,7 +29,7 @@ export interface PropertyMetadata<T> {
   compoundEntries: [string, string][];
 }
 
-const PROPERTIES = Symbol.for('@motion-canvas/2d/decorators/properties');
+const PROPERTIES = Symbol.for('@revideo/2d/decorators/properties');
 
 export function getPropertyMeta<T>(
   object: any,

--- a/packages/2d/src/lib/decorators/spacingSignal.ts
+++ b/packages/2d/src/lib/decorators/spacingSignal.ts
@@ -1,4 +1,4 @@
-import {Spacing} from '@motion-canvas/core';
+import {Spacing} from '@revideo/core';
 import {compound} from './compound';
 import {wrapper} from './signal';
 

--- a/packages/2d/src/lib/decorators/vector2Signal.ts
+++ b/packages/2d/src/lib/decorators/vector2Signal.ts
@@ -1,4 +1,4 @@
-import {PossibleVector2, Signal, Vector2} from '@motion-canvas/core';
+import {PossibleVector2, Signal, Vector2} from '@revideo/core';
 import type {Length} from '../partials';
 import {compound} from './compound';
 import {wrapper} from './signal';

--- a/packages/2d/src/lib/globals.d.ts
+++ b/packages/2d/src/lib/globals.d.ts
@@ -1,3 +1,3 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-/// <reference types="@motion-canvas/core/project" />
-/// <reference types="@motion-canvas/internal" />
+/// <reference types="@revideo/core/project" />
+/// <reference types="@revideo/internal" />

--- a/packages/2d/src/lib/jsx-runtime.ts
+++ b/packages/2d/src/lib/jsx-runtime.ts
@@ -21,7 +21,7 @@ function isClassComponent(
   return !!fn.prototype?.isClass;
 }
 
-export const Fragment = Symbol.for('@motion-canvas/2d/fragment');
+export const Fragment = Symbol.for('@revideo/2d/fragment');
 export function jsx(
   type: NodeConstructor | FunctionComponent | typeof Fragment,
   config: JSXProps,

--- a/packages/2d/src/lib/partials/Filter.ts
+++ b/packages/2d/src/lib/partials/Filter.ts
@@ -4,7 +4,7 @@ import {
   SignalValue,
   SimpleSignal,
   transformScalar,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 /**
  * All possible CSS filter names.

--- a/packages/2d/src/lib/partials/Gradient.ts
+++ b/packages/2d/src/lib/partials/Gradient.ts
@@ -6,7 +6,7 @@ import {
   SimpleSignal,
   Vector2Signal,
   unwrap,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {computed} from '../decorators/computed';
 import {initial, initializeSignals, signal} from '../decorators/signal';
 import {vector2Signal} from '../decorators/vector2Signal';

--- a/packages/2d/src/lib/partials/Pattern.ts
+++ b/packages/2d/src/lib/partials/Pattern.ts
@@ -1,4 +1,4 @@
-import {SimpleSignal} from '@motion-canvas/core';
+import {SimpleSignal} from '@revideo/core';
 import {computed} from '../decorators/computed';
 import {initial, initializeSignals, signal} from '../decorators/signal';
 

--- a/packages/2d/src/lib/partials/ShaderConfig.ts
+++ b/packages/2d/src/lib/partials/ShaderConfig.ts
@@ -4,7 +4,7 @@ import {
   useLogger,
   useScene,
   WebGLConvertible,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {Node} from '../components';
 
 /**
@@ -21,7 +21,7 @@ export interface ShaderConfig {
    * #version 300 es
    * precision highp float;
    *
-   * #include "@motion-canvas/core/shaders/common.glsl"
+   * #include "@revideo/core/shaders/common.glsl"
    *
    * void main() {
    *     out_color = texture(core_source_tx, source_uv);

--- a/packages/2d/src/lib/partials/types.ts
+++ b/packages/2d/src/lib/partials/types.ts
@@ -1,4 +1,4 @@
-import {Color, PossibleColor} from '@motion-canvas/core';
+import {Color, PossibleColor} from '@revideo/core';
 import type {Gradient} from './Gradient';
 import type {Pattern} from './Pattern';
 

--- a/packages/2d/src/lib/scenes/Scene2D.ts
+++ b/packages/2d/src/lib/scenes/Scene2D.ts
@@ -10,7 +10,7 @@ import {
   ThreadGeneratorFactory,
   Vector2,
   useLogger,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {Audio, Node, Video, View2D} from '../components';
 
 export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
@@ -25,7 +25,7 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
     super(description);
     this.recreateView();
     if (import.meta.hot) {
-      import.meta.hot.on('motion-canvas:assets', () => {
+      import.meta.hot.on('revideo:assets', () => {
         this.assetHash = Date.now().toString();
         this.getView().assetHash(this.assetHash);
       });

--- a/packages/2d/src/lib/scenes/makeScene2D.ts
+++ b/packages/2d/src/lib/scenes/makeScene2D.ts
@@ -2,7 +2,7 @@ import {
   createSceneMetadata,
   DescriptionOf,
   ThreadGeneratorFactory,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import type {View2D} from '../components';
 import {Scene2D} from './Scene2D';
 
@@ -14,6 +14,6 @@ export function makeScene2D(
     config: runner,
     stack: new Error().stack,
     meta: createSceneMetadata(),
-    plugins: ['@motion-canvas/2d/editor'],
+    plugins: ['@revideo/2d/editor'],
   };
 }

--- a/packages/2d/src/lib/scenes/useScene2D.ts
+++ b/packages/2d/src/lib/scenes/useScene2D.ts
@@ -1,4 +1,4 @@
-import {useScene} from '@motion-canvas/core';
+import {useScene} from '@revideo/core';
 import type {Scene2D} from './Scene2D';
 
 export function useScene2D(): Scene2D {

--- a/packages/2d/src/lib/tsconfig.json
+++ b/packages/2d/src/lib/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "types": ["node"],
     "jsx": "react-jsx",
-    "jsxImportSource": "@motion-canvas/2d/src/lib",
+    "jsxImportSource": "@revideo/2d/src/lib",
     "plugins": [
       {
-        "transform": "@motion-canvas/internal/transformers/markdown-literals.js"
+        "transform": "@revideo/internal/transformers/markdown-literals.js"
       }
     ]
   },

--- a/packages/2d/src/lib/utils/CanvasUtils.ts
+++ b/packages/2d/src/lib/utils/CanvasUtils.ts
@@ -1,4 +1,4 @@
-import {BBox, Color, Spacing, Vector2} from '@motion-canvas/core';
+import {BBox, Color, Spacing, Vector2} from '@revideo/core';
 import {CanvasStyle, Gradient, Pattern, PossibleCanvasStyle} from '../partials';
 
 export function canvasStyleParser(style: PossibleCanvasStyle) {

--- a/packages/2d/src/lib/utils/makeSignalExtensions.ts
+++ b/packages/2d/src/lib/utils/makeSignalExtensions.ts
@@ -1,4 +1,4 @@
-import {SignalExtensions, capitalize} from '@motion-canvas/core';
+import {SignalExtensions, capitalize} from '@revideo/core';
 import {PropertyMetadata} from '../decorators';
 
 export function makeSignalExtensions<TSetterValue, TValue extends TSetterValue>(

--- a/packages/2d/tsconfig.project.json
+++ b/packages/2d/tsconfig.project.json
@@ -1,7 +1,7 @@
 {
-  "extends": "@motion-canvas/core/tsconfig.project.json",
+  "extends": "@revideo/core/tsconfig.project.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "@motion-canvas/2d/lib"
+    "jsxImportSource": "@revideo/2d/lib"
   }
 }

--- a/packages/2d/vitest.config.ts
+++ b/packages/2d/vitest.config.ts
@@ -1,4 +1,4 @@
-import markdownLiterals from '@motion-canvas/internal/vite/markdown-literals';
+import markdownLiterals from '@revideo/internal/vite/markdown-literals';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,265 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* **2d:** handle floating point errors in acos ([#381](https://github.com/havenhq/revideo/issues/381)) ([5bca8fd](https://github.com/havenhq/revideo/commit/5bca8fd0bbdcf28f2793c124b7d6b0afd560c4b8))
+* **core:** add missing type references ([#41](https://github.com/havenhq/revideo/issues/41)) ([325c244](https://github.com/havenhq/revideo/commit/325c2442814ca19407fe0060a819aded4456f90e))
+* **core:** clear DependencyContext promises once resolved ([#617](https://github.com/havenhq/revideo/issues/617)) ([97b68da](https://github.com/havenhq/revideo/commit/97b68dabfdf86c0e0a188212308b8aba0fb35cab))
+* **core:** clear semi-transparent backgrounds ([#424](https://github.com/havenhq/revideo/issues/424)) ([1ebff1c](https://github.com/havenhq/revideo/commit/1ebff1c92bebce56d11c61eb9dadca47f5a80ac1)), closes [#423](https://github.com/havenhq/revideo/issues/423)
+* **core:** fix looping ([#217](https://github.com/havenhq/revideo/issues/217)) ([a38e1a7](https://github.com/havenhq/revideo/commit/a38e1a7c8fc21384cc17f3f982802071b8cd0cbf)), closes [#178](https://github.com/havenhq/revideo/issues/178)
+* **core:** fix playback state ([#471](https://github.com/havenhq/revideo/issues/471)) ([1c259d0](https://github.com/havenhq/revideo/commit/1c259d0d574bb56dbc8bc448300d9b94ee4d0bc4))
+* **core:** fix relative time ([#461](https://github.com/havenhq/revideo/issues/461)) ([8d4946e](https://github.com/havenhq/revideo/commit/8d4946ebf56590bc3934087f95955180b4901566))
+* **core:** fix snapshots ([#638](https://github.com/havenhq/revideo/issues/638)) ([437cc5e](https://github.com/havenhq/revideo/commit/437cc5efddbb242b10f7902e18fe15162a45d7bd))
+* **core:** fix tree shaking ([#555](https://github.com/havenhq/revideo/issues/555)) ([8de199e](https://github.com/havenhq/revideo/commit/8de199eaf833622a96ad746c984fb7f3a77df4b8))
+* **core:** fix Vector2.exactlyEquals ([#437](https://github.com/havenhq/revideo/issues/437)) ([028d264](https://github.com/havenhq/revideo/commit/028d26499d8f3fb34500b22e8dcde2d080c2e2b0))
+* **core:** handle malicious event names ([#819](https://github.com/havenhq/revideo/issues/819)) ([aba8eba](https://github.com/havenhq/revideo/commit/aba8ebaf347ac3cbf6a9446c1aa60f629c7c18bd))
+* **core:** keep falsy values with deepTween ([#45](https://github.com/havenhq/revideo/issues/45)) ([93c934f](https://github.com/havenhq/revideo/commit/93c934f9b59462581267cca5033bf132b831ce54))
+* **core:** playback speed is reset after saving with faulty code ([#204](https://github.com/havenhq/revideo/issues/204)). ([#339](https://github.com/havenhq/revideo/issues/339)) ([6771e5e](https://github.com/havenhq/revideo/commit/6771e5e17edcdc4cce074d7da0962cf71ba6c228))
+* **core:** project `variables` ([#690](https://github.com/havenhq/revideo/issues/690)) ([149f39c](https://github.com/havenhq/revideo/commit/149f39c3219aa74115be80490bd6c5f236779b0e)), closes [#689](https://github.com/havenhq/revideo/issues/689)
+* **core:** render only within the range ([#436](https://github.com/havenhq/revideo/issues/436)) ([36ccebe](https://github.com/havenhq/revideo/commit/36ccebe5321d84eeaa16f8b74a79c1001ee7ac0b))
+* correctly await re-renders ([#918](https://github.com/havenhq/revideo/issues/918)) ([873a9a3](https://github.com/havenhq/revideo/commit/873a9a3eed2676de4cc7f31fbd5ea58817a80aff))
+* **docs:** fix last updated footer ([#776](https://github.com/havenhq/revideo/issues/776)) ([09c0085](https://github.com/havenhq/revideo/commit/09c008587fcd4b52edbc5e7599ee378482f4230b)), closes [#767](https://github.com/havenhq/revideo/issues/767)
+* empty time events crashing ([a1c53de](https://github.com/havenhq/revideo/commit/a1c53deba7c405ddf1a3b4874f22b63e0b085af9))
+* fix compound property setter ([#218](https://github.com/havenhq/revideo/issues/218)) ([6cd1b95](https://github.com/havenhq/revideo/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)), closes [#208](https://github.com/havenhq/revideo/issues/208) [#210](https://github.com/havenhq/revideo/issues/210)
+* fix dependency bundling ([#897](https://github.com/havenhq/revideo/issues/897)) ([5376012](https://github.com/havenhq/revideo/commit/5376012cd02b8bca5abc2d3cf5a724662244c449))
+* fix scaffolding ([#93](https://github.com/havenhq/revideo/issues/93)) ([95c55ed](https://github.com/havenhq/revideo/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
+* fix tsdoc comments ([#21](https://github.com/havenhq/revideo/issues/21)) ([4b6cb66](https://github.com/havenhq/revideo/commit/4b6cb660ad82befcfd41188c7a8f9c8c0cba93ed)), closes [#18](https://github.com/havenhq/revideo/issues/18)
+* improper cloning of custom fields ([#925](https://github.com/havenhq/revideo/issues/925)) ([4981da7](https://github.com/havenhq/revideo/commit/4981da74e7b2b0e106fa14f1af2eac62d2bf82f4))
+* limit fps to positive numbers ([#937](https://github.com/havenhq/revideo/issues/937)) ([c7c0c67](https://github.com/havenhq/revideo/commit/c7c0c6730e1a00e6b23077188bfc2d389e98cff2)), closes [#936](https://github.com/havenhq/revideo/issues/936)
+* plug memory leaks ([#385](https://github.com/havenhq/revideo/issues/385)) ([de0af00](https://github.com/havenhq/revideo/commit/de0af00a7d2e019e2a933791c62b7901755be7b0))
+* prevent Color tree shaking ([#666](https://github.com/havenhq/revideo/issues/666)) ([e5028e3](https://github.com/havenhq/revideo/commit/e5028e3c176d5ba74dd3f28c2f25672390c76936)), closes [#577](https://github.com/havenhq/revideo/issues/577)
+* prevent consumePromises from halting ([#657](https://github.com/havenhq/revideo/issues/657)) ([363a189](https://github.com/havenhq/revideo/commit/363a189b0c7f5926c9d5ae00b58b48e8ed4d9b48))
+* previous scene being rendered twice ([#97](https://github.com/havenhq/revideo/issues/97)) ([90205bd](https://github.com/havenhq/revideo/commit/90205bdc1a086abe5f73b04cb4616c6af5ec4377))
+* restrict size of cache canvas ([#544](https://github.com/havenhq/revideo/issues/544)) ([49ec554](https://github.com/havenhq/revideo/commit/49ec55490718e503d9a39437ae13c189dc4fe9ea))
+* support color to null tweening ([#387](https://github.com/havenhq/revideo/issues/387)) ([02e9f22](https://github.com/havenhq/revideo/commit/02e9f22027a1c3a85ffcc259aeca913318fb6f54))
+* support hmr when navigating ([370ea16](https://github.com/havenhq/revideo/commit/370ea1676a1c34313c0fb917c0f0691538f72016))
+* support legacy imports again ([#868](https://github.com/havenhq/revideo/issues/868)) ([77c4e2e](https://github.com/havenhq/revideo/commit/77c4e2eeb8b0f73bdef1f72e3d81f34c79748929))
+* support multiple async players ([#450](https://github.com/havenhq/revideo/issues/450)) ([d7ec469](https://github.com/havenhq/revideo/commit/d7ec469e747eefd909f4dd59dd713f5d86308222)), closes [#434](https://github.com/havenhq/revideo/issues/434)
+* use correct scene sizes ([#146](https://github.com/havenhq/revideo/issues/146)) ([f279638](https://github.com/havenhq/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+
+
+### Code Refactoring
+
+* introduce improved names ([#425](https://github.com/havenhq/revideo/issues/425)) ([4a2188d](https://github.com/havenhq/revideo/commit/4a2188d339587fa658b2134befc3fe63c835c5d7))
+
+
+### Features
+
+* **2d:** add default computed values for signals ([#259](https://github.com/havenhq/revideo/issues/259)) ([18f61a6](https://github.com/havenhq/revideo/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
+* **2d:** add fromDegrees method to Vector2 ([#622](https://github.com/havenhq/revideo/issues/622)) ([e78b9d5](https://github.com/havenhq/revideo/commit/e78b9d51674269ab82e0c2fe4c475b5799b94975))
+* **2d:** add Path component ([#700](https://github.com/havenhq/revideo/issues/700)) ([2128b6b](https://github.com/havenhq/revideo/commit/2128b6bf871cabe19e1abc749f18945c78c01f84))
+* **2d:** add save and restore methods to nodes ([#406](https://github.com/havenhq/revideo/issues/406)) ([870e194](https://github.com/havenhq/revideo/commit/870e1947d97382bc6d82857c077140bbef7cf7e8))
+* **2d:** code bounding box helpers ([#948](https://github.com/havenhq/revideo/issues/948)) ([0ffd56f](https://github.com/havenhq/revideo/commit/0ffd56f5f8076913e687e5b908311aa7832d8b7b))
+* **2d:** improve property declarations ([27e7d26](https://github.com/havenhq/revideo/commit/27e7d267ee91bf1e8ca79686b6ec31347f9f4d41))
+* **2d:** improve Rect corner radius ([#120](https://github.com/havenhq/revideo/issues/120)) ([b471fe0](https://github.com/havenhq/revideo/commit/b471fe0e37c0a426d3af8299c9c3c22539e7df05))
+* **2d:** nested Txt nodes ([#861](https://github.com/havenhq/revideo/issues/861)) ([f2786d0](https://github.com/havenhq/revideo/commit/f2786d0cd0d06065ca1e9eb9f6b4c11a74b6c283)), closes [#540](https://github.com/havenhq/revideo/issues/540)
+* **2d:** support tweening in applyState ([#859](https://github.com/havenhq/revideo/issues/859)) ([b7ed2e2](https://github.com/havenhq/revideo/commit/b7ed2e24773227e5b576ff056eb23de9b9ff1676))
+* add `useDuration` helper ([#226](https://github.com/havenhq/revideo/issues/226)) ([fa97d6c](https://github.com/havenhq/revideo/commit/fa97d6c7f076f287c9b86d2f8852341bd368ef1c)), closes [#171](https://github.com/havenhq/revideo/issues/171)
+* add advanced caching ([#69](https://github.com/havenhq/revideo/issues/69)) ([2a644c9](https://github.com/havenhq/revideo/commit/2a644c9315acfcc5280a5eacc9904df140a61e4f))
+* add audio volume control through arrow keys ([#856](https://github.com/havenhq/revideo/issues/856)) ([8b86fd4](https://github.com/havenhq/revideo/commit/8b86fd4e70f91a0d5b1150d760427ca355666341))
+* add base class for shapes ([#67](https://github.com/havenhq/revideo/issues/67)) ([d38c172](https://github.com/havenhq/revideo/commit/d38c1724e129c553739cbfc27c4e5cd8f737f067))
+* add basic logger ([#88](https://github.com/havenhq/revideo/issues/88)) ([3d82e86](https://github.com/havenhq/revideo/commit/3d82e863af3dc88b3709adbcd0b84e790d05c3b8)), closes [#17](https://github.com/havenhq/revideo/issues/17)
+* add basic transform to Node class ([#83](https://github.com/havenhq/revideo/issues/83)) ([9e114c8](https://github.com/havenhq/revideo/commit/9e114c8830a99c78e6a4fd9265b0e7552758af14))
+* add cloning ([#80](https://github.com/havenhq/revideo/issues/80)) ([47d7a0f](https://github.com/havenhq/revideo/commit/47d7a0fa5da9a03d8ed91557db651f6f960e28b1))
+* add CodeBlock component based on code-fns to 2D ([#78](https://github.com/havenhq/revideo/issues/78)) ([ad346f1](https://github.com/havenhq/revideo/commit/ad346f118d63b1e321ec315e1c70b925670124a1))
+* add coordinates to preview ([#737](https://github.com/havenhq/revideo/issues/737)) ([330c1f9](https://github.com/havenhq/revideo/commit/330c1f962fb920269301e7ee8a2c49cbfc723d85))
+* add default renderer ([#63](https://github.com/havenhq/revideo/issues/63)) ([9255490](https://github.com/havenhq/revideo/commit/92554900965fe088538f5e703dbab2fd84f904d7)), closes [#56](https://github.com/havenhq/revideo/issues/56) [#58](https://github.com/havenhq/revideo/issues/58)
+* add DEG2RAD and RAD2DEG constants ([#630](https://github.com/havenhq/revideo/issues/630)) ([01801e8](https://github.com/havenhq/revideo/commit/01801e8766058e75a6a020400650fb00f8f430cc))
+* add deprecation support ([#130](https://github.com/havenhq/revideo/issues/130)) ([da0e104](https://github.com/havenhq/revideo/commit/da0e104451af72eedb3eedd998f60b305fffdb0e))
+* add docs to monorepo ([#22](https://github.com/havenhq/revideo/issues/22)) ([129d557](https://github.com/havenhq/revideo/commit/129d557004c63df7a4ed514d0503709f03cf6e6b))
+* add E2E testing ([#101](https://github.com/havenhq/revideo/issues/101)) ([6398c54](https://github.com/havenhq/revideo/commit/6398c54e4c4d6667ce9f45b9bbef6ea110ea2215)), closes [#42](https://github.com/havenhq/revideo/issues/42)
+* add experimental features ([#876](https://github.com/havenhq/revideo/issues/876)) ([498d387](https://github.com/havenhq/revideo/commit/498d3871d05d4dcc83453654bec7762d2ab32e7e))
+* add Grid node ([e1f83da](https://github.com/havenhq/revideo/commit/e1f83da1f43d20d392df4acb11e3df9cc457585d))
+* add inspection ([#82](https://github.com/havenhq/revideo/issues/82)) ([4d7f2ae](https://github.com/havenhq/revideo/commit/4d7f2aee6daeda1a2146b632dfdc28b455295776))
+* add markdown logs ([#138](https://github.com/havenhq/revideo/issues/138)) ([e42447a](https://github.com/havenhq/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+* add new hooks for plugins ([#679](https://github.com/havenhq/revideo/issues/679)) ([74e18bc](https://github.com/havenhq/revideo/commit/74e18bce71abd7e26a6415240603241b48cb36c2))
+* add node spawners ([#149](https://github.com/havenhq/revideo/issues/149)) ([da18a4e](https://github.com/havenhq/revideo/commit/da18a4e24104022a84ecd6cec1666b520186058f))
+* add option to group output by scenes ([#477](https://github.com/havenhq/revideo/issues/477)) ([9934593](https://github.com/havenhq/revideo/commit/99345937e7ac92fb674fdee10288e467ffd941e2))
+* add polyline ([#84](https://github.com/havenhq/revideo/issues/84)) ([4ceaf84](https://github.com/havenhq/revideo/commit/4ceaf842915ac43d81f292c58a4dc73a8d1bb8e9))
+* add random number generator ([#116](https://github.com/havenhq/revideo/issues/116)) ([d505312](https://github.com/havenhq/revideo/commit/d5053123eef308c7a2a61d92b6e76c637f4ed0b8)), closes [#14](https://github.com/havenhq/revideo/issues/14)
+* add rendering again ([#43](https://github.com/havenhq/revideo/issues/43)) ([c10d3db](https://github.com/havenhq/revideo/commit/c10d3dbb63f6248eda04128ef0aa9d72c1edfcf7))
+* add reparent helper ([80b95a9](https://github.com/havenhq/revideo/commit/80b95a9ce89d4a2eeea7e467257486e961602d69))
+* add scaffolding package ([#36](https://github.com/havenhq/revideo/issues/36)) ([266a561](https://github.com/havenhq/revideo/commit/266a561c619b57b403ec9c64185985b48bff29da)), closes [#30](https://github.com/havenhq/revideo/issues/30)
+* add Text and Image components ([#70](https://github.com/havenhq/revideo/issues/70)) ([85c7dcd](https://github.com/havenhq/revideo/commit/85c7dcdb4f8ca2f0bfb03950c85a8d6f6652fcdf))
+* add video node ([#86](https://github.com/havenhq/revideo/issues/86)) ([f4aa654](https://github.com/havenhq/revideo/commit/f4aa65437a18cc85b00199f80cd5e04654c00c4b))
+* added file type and quality options to rendering panel ([#50](https://github.com/havenhq/revideo/issues/50)) ([bee71ef](https://github.com/havenhq/revideo/commit/bee71ef2673c269db47a4433831720b7ad0fb4e8)), closes [#24](https://github.com/havenhq/revideo/issues/24)
+* application settings ([#697](https://github.com/havenhq/revideo/issues/697)) ([54016f5](https://github.com/havenhq/revideo/commit/54016f5cf3500abe13a217537307a3735d60f536)), closes [#167](https://github.com/havenhq/revideo/issues/167)
+* auto meta fields ([#565](https://github.com/havenhq/revideo/issues/565)) ([645af6d](https://github.com/havenhq/revideo/commit/645af6d2b7e8d9332b6f08419c318ee9434d7f3f))
+* better naming conventions ([#62](https://github.com/havenhq/revideo/issues/62)) ([a9d764f](https://github.com/havenhq/revideo/commit/a9d764fbceb639497ef45f44c90f9b6e408213d3))
+* convert built-in types to webgl ([#929](https://github.com/havenhq/revideo/issues/929)) ([a0f0b7d](https://github.com/havenhq/revideo/commit/a0f0b7d8996547e1a316097422ec02bddeeccec6))
+* **core:** accept PossibleMatrix2D when transforming bbox ([#770](https://github.com/havenhq/revideo/issues/770)) ([ae05282](https://github.com/havenhq/revideo/commit/ae0528266f5794aa0517f32b897c5fe6ff092a58))
+* **core:** add `debug` helper function ([#293](https://github.com/havenhq/revideo/issues/293)) ([b870873](https://github.com/havenhq/revideo/commit/b8708732af0fc08d9ff9eeecbbb77d65f1b36eb8))
+* **core:** add `gauss` function to `Random` ([#709](https://github.com/havenhq/revideo/issues/709)) ([d7de3d5](https://github.com/havenhq/revideo/commit/d7de3d56d05dc88c7cbd557a73a25d083abb54e4))
+* **core:** add `loopFor` function ([#650](https://github.com/havenhq/revideo/issues/650)) ([a42eb52](https://github.com/havenhq/revideo/commit/a42eb520fef7de06038f0df9eaad1fa35122c97a))
+* **core:** add `loopUntil` function ([#624](https://github.com/havenhq/revideo/issues/624)) ([b7aa4b5](https://github.com/havenhq/revideo/commit/b7aa4b57c76374e67bd19ce40c44cd650cf67327))
+* **core:** add configurable line numbers ([#44](https://github.com/havenhq/revideo/issues/44)) ([831334c](https://github.com/havenhq/revideo/commit/831334ca32a504991e875af37446fef4f055c285)), closes [#12](https://github.com/havenhq/revideo/issues/12)
+* **core:** add fadeTransition ([#384](https://github.com/havenhq/revideo/issues/384)) ([a248785](https://github.com/havenhq/revideo/commit/a248785e87d1c6ebc08581f4fda6be428a89824c))
+* **core:** add helper method for arc lerps ([#640](https://github.com/havenhq/revideo/issues/640)) ([bc304d2](https://github.com/havenhq/revideo/commit/bc304d242e4819650fa86636180ac5594ba743d3))
+* **core:** add intersects method to BBox ([#485](https://github.com/havenhq/revideo/issues/485)) ([604b0e7](https://github.com/havenhq/revideo/commit/604b0e7c22b4e5d196310e650f7c764526a80712))
+* **core:** add Matrix2D type ([#340](https://github.com/havenhq/revideo/issues/340)) ([66b41e6](https://github.com/havenhq/revideo/commit/66b41e6beaca5c2ba4b6bd1a7e68ca16d183b0e9))
+* **core:** add rotate and polarLerp methods to vector ([#756](https://github.com/havenhq/revideo/issues/756)) ([a18bac3](https://github.com/havenhq/revideo/commit/a18bac3c1755fa3e3240b5469ac7bc1f08b4fd24))
+* **core:** add spring interpolation ([#356](https://github.com/havenhq/revideo/issues/356)) ([1463b15](https://github.com/havenhq/revideo/commit/1463b1592e22fad9d8298c11270e2099119e2229))
+* **core:** add static properties to Vector2 corresponding to Origins ([#855](https://github.com/havenhq/revideo/issues/855)) ([9bbd249](https://github.com/havenhq/revideo/commit/9bbd249e1f7864a49ff2da49bc18d9309888f902)), closes [#844](https://github.com/havenhq/revideo/issues/844)
+* **core:** add step parameter to range function ([#373](https://github.com/havenhq/revideo/issues/373)) ([923209a](https://github.com/havenhq/revideo/commit/923209a4106c8e7f570853dcc47a10e65e0d04d8))
+* **core:** additional easing functions ([#274](https://github.com/havenhq/revideo/issues/274)) ([f81ce43](https://github.com/havenhq/revideo/commit/f81ce43019fe253e99f4ab6311c2251b40e2eae3))
+* **core:** allow getting real size of scenes ([#889](https://github.com/havenhq/revideo/issues/889)) ([3a6a672](https://github.com/havenhq/revideo/commit/3a6a672bed9098bec81d9c5347459317cbbf4c2a))
+* **core:** allow ordering of scenes during transition ([#832](https://github.com/havenhq/revideo/issues/832)) ([7a62b59](https://github.com/havenhq/revideo/commit/7a62b59c377dca8bf1f56bb551b47b9a75a6afba)), closes [#369](https://github.com/havenhq/revideo/issues/369)
+* **core:** disallow tweening to/from undefined values ([#257](https://github.com/havenhq/revideo/issues/257)) ([d4bb791](https://github.com/havenhq/revideo/commit/d4bb79145300b52c4b4d101df2afaff5ea11a9e9))
+* **core:** error double event name ([#341](https://github.com/havenhq/revideo/issues/341)) ([053b2a6](https://github.com/havenhq/revideo/commit/053b2a6c22c4e726e3962fdaf0a2e8d149889a9b))
+* **core:** expand Vector2 type ([#579](https://github.com/havenhq/revideo/issues/579)) ([010bba5](https://github.com/havenhq/revideo/commit/010bba593e1c3ce368ab409dce09dbde8f999958))
+* **core:** helper methods for references ([#775](https://github.com/havenhq/revideo/issues/775)) ([3255add](https://github.com/havenhq/revideo/commit/3255add1b05a37017d60c2eaccf4368ab4f7f568))
+* **core:** hot module replacement for audio ([#793](https://github.com/havenhq/revideo/issues/793)) ([d40c1a8](https://github.com/havenhq/revideo/commit/d40c1a83c645c8984cca1ebc6fe687b445a0550c))
+* **core:** improve `SignalGenerator` chaining ([#651](https://github.com/havenhq/revideo/issues/651)) ([de72f1f](https://github.com/havenhq/revideo/commit/de72f1f70edf7cc48fd670d9b38e0cc27f8bdb57)), closes [#480](https://github.com/havenhq/revideo/issues/480)
+* **core:** improve loop function ([#952](https://github.com/havenhq/revideo/issues/952)) ([66c18bb](https://github.com/havenhq/revideo/commit/66c18bb41617a4fbe9e3be5253b3ced02caf0cae))
+* **core:** presentation mode ([#486](https://github.com/havenhq/revideo/issues/486)) ([c4f2e48](https://github.com/havenhq/revideo/commit/c4f2e48ae6c65804ae46edd88c29125b7f983d5c))
+* **core:** preserve custom fields in meta files ([#534](https://github.com/havenhq/revideo/issues/534)) ([2e3e22e](https://github.com/havenhq/revideo/commit/2e3e22efd62ba671624526fc10ea7dd2a04a5240))
+* **core:** seek to beginning of timeline in disable loop mode ([#823](https://github.com/havenhq/revideo/issues/823)) ([3595646](https://github.com/havenhq/revideo/commit/359564645575c6f20870f4bf9642e72404717f14)), closes [#822](https://github.com/havenhq/revideo/issues/822)
+* **core:** spawn function ([#951](https://github.com/havenhq/revideo/issues/951)) ([51d8cf0](https://github.com/havenhq/revideo/commit/51d8cf0b64592fe56a0e31b5c3acc155226a9b2e))
+* **core:** support Origin in slideTransition ([#801](https://github.com/havenhq/revideo/issues/801)) ([0a3df28](https://github.com/havenhq/revideo/commit/0a3df2829fd7b308604eda3d005e90daf032e284))
+* **core:** switch to vitest ([#99](https://github.com/havenhq/revideo/issues/99)) ([762eeb0](https://github.com/havenhq/revideo/commit/762eeb0a99c2f378d20dbd147f815ba6736099d9)), closes [#48](https://github.com/havenhq/revideo/issues/48)
+* **core:** thread pausing ([#639](https://github.com/havenhq/revideo/issues/639)) ([c0aab58](https://github.com/havenhq/revideo/commit/c0aab588b18c267d3bc04e25b2f80c792496dda2))
+* **core:** tree shaking ([#523](https://github.com/havenhq/revideo/issues/523)) ([65fec78](https://github.com/havenhq/revideo/commit/65fec7825fda33812b13f57bfeb1d82193a5d190))
+* detect circular signal dependencies ([#129](https://github.com/havenhq/revideo/issues/129)) ([6fcdb41](https://github.com/havenhq/revideo/commit/6fcdb41df90dca1c39537a4f6d4960ab551f4d6e))
+* display array values in inspector ([#670](https://github.com/havenhq/revideo/issues/670)) ([e71d74c](https://github.com/havenhq/revideo/commit/e71d74c9c04995393ad8ee942b8e6e5baa6f982f))
+* display current package versions ([#501](https://github.com/havenhq/revideo/issues/501)) ([2972f67](https://github.com/havenhq/revideo/commit/2972f673e201310e69688ab6f2c1adf1cddf2bf3))
+* **docs:** fiddle editor ([#542](https://github.com/havenhq/revideo/issues/542)) ([3c68fef](https://github.com/havenhq/revideo/commit/3c68fefdf7bf375ee9345aba7dbf9e5ff35e3c3d))
+* editor improvements ([#121](https://github.com/havenhq/revideo/issues/121)) ([e8b32ce](https://github.com/havenhq/revideo/commit/e8b32ceff1b8216282c4b5713508ce1172645e20))
+* export everything from entry points ([#710](https://github.com/havenhq/revideo/issues/710)) ([3c885d9](https://github.com/havenhq/revideo/commit/3c885d9083b52fbbaccf1e2560ae50817949bc52))
+* extract konva to separate package ([#60](https://github.com/havenhq/revideo/issues/60)) ([4ecad3c](https://github.com/havenhq/revideo/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
+* finalize custom exporters ([#660](https://github.com/havenhq/revideo/issues/660)) ([6a50430](https://github.com/havenhq/revideo/commit/6a50430cdf9928992ca078eba39c484a5253da2b))
+* implement absolute scale setter ([842079a](https://github.com/havenhq/revideo/commit/842079a6547af4032719c85837df3db7c1c6d30a))
+* improve async signals ([#156](https://github.com/havenhq/revideo/issues/156)) ([db27b9d](https://github.com/havenhq/revideo/commit/db27b9d5fb69a88f42afd98c86c4a1cdceb88ea1))
+* improve error logs ([#953](https://github.com/havenhq/revideo/issues/953)) ([3b528cc](https://github.com/havenhq/revideo/commit/3b528cce13a3440c97641d1095ce09e737e89960))
+* improve image error handling ([#847](https://github.com/havenhq/revideo/issues/847)) ([db09d53](https://github.com/havenhq/revideo/commit/db09d5305a3c0507b035e3cd347eaa65b23d7d2e))
+* introduce basic caching ([#68](https://github.com/havenhq/revideo/issues/68)) ([6420d36](https://github.com/havenhq/revideo/commit/6420d362d0e4ae058f55b6ff6bb2a3a32dec559b))
+* introduce editor plugins ([#879](https://github.com/havenhq/revideo/issues/879)) ([2b72007](https://github.com/havenhq/revideo/commit/2b720074d45fc254dc40b534785b591ae44a3f37))
+* make exporting concurrent ([4f9ef8d](https://github.com/havenhq/revideo/commit/4f9ef8d40d9d9c1147e2edfc0766c5ea5cc4297c))
+* make scenes independent of names ([#53](https://github.com/havenhq/revideo/issues/53)) ([417617e](https://github.com/havenhq/revideo/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)), closes [#25](https://github.com/havenhq/revideo/issues/25)
+* merge properties and signals ([#124](https://github.com/havenhq/revideo/issues/124)) ([da3ba83](https://github.com/havenhq/revideo/commit/da3ba83d82ee74f5a5c3631b07597f08cdf9e8e4))
+* meta field descriptions ([#664](https://github.com/havenhq/revideo/issues/664)) ([80c9d07](https://github.com/havenhq/revideo/commit/80c9d07f88f4a3df0f99e5741b31313f891a5d51))
+* minor improvements ([403c7c2](https://github.com/havenhq/revideo/commit/403c7c27ad969880a14c498ec6cefb9e7e7b7544))
+* minor improvements ([#77](https://github.com/havenhq/revideo/issues/77)) ([7c6e584](https://github.com/havenhq/revideo/commit/7c6e584aca353c9af55f0acb61b32b5f99727dba))
+* navigate to scene and node source ([#144](https://github.com/havenhq/revideo/issues/144)) ([86d495d](https://github.com/havenhq/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+* navigate to slide source ([#490](https://github.com/havenhq/revideo/issues/490)) ([b5ae4bf](https://github.com/havenhq/revideo/commit/b5ae4bf37076b262a20949cca030db3902186c8d))
+* new animator ([#91](https://github.com/havenhq/revideo/issues/91)) ([d85f2f8](https://github.com/havenhq/revideo/commit/d85f2f8a54c0f8bbfbc451884385f30e5b3ec206))
+* new Code node ([#946](https://github.com/havenhq/revideo/issues/946)) ([26e55a3](https://github.com/havenhq/revideo/commit/26e55a37c416fb1313c8aadf40eed2824b45d330))
+* new playback architecture ([#402](https://github.com/havenhq/revideo/issues/402)) ([bbe3e2a](https://github.com/havenhq/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)), closes [#166](https://github.com/havenhq/revideo/issues/166)
+* new plugin hooks ([#723](https://github.com/havenhq/revideo/issues/723)) ([9a2b5ab](https://github.com/havenhq/revideo/commit/9a2b5ab8be0d001414fd00da3053d408e00fd1cd))
+* open time events in editor ([#87](https://github.com/havenhq/revideo/issues/87)) ([74b781d](https://github.com/havenhq/revideo/commit/74b781d57fca7ef1d10904673276f2a7354c01b8))
+* plugin architecture ([#564](https://github.com/havenhq/revideo/issues/564)) ([1c375b8](https://github.com/havenhq/revideo/commit/1c375b81e0af8a76467d42dd46a7031adb9d71d3))
+* project variables ([#255](https://github.com/havenhq/revideo/issues/255)) ([4883295](https://github.com/havenhq/revideo/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
+* signal error handling ([#89](https://github.com/havenhq/revideo/issues/89)) ([472ac65](https://github.com/havenhq/revideo/commit/472ac65938b804a6b698c8522ec0c3b6bdbcf1b1))
+* simplify size access further ([#66](https://github.com/havenhq/revideo/issues/66)) ([9091a5e](https://github.com/havenhq/revideo/commit/9091a5e05d8fadf72c50832c7c4467ac4424b72c))
+* support for multiple projects ([#57](https://github.com/havenhq/revideo/issues/57)) ([573752d](https://github.com/havenhq/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)), closes [#141414](https://github.com/havenhq/revideo/issues/141414)
+* support multiple players ([#128](https://github.com/havenhq/revideo/issues/128)) ([24f75cf](https://github.com/havenhq/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+* switch to monorepo ([6c8d190](https://github.com/havenhq/revideo/commit/6c8d190c7d3d24bb4eac29eeb4b6d1abf370e160)), closes [#23](https://github.com/havenhq/revideo/issues/23) [#86](https://github.com/havenhq/revideo/issues/86) [#49](https://github.com/havenhq/revideo/issues/49)
+* switch to signals ([#64](https://github.com/havenhq/revideo/issues/64)) ([d22d237](https://github.com/havenhq/revideo/commit/d22d23728597e6fa82ea5c5a99a6c0a56819bded))
+* switch to Vite ([#28](https://github.com/havenhq/revideo/issues/28)) ([65b9133](https://github.com/havenhq/revideo/commit/65b91337dbc47fe51cecc83657f79fab15343a0d)), closes [#141414](https://github.com/havenhq/revideo/issues/141414) [#13](https://github.com/havenhq/revideo/issues/13)
+* turn Layout into node ([#75](https://github.com/havenhq/revideo/issues/75)) ([cdf8dc0](https://github.com/havenhq/revideo/commit/cdf8dc0a35522482dee2dd78a69606b79f52246e))
+* **ui:** estimate remaining rendering time ([#795](https://github.com/havenhq/revideo/issues/795)) ([1a46148](https://github.com/havenhq/revideo/commit/1a4614801869ab36827ca857d66eed8de9cffd09)), closes [#784](https://github.com/havenhq/revideo/issues/784)
+* **ui:** small improvements ([#833](https://github.com/havenhq/revideo/issues/833)) ([f44400c](https://github.com/havenhq/revideo/commit/f44400c458a1d7f49520494f01efb9936f4df83e))
+* **ui:** timeline scrubbing ([#862](https://github.com/havenhq/revideo/issues/862)) ([211b9a4](https://github.com/havenhq/revideo/commit/211b9a4327720afd1ce0ff93868a501c2fd745aa)), closes [#286](https://github.com/havenhq/revideo/issues/286)
+* unify core types ([#71](https://github.com/havenhq/revideo/issues/71)) ([9c5853d](https://github.com/havenhq/revideo/commit/9c5853d8bc65204693c38109a25d1fefd44241b7))
+* unify references and signals ([#137](https://github.com/havenhq/revideo/issues/137)) ([063aede](https://github.com/havenhq/revideo/commit/063aede0842f948d2c6704c6edd426e954bb4668))
+* update vite from v3 to v4 ([#495](https://github.com/havenhq/revideo/issues/495)) ([c409eee](https://github.com/havenhq/revideo/commit/c409eee0e61b67e43afed240c5ae279714681246)), closes [#197](https://github.com/havenhq/revideo/issues/197)
+* use PossibleVector2 in Vector2 methods ([#478](https://github.com/havenhq/revideo/issues/478)) ([8ccb44a](https://github.com/havenhq/revideo/commit/8ccb44a265016e25b2b177a65d44f801c9d861f9))
+* **vite-plugin:** add CORS Proxy ([#357](https://github.com/havenhq/revideo/issues/357)) ([a3c5822](https://github.com/havenhq/revideo/commit/a3c58228b7d3dab08fc27414d19870d35773b280)), closes [#338](https://github.com/havenhq/revideo/issues/338)
+* webgl shaders ([#920](https://github.com/havenhq/revideo/issues/920)) ([849216e](https://github.com/havenhq/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+* world space cache ([#498](https://github.com/havenhq/revideo/issues/498)) ([633e9e1](https://github.com/havenhq/revideo/commit/633e9e140dfbbe397df6ddc1f96ed30782ddce94)), closes [#342](https://github.com/havenhq/revideo/issues/342)
+
+
+### Reverts
+
+* "ci(release): 9.1.3 [skip ci]" ([62953a6](https://github.com/havenhq/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+
+
+### BREAKING CHANGES
+
+* multiple name changes
+
+To avoid collisions, names of certain classes have changed:
+- `Text => Txt`
+- `Image => Img`
+- `Rect (type) => BBox`
+
+Cache related methods of `Node` have changed:
+- `getCacheRect => getCacheBBox`
+- `cacheRect => cacheBBox`
+- `fullCacheRect => fullCacheBBox`
+
+The `CodeBlock` property has changed:
+- `CodeBlock.selectionOpacity => CodeBlock.unselectedOpacity`
+* `makeProject` no longer accepts some settings.
+
+Settings such as `background` and `audioOffset` are now stored in the project
+meta file.
+* change names of timing and interpolation functions
+
+`TweenFunction` is now called `InterpolationFunction`.
+Individual functions are now called `[type]Lerp` instead of `[type]Tween`.
+For instance: `colorTween` is now `colorLerp`.
+
+`InterpolationFunction` is now called `TimingFunction`.
+This name is better aligned with the CSS spec.
+* change to import paths
+
+See [the migration guide](https://motion-canvas.github.io/guides/migration/12.0.0) for more info.
+* change the way scenes are imported
+
+Scene files no longer need to follow the pattern: `[name].scene.tsx`.
+When importing scenes in the project file, a dedicated `?scene` query param should be used:
+```ts
+import example from './scenes/example?scene';
+
+export default new Project({
+  name: 'project',
+  scenes: [example],
+});
+```
+* change the overall structure of a project
+
+`vite` and `@motion-canvas/vite-plugin` packages are now required to build a project:
+```
+npm i -D vite @motion-canvas/vite-plugin
+```
+The following `vite.config.ts` file needs to be created in the root of the project:
+```ts
+import {defineConfig} from 'vite';
+import motionCanvas from '@motion-canvas/vite-plugin';
+
+export default defineConfig({
+  plugins: [motionCanvas()],
+});
+```
+
+Types exposed by Motion Canvas are no longer global.
+An additional `motion-canvas.d.ts` file needs to be created in the `src` directory:
+```ts
+/// <reference types="@motion-canvas/core/project" />
+```
+
+ Finally, the `bootstrap` function no longer exists.
+ Project files should export an instance of the `Project` class instead:
+ ```ts
+ import {Project} from '@motion-canvas/core/lib';
+
+ import example from './scenes/example.scene';
+
+ export default new Project({
+   name: 'project',
+   scenes: [example],
+   // same options as in bootstrap() are available:
+
+
+
+
+
 ## [3.14.1](https://github.com/motion-canvas/motion-canvas/compare/v3.14.0...v3.14.1) (2024-02-06)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/core",
-  "version": "3.14.1",
+  "version": "0.1.0",
   "description": "A web-based framework for creating videos programmatically",
   "main": "lib/index.js",
   "author": "revideo",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@motion-canvas/core",
+  "name": "@revideo/core",
   "version": "3.14.1",
-  "description": "Web-based tool for creating animations programmatically",
+  "description": "A web-based framework for creating videos programmatically",
   "main": "lib/index.js",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "scripts": {
     "dev": "tspc -p tsconfig.build.json -w",
@@ -16,7 +16,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/motion-canvas/motion-canvas.git"
+    "url": "https://github.com/havenhq/revideo.git"
   },
   "files": [
     "lib",
@@ -29,7 +29,7 @@
     "chroma-js": "^2.4.2"
   },
   "devDependencies": {
-    "@motion-canvas/internal": "0.0.0",
+    "@revideo/internal": "0.0.0",
     "jsdom": "^22.1.0",
     "vitest": "^0.34.6"
   }

--- a/packages/core/rollup.config.mjs
+++ b/packages/core/rollup.config.mjs
@@ -1,4 +1,4 @@
-import typescript from '@motion-canvas/internal/rollup/typescript.mjs';
+import typescript from '@revideo/internal/rollup/typescript.mjs';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';

--- a/packages/core/src/app/ImageExporter.ts
+++ b/packages/core/src/app/ImageExporter.ts
@@ -29,7 +29,7 @@ interface ServerResponse {
  * @internal
  */
 export class ImageExporter implements Exporter {
-  public static readonly id = '@motion-canvas/core/image-sequence';
+  public static readonly id = '@revideo/core/image-sequence';
   public static readonly displayName = 'Image sequence';
 
   public static meta() {
@@ -61,7 +61,7 @@ export class ImageExporter implements Exporter {
 
   static {
     if (import.meta.hot) {
-      import.meta.hot.on('motion-canvas:export-ack', response => {
+      import.meta.hot.on('revideo:export-ack', response => {
         this.response.dispatch(response);
       });
     }
@@ -108,7 +108,7 @@ export class ImageExporter implements Exporter {
       }
 
       this.frameLookup.add(frame);
-      import.meta.hot!.send('motion-canvas:export', {
+      import.meta.hot!.send('revideo:export', {
         frame,
         sceneFrame,
         data: canvas.toDataURL(this.fileType, this.quality),

--- a/packages/core/src/app/Presenter.ts
+++ b/packages/core/src/app/Presenter.ts
@@ -32,8 +32,8 @@ export enum PresenterState {
   Aborting,
 }
 
-const NextSlide = Symbol('@motion-canvas/core/app/NextSlide');
-const PreviousSlide = Symbol('@motion-canvas/core/app/PreviousSlide');
+const NextSlide = Symbol('@revideo/core/app/NextSlide');
+const PreviousSlide = Symbol('@revideo/core/app/PreviousSlide');
 
 export class Presenter {
   public get onStateChanged() {

--- a/packages/core/src/app/Renderer.ts
+++ b/packages/core/src/app/Renderer.ts
@@ -172,7 +172,7 @@ export class Renderer {
       );
 
       if (import.meta.hot) {
-        import.meta.hot.send('motion-canvas:export', {
+        import.meta.hot.send('revideo:export', {
           frame,
           data: this.stage.finalBuffer.toDataURL('image/png'),
           mimeType: 'image/png',

--- a/packages/core/src/decorators/lazy.ts
+++ b/packages/core/src/decorators/lazy.ts
@@ -1,6 +1,4 @@
-const UNINITIALIZED = Symbol.for(
-  '@motion-canvas/core/decorators/UNINITIALIZED',
-);
+const UNINITIALIZED = Symbol.for('@revideo/core/decorators/UNINITIALIZED');
 
 /**
  * Create a lazy decorator.

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -1,3 +1,3 @@
-/// <reference types="@motion-canvas/internal" />
+/// <reference types="@revideo/internal" />
 
 declare type Callback = (...args: any[]) => void;

--- a/packages/core/src/media/AudioManager.ts
+++ b/packages/core/src/media/AudioManager.ts
@@ -18,7 +18,7 @@ export class AudioManager {
 
   public constructor(private readonly logger: Logger) {
     if (import.meta.hot) {
-      import.meta.hot.on('motion-canvas:assets', ({urls}) => {
+      import.meta.hot.on('revideo:assets', ({urls}) => {
         if (this.source && urls.includes(this.source)) {
           this.setSource(this.source);
         }

--- a/packages/core/src/meta/EnumMetaField.ts
+++ b/packages/core/src/meta/EnumMetaField.ts
@@ -6,7 +6,7 @@ import {MetaOption} from './MetaOption';
  */
 export class EnumMetaField<T> extends MetaField<T> {
   public static readonly symbol = Symbol.for(
-    '@motion-canvas/core/meta/EnumMetaField',
+    '@revideo/core/meta/EnumMetaField',
   );
   public readonly type = EnumMetaField.symbol;
 

--- a/packages/core/src/meta/MetaFile.ts
+++ b/packages/core/src/meta/MetaFile.ts
@@ -69,7 +69,7 @@ export class MetaFile<T> {
         delete MetaFile.sourceLookup[source];
         resolve();
       };
-      import.meta.hot!.send('motion-canvas:meta', {
+      import.meta.hot!.send('revideo:meta', {
         source,
         data,
       });
@@ -95,7 +95,7 @@ export class MetaFile<T> {
 
   static {
     if (import.meta.hot) {
-      import.meta.hot.on('motion-canvas:meta-ack', ({source}) => {
+      import.meta.hot.on('revideo:meta-ack', ({source}) => {
         this.sourceLookup[source]?.();
       });
     }

--- a/packages/core/src/meta/RangeMetaField.ts
+++ b/packages/core/src/meta/RangeMetaField.ts
@@ -14,7 +14,7 @@ export class RangeMetaField extends MetaField<
   [number, number]
 > {
   public static readonly symbol = Symbol.for(
-    '@motion-canvas/core/meta/RangeMetaField',
+    '@revideo/core/meta/RangeMetaField',
   );
   public readonly type = RangeMetaField.symbol;
 

--- a/packages/core/src/plugin/DefaultPlugin.ts
+++ b/packages/core/src/plugin/DefaultPlugin.ts
@@ -7,7 +7,7 @@ import {makePlugin} from './makePlugin';
  * @internal
  */
 export default makePlugin({
-  name: '@motion-canvas/core/default',
+  name: '@revideo/core/default',
   exporters() {
     return [ImageExporter];
   },

--- a/packages/core/src/signals/symbols.ts
+++ b/packages/core/src/signals/symbols.ts
@@ -1,1 +1,1 @@
-export const DEFAULT = Symbol.for('@motion-canvas/core/signals/default');
+export const DEFAULT = Symbol.for('@revideo/core/signals/default');

--- a/packages/core/src/types/BBox.ts
+++ b/packages/core/src/types/BBox.ts
@@ -26,7 +26,7 @@ export type RectSignal<T> = CompoundSignal<
 >;
 
 export class BBox implements Type, WebGLConvertible {
-  public static readonly symbol = Symbol.for('@motion-canvas/core/types/Rect');
+  public static readonly symbol = Symbol.for('@revideo/core/types/Rect');
 
   public x = 0;
   public y = 0;

--- a/packages/core/src/types/Color.ts
+++ b/packages/core/src/types/Color.ts
@@ -56,7 +56,7 @@ type ExtendedColor = Color;
 // iife prevents tree shaking from stripping our methods.
 const ExtendedColor: typeof Color = (() => {
   Color.symbol = Color.prototype.symbol = Symbol.for(
-    '@motion-canvas/core/types/Color',
+    '@revideo/core/types/Color',
   );
 
   Color.lerp = Color.prototype.lerp = (

--- a/packages/core/src/types/Matrix2D.ts
+++ b/packages/core/src/types/Matrix2D.ts
@@ -31,9 +31,7 @@ export type PossibleMatrix2D =
  *   - r(AB) = (rA)B = A(rB) does not hold for a Matrix2D
  */
 export class Matrix2D implements Type, WebGLConvertible {
-  public static readonly symbol = Symbol.for(
-    '@motion-canvas/core/types/Matrix2D',
-  );
+  public static readonly symbol = Symbol.for('@revideo/core/types/Matrix2D');
 
   public readonly values: Float32Array = new Float32Array(6);
   public static readonly identity: Matrix2D = new Matrix2D(1, 0, 0, 1, 0, 0);

--- a/packages/core/src/types/Spacing.ts
+++ b/packages/core/src/types/Spacing.ts
@@ -25,9 +25,7 @@ export type SpacingSignal<T> = CompoundSignal<
 >;
 
 export class Spacing implements Type, WebGLConvertible {
-  public static readonly symbol = Symbol.for(
-    '@motion-canvas/core/types/Spacing',
-  );
+  public static readonly symbol = Symbol.for('@revideo/core/types/Spacing');
 
   public top = 0;
   public right = 0;

--- a/packages/core/src/types/Vector.ts
+++ b/packages/core/src/types/Vector.ts
@@ -36,9 +36,7 @@ export type SimpleVector2Signal<T> = Signal<PossibleVector2, Vector2, T>;
  * Represents a two-dimensional vector.
  */
 export class Vector2 implements Type, WebGLConvertible {
-  public static readonly symbol = Symbol.for(
-    '@motion-canvas/core/types/Vector2',
-  );
+  public static readonly symbol = Symbol.for('@revideo/core/types/Vector2');
 
   public static readonly zero = new Vector2();
   public static readonly one = new Vector2(1, 1);

--- a/packages/core/src/vite-env.d.ts
+++ b/packages/core/src/vite-env.d.ts
@@ -4,9 +4,9 @@ import 'vite/types/customEvent';
 
 declare module 'vite/types/customEvent' {
   interface CustomEventMap {
-    'motion-canvas:meta': {source: string; data: any};
-    'motion-canvas:meta-ack': {source: string};
-    'motion-canvas:export': {
+    'revideo:meta': {source: string; data: any};
+    'revideo:meta-ack': {source: string};
+    'revideo:export': {
       data: string;
       subDirectories: string[];
       mimeType: string;
@@ -14,7 +14,7 @@ declare module 'vite/types/customEvent' {
       sceneFrame?: number;
       groupByScene?: boolean;
     };
-    'motion-canvas:export-ack': {frame: number};
-    'motion-canvas:assets': {urls: string[]};
+    'revideo:export-ack': {frame: number};
+    'revideo:assets': {urls: string[]};
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -15,7 +15,7 @@
     "experimentalDecorators": true,
     "plugins": [
       {
-        "transform": "@motion-canvas/internal/transformers/markdown-literals.js"
+        "transform": "@revideo/internal/transformers/markdown-literals.js"
       }
     ]
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,4 +1,4 @@
-import markdownLiterals from '@motion-canvas/internal/vite/markdown-literals';
+import markdownLiterals from '@revideo/internal/vite/markdown-literals';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.3](https://github.com/havenhq/revideo/compare/v0.1.2...v0.1.3) (2024-03-17)
+
+
+### Bug Fixes
+
+* revert version bump to 0.1.1 ([998aca2](https://github.com/havenhq/revideo/commit/998aca20439d46bb804fd8bf9b3776639bfb8103))
+
+
+
+
+
 ## [0.1.2](https://github.com/havenhq/revideo/compare/v0.1.1...v0.1.2) (2024-03-17)
 
 

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/havenhq/revideo/compare/v0.1.0...v0.1.1) (2024-03-17)
+
+
+### Bug Fixes
+
+* resolve import issues in quickstart project ([e839086](https://github.com/havenhq/revideo/commit/e8390869c087c92c9d448cd16e9cc648d6b2dbe0))
+
+
+
+
+
 
 
 **Note:** Version bump only for package @revideo/create

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,79 +3,79 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.14.2](https://github.com/motion-canvas/motion-canvas/compare/v3.14.1...v3.14.2) (2024-02-08)
+## [3.14.2](https://github.com/revideo/revideo/compare/v3.14.1...v3.14.2) (2024-02-08)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-
-
-
-
-## [3.14.1](https://github.com/motion-canvas/motion-canvas/compare/v3.14.0...v3.14.1) (2024-02-06)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 
 
 
 
-# [3.14.0](https://github.com/motion-canvas/motion-canvas/compare/v3.13.0...v3.14.0) (2024-02-04)
+## [3.14.1](https://github.com/revideo/revideo/compare/v3.14.0...v3.14.1) (2024-02-06)
+
+**Note:** Version bump only for package @revideo/create
+
+
+
+
+
+# [3.14.0](https://github.com/revideo/revideo/compare/v3.13.0...v3.14.0) (2024-02-04)
 
 
 ### Features
 
-* **create:** include simple animation ([#931](https://github.com/motion-canvas/motion-canvas/issues/931)) ([925f63f](https://github.com/motion-canvas/motion-canvas/commit/925f63f3588922224511b1687ac44ba7b9920d83))
+* **create:** include simple animation ([#931](https://github.com/revideo/revideo/issues/931)) ([925f63f](https://github.com/revideo/revideo/commit/925f63f3588922224511b1687ac44ba7b9920d83))
 
 
 
 
 
-# [3.13.0](https://github.com/motion-canvas/motion-canvas/compare/v3.12.4...v3.13.0) (2024-01-10)
+# [3.13.0](https://github.com/revideo/revideo/compare/v3.12.4...v3.13.0) (2024-01-10)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-
+**Note:** Version bump only for package @revideo/create
 
 
 
-## [3.12.4](https://github.com/motion-canvas/motion-canvas/compare/v3.12.3...v3.12.4) (2024-01-05)
+
+
+## [3.12.4](https://github.com/revideo/revideo/compare/v3.12.3...v3.12.4) (2024-01-05)
 
 
 ### Reverts
 
-* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/motion-canvas/motion-canvas/issues/908)) ([86c5170](https://github.com/motion-canvas/motion-canvas/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
+* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/revideo/revideo/issues/908)) ([86c5170](https://github.com/revideo/revideo/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
 
 
 
 
 
-## [3.12.3](https://github.com/motion-canvas/motion-canvas/compare/v3.12.2...v3.12.3) (2024-01-04)
+## [3.12.3](https://github.com/revideo/revideo/compare/v3.12.2...v3.12.3) (2024-01-04)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-
-
-
-
-## [3.12.2](https://github.com/motion-canvas/motion-canvas/compare/v3.12.1...v3.12.2) (2023-12-31)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 
 
 
 
-## [3.12.1](https://github.com/motion-canvas/motion-canvas/compare/v3.12.0...v3.12.1) (2023-12-31)
+## [3.12.2](https://github.com/revideo/revideo/compare/v3.12.1...v3.12.2) (2023-12-31)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-
+**Note:** Version bump only for package @revideo/create
 
 
 
-# [3.12.0](https://github.com/motion-canvas/motion-canvas/compare/v3.11.0...v3.12.0) (2023-12-31)
 
-**Note:** Version bump only for package @motion-canvas/create
+
+## [3.12.1](https://github.com/revideo/revideo/compare/v3.12.0...v3.12.1) (2023-12-31)
+
+**Note:** Version bump only for package @revideo/create
+
+
+
+
+
+# [3.12.0](https://github.com/revideo/revideo/compare/v3.11.0...v3.12.0) (2023-12-31)
+
+**Note:** Version bump only for package @revideo/create
 
 
 
@@ -86,269 +86,269 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.11.0](https://github.com/motion-canvas/motion-canvas/compare/v3.10.1...v3.11.0) (2023-10-13)
+# [3.11.0](https://github.com/revideo/revideo/compare/v3.10.1...v3.11.0) (2023-10-13)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [3.10.1](https://github.com/motion-canvas/motion-canvas/compare/v3.10.0...v3.10.1) (2023-07-25)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.10.0](https://github.com/motion-canvas/motion-canvas/compare/v3.9.0...v3.10.0) (2023-07-23)
+## [3.10.1](https://github.com/revideo/revideo/compare/v3.10.0...v3.10.1) (2023-07-25)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [3.9.0](https://github.com/motion-canvas/motion-canvas/compare/v3.8.0...v3.9.0) (2023-05-29)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.8.0](https://github.com/motion-canvas/motion-canvas/compare/v3.7.0...v3.8.0) (2023-05-13)
+# [3.10.0](https://github.com/revideo/revideo/compare/v3.9.0...v3.10.0) (2023-07-23)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.9.0](https://github.com/revideo/revideo/compare/v3.8.0...v3.9.0) (2023-05-29)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.8.0](https://github.com/revideo/revideo/compare/v3.7.0...v3.8.0) (2023-05-13)
 
 ### Features
 
 - **create:** add exporter selection
-  ([#673](https://github.com/motion-canvas/motion-canvas/issues/673))
-  ([82fd47d](https://github.com/motion-canvas/motion-canvas/commit/82fd47d93ffad6125a685880a132ce0d3a388693))
+  ([#673](https://github.com/revideo/revideo/issues/673))
+  ([82fd47d](https://github.com/revideo/revideo/commit/82fd47d93ffad6125a685880a132ce0d3a388693))
 - **create:** support command-line arguments
-  ([#668](https://github.com/motion-canvas/motion-canvas/issues/668))
-  ([fa62a98](https://github.com/motion-canvas/motion-canvas/commit/fa62a9868d5cd33f1cb6ac5f147cca81917457dc))
+  ([#668](https://github.com/revideo/revideo/issues/668))
+  ([fa62a98](https://github.com/revideo/revideo/commit/fa62a9868d5cd33f1cb6ac5f147cca81917457dc))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.7.0](https://github.com/motion-canvas/motion-canvas/compare/v3.6.2...v3.7.0) (2023-05-10)
+# [3.7.0](https://github.com/revideo/revideo/compare/v3.6.2...v3.7.0) (2023-05-10)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [3.6.2](https://github.com/motion-canvas/motion-canvas/compare/v3.6.1...v3.6.2) (2023-05-09)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.6.1](https://github.com/motion-canvas/motion-canvas/compare/v3.6.0...v3.6.1) (2023-05-08)
+## [3.6.2](https://github.com/revideo/revideo/compare/v3.6.1...v3.6.2) (2023-05-09)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [3.6.0](https://github.com/motion-canvas/motion-canvas/compare/v3.5.1...v3.6.0) (2023-05-08)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.5.1](https://github.com/motion-canvas/motion-canvas/compare/v3.5.0...v3.5.1) (2023-04-08)
+## [3.6.1](https://github.com/revideo/revideo/compare/v3.6.0...v3.6.1) (2023-05-08)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [3.5.0](https://github.com/motion-canvas/motion-canvas/compare/v3.4.0...v3.5.0) (2023-04-06)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.4.0](https://github.com/motion-canvas/motion-canvas/compare/v3.3.4...v3.4.0) (2023-03-28)
+# [3.6.0](https://github.com/revideo/revideo/compare/v3.5.1...v3.6.0) (2023-05-08)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [3.3.4](https://github.com/motion-canvas/motion-canvas/compare/v3.3.3...v3.3.4) (2023-03-19)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.3.3](https://github.com/motion-canvas/motion-canvas/compare/v3.3.2...v3.3.3) (2023-03-18)
+## [3.5.1](https://github.com/revideo/revideo/compare/v3.5.0...v3.5.1) (2023-04-08)
 
-**Note:** Version bump only for package @motion-canvas/create
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [3.3.2](https://github.com/motion-canvas/motion-canvas/compare/v3.3.1...v3.3.2) (2023-03-18)
-
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.3.1](https://github.com/motion-canvas/motion-canvas/compare/v3.3.0...v3.3.1) (2023-03-18)
+# [3.5.0](https://github.com/revideo/revideo/compare/v3.4.0...v3.5.0) (2023-04-06)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.3.0](https://github.com/motion-canvas/motion-canvas/compare/v3.2.1...v3.3.0) (2023-03-18)
+# [3.4.0](https://github.com/revideo/revideo/compare/v3.3.4...v3.4.0) (2023-03-28)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [3.3.4](https://github.com/revideo/revideo/compare/v3.3.3...v3.3.4) (2023-03-19)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [3.3.3](https://github.com/revideo/revideo/compare/v3.3.2...v3.3.3) (2023-03-18)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [3.3.2](https://github.com/revideo/revideo/compare/v3.3.1...v3.3.2) (2023-03-18)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [3.3.1](https://github.com/revideo/revideo/compare/v3.3.0...v3.3.1) (2023-03-18)
+
+**Note:** Version bump only for package @revideo/create
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.3.0](https://github.com/revideo/revideo/compare/v3.2.1...v3.3.0) (2023-03-18)
 
 ### Features
 
 - update vite from v3 to v4
-  ([#495](https://github.com/motion-canvas/motion-canvas/issues/495))
-  ([c409eee](https://github.com/motion-canvas/motion-canvas/commit/c409eee0e61b67e43afed240c5ae279714681246)),
-  closes [#197](https://github.com/motion-canvas/motion-canvas/issues/197)
+  ([#495](https://github.com/revideo/revideo/issues/495))
+  ([c409eee](https://github.com/revideo/revideo/commit/c409eee0e61b67e43afed240c5ae279714681246)),
+  closes [#197](https://github.com/revideo/revideo/issues/197)
 
-## [3.2.1](https://github.com/motion-canvas/motion-canvas/compare/v3.2.0...v3.2.1) (2023-03-10)
+## [3.2.1](https://github.com/revideo/revideo/compare/v3.2.0...v3.2.1) (2023-03-10)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [3.2.0](https://github.com/motion-canvas/motion-canvas/compare/v3.1.0...v3.2.0) (2023-03-10)
+# [3.2.0](https://github.com/revideo/revideo/compare/v3.1.0...v3.2.0) (2023-03-10)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [3.1.0](https://github.com/motion-canvas/motion-canvas/compare/v3.0.2...v3.1.0) (2023-03-07)
+# [3.1.0](https://github.com/revideo/revideo/compare/v3.0.2...v3.1.0) (2023-03-07)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-## [3.0.2](https://github.com/motion-canvas/motion-canvas/compare/v3.0.1...v3.0.2) (2023-02-27)
+## [3.0.2](https://github.com/revideo/revideo/compare/v3.0.1...v3.0.2) (2023-02-27)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-## [3.0.1](https://github.com/motion-canvas/motion-canvas/compare/v3.0.0...v3.0.1) (2023-02-27)
+## [3.0.1](https://github.com/revideo/revideo/compare/v3.0.0...v3.0.1) (2023-02-27)
 
 ### Bug Fixes
 
 - **create:** update templates
-  ([#439](https://github.com/motion-canvas/motion-canvas/issues/439))
-  ([8483557](https://github.com/motion-canvas/motion-canvas/commit/8483557f0a3ca7914aafacceab5d466abba59df0))
+  ([#439](https://github.com/revideo/revideo/issues/439))
+  ([8483557](https://github.com/revideo/revideo/commit/8483557f0a3ca7914aafacceab5d466abba59df0))
 
-# [3.0.0](https://github.com/motion-canvas/motion-canvas/compare/v2.6.0...v3.0.0) (2023-02-27)
+# [3.0.0](https://github.com/revideo/revideo/compare/v2.6.0...v3.0.0) (2023-02-27)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [2.6.0](https://github.com/motion-canvas/motion-canvas/compare/v2.5.0...v2.6.0) (2023-02-24)
+# [2.6.0](https://github.com/revideo/revideo/compare/v2.5.0...v2.6.0) (2023-02-24)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [2.5.0](https://github.com/motion-canvas/motion-canvas/compare/v2.4.0...v2.5.0) (2023-02-20)
+# [2.5.0](https://github.com/revideo/revideo/compare/v2.4.0...v2.5.0) (2023-02-20)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [2.4.0](https://github.com/motion-canvas/motion-canvas/compare/v2.3.0...v2.4.0) (2023-02-18)
+# [2.4.0](https://github.com/revideo/revideo/compare/v2.3.0...v2.4.0) (2023-02-18)
 
 ### Bug Fixes
 
 - **vite-plugin:** fix js template
-  ([#337](https://github.com/motion-canvas/motion-canvas/issues/337))
-  ([3b33d73](https://github.com/motion-canvas/motion-canvas/commit/3b33d73416541d491b633bada29f085f5489f6c2))
+  ([#337](https://github.com/revideo/revideo/issues/337))
+  ([3b33d73](https://github.com/revideo/revideo/commit/3b33d73416541d491b633bada29f085f5489f6c2))
 
-# [2.3.0](https://github.com/motion-canvas/motion-canvas/compare/v2.2.0...v2.3.0) (2023-02-11)
+# [2.3.0](https://github.com/revideo/revideo/compare/v2.2.0...v2.3.0) (2023-02-11)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [2.2.0](https://github.com/motion-canvas/motion-canvas/compare/v2.1.0...v2.2.0) (2023-02-09)
+# [2.2.0](https://github.com/revideo/revideo/compare/v2.1.0...v2.2.0) (2023-02-09)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
-# [2.1.0](https://github.com/motion-canvas/motion-canvas/compare/v2.0.0...v2.1.0) (2023-02-07)
+# [2.1.0](https://github.com/revideo/revideo/compare/v2.0.0...v2.1.0) (2023-02-07)
 
-**Note:** Version bump only for package @motion-canvas/create
+**Note:** Version bump only for package @revideo/create
 
 # 2.0.0 (2023-02-04)
 
 ### Bug Fixes
 
 - change executable file permissions
-  ([#38](https://github.com/motion-canvas/motion-canvas/issues/38))
-  ([23025a2](https://github.com/motion-canvas/motion-canvas/commit/23025a2caefd993f7e4751b1efced3a25ed497a6))
+  ([#38](https://github.com/revideo/revideo/issues/38))
+  ([23025a2](https://github.com/revideo/revideo/commit/23025a2caefd993f7e4751b1efced3a25ed497a6))
 - **create:** fix package type
-  ([#40](https://github.com/motion-canvas/motion-canvas/issues/40))
-  ([f07aa5d](https://github.com/motion-canvas/motion-canvas/commit/f07aa5d8f6c3485464ed3158187340c7db7d5af7))
+  ([#40](https://github.com/revideo/revideo/issues/40))
+  ([f07aa5d](https://github.com/revideo/revideo/commit/f07aa5d8f6c3485464ed3158187340c7db7d5af7))
 - fix scaffolding
-  ([#93](https://github.com/motion-canvas/motion-canvas/issues/93))
-  ([95c55ed](https://github.com/motion-canvas/motion-canvas/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
+  ([#93](https://github.com/revideo/revideo/issues/93))
+  ([95c55ed](https://github.com/revideo/revideo/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
 
 ### Code Refactoring
 
 - remove legacy package
-  ([6a84120](https://github.com/motion-canvas/motion-canvas/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+  ([6a84120](https://github.com/revideo/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
 
 ### Features
 
 - add scaffolding package
-  ([#36](https://github.com/motion-canvas/motion-canvas/issues/36))
-  ([266a561](https://github.com/motion-canvas/motion-canvas/commit/266a561c619b57b403ec9c64185985b48bff29da)),
-  closes [#30](https://github.com/motion-canvas/motion-canvas/issues/30)
+  ([#36](https://github.com/revideo/revideo/issues/36))
+  ([266a561](https://github.com/revideo/revideo/commit/266a561c619b57b403ec9c64185985b48bff29da)),
+  closes [#30](https://github.com/revideo/revideo/issues/30)
 - extract konva to separate package
-  ([#60](https://github.com/motion-canvas/motion-canvas/issues/60))
-  ([4ecad3c](https://github.com/motion-canvas/motion-canvas/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
+  ([#60](https://github.com/revideo/revideo/issues/60))
+  ([4ecad3c](https://github.com/revideo/revideo/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
 - make scenes independent of names
-  ([#53](https://github.com/motion-canvas/motion-canvas/issues/53))
-  ([417617e](https://github.com/motion-canvas/motion-canvas/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)),
-  closes [#25](https://github.com/motion-canvas/motion-canvas/issues/25)
+  ([#53](https://github.com/revideo/revideo/issues/53))
+  ([417617e](https://github.com/revideo/revideo/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)),
+  closes [#25](https://github.com/revideo/revideo/issues/25)
 - support for multiple projects
-  ([#57](https://github.com/motion-canvas/motion-canvas/issues/57))
-  ([573752d](https://github.com/motion-canvas/motion-canvas/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)),
-  closes [#141414](https://github.com/motion-canvas/motion-canvas/issues/141414)
+  ([#57](https://github.com/revideo/revideo/issues/57))
+  ([573752d](https://github.com/revideo/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)),
+  closes [#141414](https://github.com/revideo/revideo/issues/141414)
 
 ### Reverts
 
 - "ci(release): 9.1.3 [skip ci]"
-  ([62953a6](https://github.com/motion-canvas/motion-canvas/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+  ([62953a6](https://github.com/revideo/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
 - ci(release): 1.0.1 [skip ci]
-  ([#175](https://github.com/motion-canvas/motion-canvas/issues/175))
-  ([161a046](https://github.com/motion-canvas/motion-canvas/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+  ([#175](https://github.com/revideo/revideo/issues/175))
+  ([161a046](https://github.com/revideo/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
 - ci(release): 2.0.0 [skip ci]
-  ([#176](https://github.com/motion-canvas/motion-canvas/issues/176))
-  ([551096b](https://github.com/motion-canvas/motion-canvas/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+  ([#176](https://github.com/revideo/revideo/issues/176))
+  ([551096b](https://github.com/revideo/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
 
 ### BREAKING CHANGES
 
@@ -356,7 +356,7 @@ All notable changes to this project will be documented in this file. See
 - change to import paths
 
 See
-[the migration guide](https://motion-canvas.github.io/guides/migration/12.0.0)
+[the migration guide](https://revideo.github.io/guides/migration/12.0.0)
 for more info.
 
 - change the way scenes are imported

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @revideo/create
+
+
+
+
+
 # 0.1.0 (2024-03-17)
 
 

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.2](https://github.com/havenhq/revideo/compare/v0.1.1...v0.1.2) (2024-03-17)
+
+
+### Bug Fixes
+
+* bump up ffmpeg version in quickstart ([aaefb4b](https://github.com/havenhq/revideo/commit/aaefb4bf928a6d64ff6f79f2e5f2613d62f8cc2d))
+
+
+
+
+
 ## [0.1.1](https://github.com/havenhq/revideo/compare/v0.1.0...v0.1.1) (2024-03-17)
 
 

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -3,6 +3,66 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* change executable file permissions ([#38](https://github.com/havenhq/revideo/issues/38)) ([23025a2](https://github.com/havenhq/revideo/commit/23025a2caefd993f7e4751b1efced3a25ed497a6))
+* **create:** fix package type ([#40](https://github.com/havenhq/revideo/issues/40)) ([f07aa5d](https://github.com/havenhq/revideo/commit/f07aa5d8f6c3485464ed3158187340c7db7d5af7))
+* **create:** update templates ([#439](https://github.com/havenhq/revideo/issues/439)) ([8483557](https://github.com/havenhq/revideo/commit/8483557f0a3ca7914aafacceab5d466abba59df0))
+* fix scaffolding ([#93](https://github.com/havenhq/revideo/issues/93)) ([95c55ed](https://github.com/havenhq/revideo/commit/95c55ed338127dad22f42b24c8f6b101b8863be7))
+* **vite-plugin:** fix js template ([#337](https://github.com/havenhq/revideo/issues/337)) ([3b33d73](https://github.com/havenhq/revideo/commit/3b33d73416541d491b633bada29f085f5489f6c2))
+
+
+### Code Refactoring
+
+* remove legacy package ([6a84120](https://github.com/havenhq/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+
+
+### Features
+
+* add scaffolding package ([#36](https://github.com/havenhq/revideo/issues/36)) ([266a561](https://github.com/havenhq/revideo/commit/266a561c619b57b403ec9c64185985b48bff29da)), closes [#30](https://github.com/havenhq/revideo/issues/30)
+* **create:** add exporter selection ([#673](https://github.com/havenhq/revideo/issues/673)) ([82fd47d](https://github.com/havenhq/revideo/commit/82fd47d93ffad6125a685880a132ce0d3a388693))
+* **create:** include simple animation ([#931](https://github.com/havenhq/revideo/issues/931)) ([925f63f](https://github.com/havenhq/revideo/commit/925f63f3588922224511b1687ac44ba7b9920d83))
+* **create:** support command-line arguments ([#668](https://github.com/havenhq/revideo/issues/668)) ([fa62a98](https://github.com/havenhq/revideo/commit/fa62a9868d5cd33f1cb6ac5f147cca81917457dc))
+* extract konva to separate package ([#60](https://github.com/havenhq/revideo/issues/60)) ([4ecad3c](https://github.com/havenhq/revideo/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
+* make scenes independent of names ([#53](https://github.com/havenhq/revideo/issues/53)) ([417617e](https://github.com/havenhq/revideo/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)), closes [#25](https://github.com/havenhq/revideo/issues/25)
+* support for multiple projects ([#57](https://github.com/havenhq/revideo/issues/57)) ([573752d](https://github.com/havenhq/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)), closes [#141414](https://github.com/havenhq/revideo/issues/141414)
+* update vite from v3 to v4 ([#495](https://github.com/havenhq/revideo/issues/495)) ([c409eee](https://github.com/havenhq/revideo/commit/c409eee0e61b67e43afed240c5ae279714681246)), closes [#197](https://github.com/havenhq/revideo/issues/197)
+
+
+### Reverts
+
+* "ci(release): 9.1.3 [skip ci]" ([62953a6](https://github.com/havenhq/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/havenhq/revideo/issues/908)) ([86c5170](https://github.com/havenhq/revideo/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
+
+
+### BREAKING CHANGES
+
+* remove legacy package
+* change to import paths
+
+See [the migration guide](https://motion-canvas.github.io/guides/migration/12.0.0) for more info.
+* change the way scenes are imported
+
+Scene files no longer need to follow the pattern: `[name].scene.tsx`.
+When importing scenes in the project file, a dedicated `?scene` query param should be used:
+```ts
+import example from './scenes/example?scene';
+
+export default new Project({
+  name: 'project',
+  scenes: [example],
+});
+```
+
+
+
+
+
 ## [3.14.2](https://github.com/revideo/revideo/compare/v3.14.1...v3.14.2) (2024-02-08)
 
 **Note:** Version bump only for package @revideo/create

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -21,13 +21,13 @@ const MANIFEST = JSON.parse(
 
 const PLUGINS = {
   core: {
-    package: '@motion-canvas/vite-plugin',
+    package: '@revideo/vite-plugin',
     variable: 'motionCanvas',
     options: response =>
       response.language === 'js' ? `{project: './src/project.js'}` : '',
   },
   ffmpeg: {
-    package: '@motion-canvas/ffmpeg',
+    package: '@revideo/ffmpeg',
     variable: 'ffmpeg',
     version: '^1.1.0',
   },
@@ -261,7 +261,7 @@ function getPackageManager() {
 function cloneVersions(versions) {
   for (const dependency in versions) {
     if (
-      dependency.startsWith('@motion-canvas') &&
+      dependency.startsWith('@revideo') &&
       MANIFEST.devDependencies[dependency]
     ) {
       versions[dependency] = MANIFEST.devDependencies[dependency];

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -29,7 +29,7 @@ const PLUGINS = {
   ffmpeg: {
     package: '@revideo/ffmpeg',
     variable: 'ffmpeg',
-    version: '^0.1.0',
+    version: '^0.1.2',
   },
 };
 

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -29,7 +29,7 @@ const PLUGINS = {
   ffmpeg: {
     package: '@revideo/ffmpeg',
     variable: 'ffmpeg',
-    version: '^0.1.2',
+    version: '^0.1.1',
   },
 };
 

--- a/packages/create/index.js
+++ b/packages/create/index.js
@@ -29,7 +29,7 @@ const PLUGINS = {
   ffmpeg: {
     package: '@revideo/ffmpeg',
     variable: 'ffmpeg',
-    version: '^1.1.0',
+    version: '^0.1.0',
   },
 };
 

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/create",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Quickly scaffold revideo projects",
   "main": "index.js",
   "author": "revideo",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/create",
-  "version": "3.14.2",
+  "version": "0.1.0",
   "description": "Quickly scaffold revideo projects",
   "main": "index.js",
   "author": "revideo",
@@ -20,10 +20,10 @@
     "url": "https://github.com/havenhq/revideo.git"
   },
   "devDependencies": {
-    "@revideo/2d": "^3.14.2",
-    "@revideo/core": "^3.14.1",
-    "@revideo/ui": "^3.14.2",
-    "@revideo/vite-plugin": "^3.14.1"
+    "@revideo/2d": "^0.1.0",
+    "@revideo/core": "^0.1.0",
+    "@revideo/ui": "^0.1.0",
+    "@revideo/vite-plugin": "^0.1.0"
   },
   "dependencies": {
     "minimist": "^1.2.8",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/create",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Quickly scaffold revideo projects",
   "main": "index.js",
   "author": "revideo",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@motion-canvas/create",
+  "name": "@revideo/create",
   "version": "3.14.2",
-  "description": "Quickly scaffold Motion Canvas projects",
+  "description": "Quickly scaffold revideo projects",
   "main": "index.js",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "create-motion-canvas": "index.js"
+    "create-revideo": "index.js"
   },
   "files": [
     "index.js",
@@ -17,13 +17,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/motion-canvas/motion-canvas.git"
+    "url": "https://github.com/havenhq/revideo.git"
   },
   "devDependencies": {
-    "@motion-canvas/2d": "^3.14.2",
-    "@motion-canvas/core": "^3.14.1",
-    "@motion-canvas/ui": "^3.14.2",
-    "@motion-canvas/vite-plugin": "^3.14.1"
+    "@revideo/2d": "^3.14.2",
+    "@revideo/core": "^3.14.1",
+    "@revideo/ui": "^3.14.2",
+    "@revideo/vite-plugin": "^3.14.1"
   },
   "dependencies": {
     "minimist": "^1.2.8",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/create",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Quickly scaffold revideo projects",
   "main": "index.js",
   "author": "revideo",

--- a/packages/create/template-2d-js/package.json
+++ b/packages/create/template-2d-js/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@revideo/ui": "*",
     "@revideo/vite-plugin": "*",
-    "vite": "^4.0.0"
+    "vite": "^4.5"
   }
 }

--- a/packages/create/template-2d-js/package.json
+++ b/packages/create/template-2d-js/package.json
@@ -8,12 +8,12 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@motion-canvas/core": "*",
-    "@motion-canvas/2d": "*"
+    "@revideo/core": "*",
+    "@revideo/2d": "*"
   },
   "devDependencies": {
-    "@motion-canvas/ui": "*",
-    "@motion-canvas/vite-plugin": "*",
+    "@revideo/ui": "*",
+    "@revideo/vite-plugin": "*",
     "vite": "^4.0.0"
   }
 }

--- a/packages/create/template-2d-js/src/project.js
+++ b/packages/create/template-2d-js/src/project.js
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import example from './scenes/example?scene';
 

--- a/packages/create/template-2d-js/src/scenes/example.jsx
+++ b/packages/create/template-2d-js/src/scenes/example.jsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   // Create your animations here

--- a/packages/create/template-2d-ts/package.json
+++ b/packages/create/template-2d-ts/package.json
@@ -8,12 +8,12 @@
     "build": "tsc && vite build"
   },
   "dependencies": {
-    "@motion-canvas/core": "*",
-    "@motion-canvas/2d": "*"
+    "@revideo/core": "*",
+    "@revideo/2d": "*"
   },
   "devDependencies": {
-    "@motion-canvas/ui": "*",
-    "@motion-canvas/vite-plugin": "*",
+    "@revideo/ui": "*",
+    "@revideo/vite-plugin": "*",
     "typescript": "^5.2.2",
     "vite": "^5.0"
   }

--- a/packages/create/template-2d-ts/package.json
+++ b/packages/create/template-2d-ts/package.json
@@ -15,6 +15,6 @@
     "@revideo/ui": "*",
     "@revideo/vite-plugin": "*",
     "typescript": "^5.2.2",
-    "vite": "^5.0"
+    "vite": "^4.5"
   }
 }

--- a/packages/create/template-2d-ts/src/motion-canvas.d.ts
+++ b/packages/create/template-2d-ts/src/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/create/template-2d-ts/src/project.ts
+++ b/packages/create/template-2d-ts/src/project.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import example from './scenes/example?scene';
 

--- a/packages/create/template-2d-ts/src/revideo.d.ts
+++ b/packages/create/template-2d-ts/src/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/create/template-2d-ts/src/scenes/example.tsx
+++ b/packages/create/template-2d-ts/src/scenes/example.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   // Create your animations here

--- a/packages/create/template-2d-ts/tsconfig.json
+++ b/packages/create/template-2d-ts/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@motion-canvas/2d/tsconfig.project.json",
+  "extends": "@revideo/2d/tsconfig.project.json",
   "include": ["src"]
 }

--- a/packages/docs/blog/2023-02-08-version-2.1.0.mdx
+++ b/packages/docs/blog/2023-02-08-version-2.1.0.mdx
@@ -7,40 +7,40 @@ authors: aarthificial
 ### Features
 
 - add [`useDuration`](/docs/time-events#controlling-animation-duration) helper
-  ([#226](https://github.com/motion-canvas/motion-canvas/issues/226))
-  ([fa97d6c](https://github.com/motion-canvas/motion-canvas/commit/fa97d6c7f076f287c9b86d2f8852341bd368ef1c)),
-  closes [#171](https://github.com/motion-canvas/motion-canvas/issues/171)
+  ([#226](https://github.com/revideo/revideo/issues/226))
+  ([fa97d6c](https://github.com/revideo/revideo/commit/fa97d6c7f076f287c9b86d2f8852341bd368ef1c)),
+  closes [#171](https://github.com/revideo/revideo/issues/171)
 
 ### Bug Fixes
 
 - **2d:** fix font ligatures in CodeBlock
-  ([#231](https://github.com/motion-canvas/motion-canvas/issues/231))
-  ([11ee3fe](https://github.com/motion-canvas/motion-canvas/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
+  ([#231](https://github.com/revideo/revideo/issues/231))
+  ([11ee3fe](https://github.com/revideo/revideo/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
 - **2d:** fix Line cache
-  ([#232](https://github.com/motion-canvas/motion-canvas/issues/232))
-  ([a953b64](https://github.com/motion-canvas/motion-canvas/commit/a953b64540c020657845efc84d4179142a7a0974)),
-  closes [#205](https://github.com/motion-canvas/motion-canvas/issues/205)
+  ([#232](https://github.com/revideo/revideo/issues/232))
+  ([a953b64](https://github.com/revideo/revideo/commit/a953b64540c020657845efc84d4179142a7a0974)),
+  closes [#205](https://github.com/revideo/revideo/issues/205)
 - **2d:** handle lines with no points
-  ([#233](https://github.com/motion-canvas/motion-canvas/issues/233))
-  ([8108474](https://github.com/motion-canvas/motion-canvas/commit/81084743dfad7b6419760796fda825047909d4d4)),
-  closes [#212](https://github.com/motion-canvas/motion-canvas/issues/212)
+  ([#233](https://github.com/revideo/revideo/issues/233))
+  ([8108474](https://github.com/revideo/revideo/commit/81084743dfad7b6419760796fda825047909d4d4)),
+  closes [#212](https://github.com/revideo/revideo/issues/212)
 - **2d:** improve Rect radius
-  ([#221](https://github.com/motion-canvas/motion-canvas/issues/221))
-  ([3437e42](https://github.com/motion-canvas/motion-canvas/commit/3437e42713a3f4a8d44d246ee01e2eb23b61e06a)),
-  closes [#207](https://github.com/motion-canvas/motion-canvas/issues/207)
+  ([#221](https://github.com/revideo/revideo/issues/221))
+  ([3437e42](https://github.com/revideo/revideo/commit/3437e42713a3f4a8d44d246ee01e2eb23b61e06a)),
+  closes [#207](https://github.com/revideo/revideo/issues/207)
 - **2d:** stop code highlighting from jumping
-  ([#230](https://github.com/motion-canvas/motion-canvas/issues/230))
-  ([67ef1c4](https://github.com/motion-canvas/motion-canvas/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
+  ([#230](https://github.com/revideo/revideo/issues/230))
+  ([67ef1c4](https://github.com/revideo/revideo/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
 - **core:** fix looping
-  ([#217](https://github.com/motion-canvas/motion-canvas/issues/217))
-  ([a38e1a7](https://github.com/motion-canvas/motion-canvas/commit/a38e1a7c8fc21384cc17f3f982802071b8cd0cbf)),
-  closes [#178](https://github.com/motion-canvas/motion-canvas/issues/178)
+  ([#217](https://github.com/revideo/revideo/issues/217))
+  ([a38e1a7](https://github.com/revideo/revideo/commit/a38e1a7c8fc21384cc17f3f982802071b8cd0cbf)),
+  closes [#178](https://github.com/revideo/revideo/issues/178)
 - fix compound property setter
-  ([#218](https://github.com/motion-canvas/motion-canvas/issues/218))
-  ([6cd1b95](https://github.com/motion-canvas/motion-canvas/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)),
-  closes [#208](https://github.com/motion-canvas/motion-canvas/issues/208)
-  [#210](https://github.com/motion-canvas/motion-canvas/issues/210)
+  ([#218](https://github.com/revideo/revideo/issues/218))
+  ([6cd1b95](https://github.com/revideo/revideo/commit/6cd1b952df950554eb637c9f8e82947c415d00c5)),
+  closes [#208](https://github.com/revideo/revideo/issues/208)
+  [#210](https://github.com/revideo/revideo/issues/210)
 - **vite-plugin:** add missing headers to html
-  ([#219](https://github.com/motion-canvas/motion-canvas/issues/219))
-  ([2552bcf](https://github.com/motion-canvas/motion-canvas/commit/2552bcfbe2e90f3d4b86810d39f8cee24349e405)),
-  closes [#201](https://github.com/motion-canvas/motion-canvas/issues/201)
+  ([#219](https://github.com/revideo/revideo/issues/219))
+  ([2552bcf](https://github.com/revideo/revideo/commit/2552bcfbe2e90f3d4b86810d39f8cee24349e405)),
+  closes [#201](https://github.com/revideo/revideo/issues/201)

--- a/packages/docs/blog/2023-02-08-version-2.1.0.mdx
+++ b/packages/docs/blog/2023-02-08-version-2.1.0.mdx
@@ -16,8 +16,7 @@ authors: aarthificial
 - **2d:** fix font ligatures in CodeBlock
   ([#231](https://github.com/revideo/revideo/issues/231))
   ([11ee3fe](https://github.com/revideo/revideo/commit/11ee3fef5ad878313cf19833df6881333ced4dac))
-- **2d:** fix Line cache
-  ([#232](https://github.com/revideo/revideo/issues/232))
+- **2d:** fix Line cache ([#232](https://github.com/revideo/revideo/issues/232))
   ([a953b64](https://github.com/revideo/revideo/commit/a953b64540c020657845efc84d4179142a7a0974)),
   closes [#205](https://github.com/revideo/revideo/issues/205)
 - **2d:** handle lines with no points
@@ -31,8 +30,7 @@ authors: aarthificial
 - **2d:** stop code highlighting from jumping
   ([#230](https://github.com/revideo/revideo/issues/230))
   ([67ef1c4](https://github.com/revideo/revideo/commit/67ef1c497056dd1f8f9e20d1d7fc1af03ec3849e))
-- **core:** fix looping
-  ([#217](https://github.com/revideo/revideo/issues/217))
+- **core:** fix looping ([#217](https://github.com/revideo/revideo/issues/217))
   ([a38e1a7](https://github.com/revideo/revideo/commit/a38e1a7c8fc21384cc17f3f982802071b8cd0cbf)),
   closes [#178](https://github.com/revideo/revideo/issues/178)
 - fix compound property setter

--- a/packages/docs/blog/2023-02-09-version-2.2.0.mdx
+++ b/packages/docs/blog/2023-02-09-version-2.2.0.mdx
@@ -7,17 +7,17 @@ authors: aarthificial
 ### Features
 
 - New [project variables](/docs/project-variables) let you create customizable
-  animations ([#255](https://github.com/motion-canvas/motion-canvas/issues/255))
-  ([4883295](https://github.com/motion-canvas/motion-canvas/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
+  animations ([#255](https://github.com/revideo/revideo/issues/255))
+  ([4883295](https://github.com/revideo/revideo/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
 - The [`Video`](/api/2d/components/Video) component has new getters for the
   [duration](/api/2d/components/Video#getDuration),
   [current time](/api/2d/components/Video#getCurrentTime), and
   [state](/api/2d/components/Video#isPlaying) of the video
-  ([#240](https://github.com/motion-canvas/motion-canvas/issues/240))
-  ([59de5ab](https://github.com/motion-canvas/motion-canvas/commit/59de5ab2c089589773a2f9ad7588eda7d72693a7))
+  ([#240](https://github.com/revideo/revideo/issues/240))
+  ([59de5ab](https://github.com/revideo/revideo/commit/59de5ab2c089589773a2f9ad7588eda7d72693a7))
 
 ### Bug Fixes
 
 - Text is now visible in Firefox without the need of a custom flag
-  ([#249](https://github.com/motion-canvas/motion-canvas/pull/249))
-  ([20a4d65](https://github.com/motion-canvas/motion-canvas/commit/20a4d65bbfa0c568e571274d9b6a16fb4327a5fa))
+  ([#249](https://github.com/revideo/revideo/pull/249))
+  ([20a4d65](https://github.com/revideo/revideo/commit/20a4d65bbfa0c568e571274d9b6a16fb4327a5fa))

--- a/packages/docs/blog/2023-02-11-version-2.3.0.mdx
+++ b/packages/docs/blog/2023-02-11-version-2.3.0.mdx
@@ -7,41 +7,41 @@ authors: aarthificial
 ### Features
 
 - A new [`LaTeX`](/docs/nodes) node!
-  ([#228](https://github.com/motion-canvas/motion-canvas/issues/228))
-  ([4c26d2a](https://github.com/motion-canvas/motion-canvas/commit/4c26d2aaf0c697486639aa917cd5c585d3d0ea74))
+  ([#228](https://github.com/revideo/revideo/issues/228))
+  ([4c26d2a](https://github.com/revideo/revideo/commit/4c26d2aaf0c697486639aa917cd5c585d3d0ea74))
 - CodeBlock themes (documentation coming soon)
-  ([#279](https://github.com/motion-canvas/motion-canvas/issues/279))
-  ([fe34fa8](https://github.com/motion-canvas/motion-canvas/commit/fe34fa8ebfe66cd356fb1c3d85adedef11e03b45))
+  ([#279](https://github.com/revideo/revideo/issues/279))
+  ([fe34fa8](https://github.com/revideo/revideo/commit/fe34fa8ebfe66cd356fb1c3d85adedef11e03b45))
 - An [antialiased](/api/2d/components/Shape#antialiased) property for Shapes
-  ([#282](https://github.com/motion-canvas/motion-canvas/issues/282))
-  ([7c6905d](https://github.com/motion-canvas/motion-canvas/commit/7c6905d72c6c2f49e10f0a80704c0afe3504d01b))
+  ([#282](https://github.com/revideo/revideo/issues/282))
+  ([7c6905d](https://github.com/revideo/revideo/commit/7c6905d72c6c2f49e10f0a80704c0afe3504d01b))
 - [Smooth corners](/api/2d/components/Rect#smoothCorners) and
   [sharpness control](/api/2d/components/Rect#cornerSharpness) for Rects
-  ([#310](https://github.com/motion-canvas/motion-canvas/issues/310))
-  ([f7fbefd](https://github.com/motion-canvas/motion-canvas/commit/f7fbefd27f7f6972cfb5a45a68e5d0aed9593ae4))
+  ([#310](https://github.com/revideo/revideo/issues/310))
+  ([f7fbefd](https://github.com/revideo/revideo/commit/f7fbefd27f7f6972cfb5a45a68e5d0aed9593ae4))
 - A simpler [`debug`](/api/core/utils#debug) function
-  ([#293](https://github.com/motion-canvas/motion-canvas/issues/293))
-  ([b870873](https://github.com/motion-canvas/motion-canvas/commit/b8708732af0fc08d9ff9eeecbbb77d65f1b36eb8))
+  ([#293](https://github.com/revideo/revideo/issues/293))
+  ([b870873](https://github.com/revideo/revideo/commit/b8708732af0fc08d9ff9eeecbbb77d65f1b36eb8))
 - Multiple new [easing functions](/api/core/tweening#createEaseInBack)
-  ([#274](https://github.com/motion-canvas/motion-canvas/issues/274))
-  ([f81ce43](https://github.com/motion-canvas/motion-canvas/commit/f81ce43019fe253e99f4ab6311c2251b40e2eae3))
+  ([#274](https://github.com/revideo/revideo/issues/274))
+  ([f81ce43](https://github.com/revideo/revideo/commit/f81ce43019fe253e99f4ab6311c2251b40e2eae3))
 - Tweening to/from undefined values now warns the user
-  ([#257](https://github.com/motion-canvas/motion-canvas/issues/257))
-  ([d4bb791](https://github.com/motion-canvas/motion-canvas/commit/d4bb79145300b52c4b4d101df2afaff5ea11a9e9))
+  ([#257](https://github.com/revideo/revideo/issues/257))
+  ([d4bb791](https://github.com/revideo/revideo/commit/d4bb79145300b52c4b4d101df2afaff5ea11a9e9))
 - API documentation is always re-build when in `build` mode
-  ([#298](https://github.com/motion-canvas/motion-canvas/issues/298))
-  ([27a4d96](https://github.com/motion-canvas/motion-canvas/commit/27a4d96593d8e925385252b0d6f62646cd9fa6d5)),
-  closes [#294](https://github.com/motion-canvas/motion-canvas/issues/294)
+  ([#298](https://github.com/revideo/revideo/issues/298))
+  ([27a4d96](https://github.com/revideo/revideo/commit/27a4d96593d8e925385252b0d6f62646cd9fa6d5)),
+  closes [#294](https://github.com/revideo/revideo/issues/294)
 
 ### Bug Fixes
 
 - `textWrap={'pre'}` now works in Firefox
-  ([#287](https://github.com/motion-canvas/motion-canvas/issues/287))
-  ([cb07f4b](https://github.com/motion-canvas/motion-canvas/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
+  ([#287](https://github.com/revideo/revideo/issues/287))
+  ([cb07f4b](https://github.com/revideo/revideo/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
 - Using space to play/pause the animation when focused on the play button now
   works properly
-  ([#299](https://github.com/motion-canvas/motion-canvas/issues/299))
-  ([191f54a](https://github.com/motion-canvas/motion-canvas/commit/191f54a0a5a9de2fd2dc27bffc6d21d692ce6f72))
+  ([#299](https://github.com/revideo/revideo/issues/299))
+  ([191f54a](https://github.com/revideo/revideo/commit/191f54a0a5a9de2fd2dc27bffc6d21d692ce6f72))
 - The glossy effect on the select element has been removed in Safari
-  ([#292](https://github.com/motion-canvas/motion-canvas/issues/292))
-  ([9c062b2](https://github.com/motion-canvas/motion-canvas/commit/9c062b26e48fbdb1905daae25a3fb34df82307d3))
+  ([#292](https://github.com/revideo/revideo/issues/292))
+  ([9c062b2](https://github.com/revideo/revideo/commit/9c062b26e48fbdb1905daae25a3fb34df82307d3))

--- a/packages/docs/blog/2023-02-11-version-2.3.0.mdx
+++ b/packages/docs/blog/2023-02-11-version-2.3.0.mdx
@@ -39,8 +39,7 @@ authors: aarthificial
   ([#287](https://github.com/revideo/revideo/issues/287))
   ([cb07f4b](https://github.com/revideo/revideo/commit/cb07f4bdf07edc8a086b934ca5ab769682b9a010))
 - Using space to play/pause the animation when focused on the play button now
-  works properly
-  ([#299](https://github.com/revideo/revideo/issues/299))
+  works properly ([#299](https://github.com/revideo/revideo/issues/299))
   ([191f54a](https://github.com/revideo/revideo/commit/191f54a0a5a9de2fd2dc27bffc6d21d692ce6f72))
 - The glossy effect on the select element has been removed in Safari
   ([#292](https://github.com/revideo/revideo/issues/292))

--- a/packages/docs/blog/2023-02-18-version-2.4.0.mdx
+++ b/packages/docs/blog/2023-02-18-version-2.4.0.mdx
@@ -8,65 +8,65 @@ authors: aarthificial
 
 - [`DEFAULT`](/docs/signals#default-values) signal values. `lineHeight` now
   supports percentages.
-  ([#259](https://github.com/motion-canvas/motion-canvas/issues/259))
-  ([18f61a6](https://github.com/motion-canvas/motion-canvas/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
+  ([#259](https://github.com/revideo/revideo/issues/259))
+  ([18f61a6](https://github.com/revideo/revideo/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
 - New [`moveBelow`](/api/2d/components/Node#moveBelow),
   [`moveAbove`](/api/2d/components/Node#moveAbove) and
   [`moveTo`](/api/2d/components/Node#moveTo) methods for rearranging the nodes.
-  ([#365](https://github.com/motion-canvas/motion-canvas/issues/365))
-  ([16752a3](https://github.com/motion-canvas/motion-canvas/commit/16752a3b8ae7461b33d6208a9675729f374e8324))
+  ([#365](https://github.com/revideo/revideo/issues/365))
+  ([16752a3](https://github.com/revideo/revideo/commit/16752a3b8ae7461b33d6208a9675729f374e8324))
 - New [`CodeBlock`](/docs/code-block) documentation
-  ([#302](https://github.com/motion-canvas/motion-canvas/issues/302))
-  ([73f7221](https://github.com/motion-canvas/motion-canvas/commit/73f7221536e09d5cf77f75ca173d1a7637d5b98f))
+  ([#302](https://github.com/revideo/revideo/issues/302))
+  ([73f7221](https://github.com/revideo/revideo/commit/73f7221536e09d5cf77f75ca173d1a7637d5b98f))
 - The editor now warns about duplicated time events.
-  ([#341](https://github.com/motion-canvas/motion-canvas/issues/341))
-  ([053b2a6](https://github.com/motion-canvas/motion-canvas/commit/053b2a6c22c4e726e3962fdaf0a2e8d149889a9b))
+  ([#341](https://github.com/revideo/revideo/issues/341))
+  ([053b2a6](https://github.com/revideo/revideo/commit/053b2a6c22c4e726e3962fdaf0a2e8d149889a9b))
 - We now have a search bar on the documentation website.
-  ([#335](https://github.com/motion-canvas/motion-canvas/issues/335))
-  ([48f74a6](https://github.com/motion-canvas/motion-canvas/commit/48f74a60d54cc52c7f069a9ec39071c99163bd19))
+  ([#335](https://github.com/revideo/revideo/issues/335))
+  ([48f74a6](https://github.com/revideo/revideo/commit/48f74a60d54cc52c7f069a9ec39071c99163bd19))
 - You can now open the documentation from within the editor.
-  ([#346](https://github.com/motion-canvas/motion-canvas/issues/346))
-  ([fc4ee5d](https://github.com/motion-canvas/motion-canvas/commit/fc4ee5d028312904ed9e11c5341ac00f36e7242b))
+  ([#346](https://github.com/revideo/revideo/issues/346))
+  ([fc4ee5d](https://github.com/revideo/revideo/commit/fc4ee5d028312904ed9e11c5341ac00f36e7242b))
 - `SHIFT + ->` moves to the last frame.
-  ([#354](https://github.com/motion-canvas/motion-canvas/issues/354))
-  ([4b81709](https://github.com/motion-canvas/motion-canvas/commit/4b8170971400c5bf4fe690a58d3f44c3e1d00b94)),
-  closes [#353](https://github.com/motion-canvas/motion-canvas/issues/353)
+  ([#354](https://github.com/revideo/revideo/issues/354))
+  ([4b81709](https://github.com/revideo/revideo/commit/4b8170971400c5bf4fe690a58d3f44c3e1d00b94)),
+  closes [#353](https://github.com/revideo/revideo/issues/353)
 - Flexbox `gap` is now represented by a `Vector2` signal.
-  ([#355](https://github.com/motion-canvas/motion-canvas/issues/355))
-  ([3cae97e](https://github.com/motion-canvas/motion-canvas/commit/3cae97ea704d0533020fa87326dacadcc037d517)),
-  closes [#352](https://github.com/motion-canvas/motion-canvas/issues/352)
+  ([#355](https://github.com/revideo/revideo/issues/355))
+  ([3cae97e](https://github.com/revideo/revideo/commit/3cae97ea704d0533020fa87326dacadcc037d517)),
+  closes [#352](https://github.com/revideo/revideo/issues/352)
 - New [`Matrix2D`](/api/core/types/Matrix2D) type.
-  ([#340](https://github.com/motion-canvas/motion-canvas/issues/340))
-  ([66b41e6](https://github.com/motion-canvas/motion-canvas/commit/66b41e6beaca5c2ba4b6bd1a7e68ca16d183b0e9))
+  ([#340](https://github.com/revideo/revideo/issues/340))
+  ([66b41e6](https://github.com/revideo/revideo/commit/66b41e6beaca5c2ba4b6bd1a7e68ca16d183b0e9))
 
 ### Bug Fixes
 
 - **2d:** fix Gradient and Pattern signals
-  ([#376](https://github.com/motion-canvas/motion-canvas/issues/376))
-  ([6e0dc8a](https://github.com/motion-canvas/motion-canvas/commit/6e0dc8af8d19f93fd6a42addca2b3a2958b4dd33))
+  ([#376](https://github.com/revideo/revideo/issues/376))
+  ([6e0dc8a](https://github.com/revideo/revideo/commit/6e0dc8af8d19f93fd6a42addca2b3a2958b4dd33))
 - **2d:** fix layout calculation for nodes not explicitly added to view
-  ([#331](https://github.com/motion-canvas/motion-canvas/issues/331))
-  ([528e2d5](https://github.com/motion-canvas/motion-canvas/commit/528e2d5a0abec99819e022d2848b256ece9f869a))
+  ([#331](https://github.com/revideo/revideo/issues/331))
+  ([528e2d5](https://github.com/revideo/revideo/commit/528e2d5a0abec99819e022d2848b256ece9f869a))
 - **2d:** format whitespaces according to HTML
-  ([#372](https://github.com/motion-canvas/motion-canvas/issues/372))
-  ([83fb565](https://github.com/motion-canvas/motion-canvas/commit/83fb565742d98f060c0400c8cbaf9961b69f34d0)),
-  closes [#370](https://github.com/motion-canvas/motion-canvas/issues/370)
+  ([#372](https://github.com/revideo/revideo/issues/372))
+  ([83fb565](https://github.com/revideo/revideo/commit/83fb565742d98f060c0400c8cbaf9961b69f34d0)),
+  closes [#370](https://github.com/revideo/revideo/issues/370)
 - **core:** playback speed is reset after saving with faulty code
-  ([#204](https://github.com/motion-canvas/motion-canvas/issues/204)).
-  ([#339](https://github.com/motion-canvas/motion-canvas/issues/339))
-  ([6771e5e](https://github.com/motion-canvas/motion-canvas/commit/6771e5e17edcdc4cce074d7da0962cf71ba6c228))
+  ([#204](https://github.com/revideo/revideo/issues/204)).
+  ([#339](https://github.com/revideo/revideo/issues/339))
+  ([6771e5e](https://github.com/revideo/revideo/commit/6771e5e17edcdc4cce074d7da0962cf71ba6c228))
 - **docs:** fix search
-  ([#336](https://github.com/motion-canvas/motion-canvas/issues/336))
-  ([e44ec02](https://github.com/motion-canvas/motion-canvas/commit/e44ec02539a67f099471a6aa84f673a236494687))
+  ([#336](https://github.com/revideo/revideo/issues/336))
+  ([e44ec02](https://github.com/revideo/revideo/commit/e44ec02539a67f099471a6aa84f673a236494687))
 - typo on codeblock remove comments
-  ([#368](https://github.com/motion-canvas/motion-canvas/issues/368))
-  ([2025adc](https://github.com/motion-canvas/motion-canvas/commit/2025adc6e7aa11d81b6f5f6989e8eae18cf86cb7))
+  ([#368](https://github.com/revideo/revideo/issues/368))
+  ([2025adc](https://github.com/revideo/revideo/commit/2025adc6e7aa11d81b6f5f6989e8eae18cf86cb7))
 - **ui:** fix inspector tab
-  ([#374](https://github.com/motion-canvas/motion-canvas/issues/374))
-  ([c4cb378](https://github.com/motion-canvas/motion-canvas/commit/c4cb378c2f9d972bb41542bbe3b3aa314fa1f3ad))
+  ([#374](https://github.com/revideo/revideo/issues/374))
+  ([c4cb378](https://github.com/revideo/revideo/commit/c4cb378c2f9d972bb41542bbe3b3aa314fa1f3ad))
 - **vite-plugin:** fix js template
-  ([#337](https://github.com/motion-canvas/motion-canvas/issues/337))
-  ([3b33d73](https://github.com/motion-canvas/motion-canvas/commit/3b33d73416541d491b633bada29f085f5489f6c2))
+  ([#337](https://github.com/revideo/revideo/issues/337))
+  ([3b33d73](https://github.com/revideo/revideo/commit/3b33d73416541d491b633bada29f085f5489f6c2))
 - **vite-plugin:** ignore query param in devserver
-  ([#351](https://github.com/motion-canvas/motion-canvas/issues/351))
-  ([5644d72](https://github.com/motion-canvas/motion-canvas/commit/5644d72d36adcdc817f0856aaff0be5507338cb8))
+  ([#351](https://github.com/revideo/revideo/issues/351))
+  ([5644d72](https://github.com/revideo/revideo/commit/5644d72d36adcdc817f0856aaff0be5507338cb8))

--- a/packages/docs/blog/2023-02-18-version-2.4.0.mdx
+++ b/packages/docs/blog/2023-02-18-version-2.4.0.mdx
@@ -7,8 +7,7 @@ authors: aarthificial
 ### Features
 
 - [`DEFAULT`](/docs/signals#default-values) signal values. `lineHeight` now
-  supports percentages.
-  ([#259](https://github.com/revideo/revideo/issues/259))
+  supports percentages. ([#259](https://github.com/revideo/revideo/issues/259))
   ([18f61a6](https://github.com/revideo/revideo/commit/18f61a668420dec8afba52d52a6557e7a7919ba2))
 - New [`moveBelow`](/api/2d/components/Node#moveBelow),
   [`moveAbove`](/api/2d/components/Node#moveAbove) and
@@ -55,8 +54,7 @@ authors: aarthificial
   ([#204](https://github.com/revideo/revideo/issues/204)).
   ([#339](https://github.com/revideo/revideo/issues/339))
   ([6771e5e](https://github.com/revideo/revideo/commit/6771e5e17edcdc4cce074d7da0962cf71ba6c228))
-- **docs:** fix search
-  ([#336](https://github.com/revideo/revideo/issues/336))
+- **docs:** fix search ([#336](https://github.com/revideo/revideo/issues/336))
   ([e44ec02](https://github.com/revideo/revideo/commit/e44ec02539a67f099471a6aa84f673a236494687))
 - typo on codeblock remove comments
   ([#368](https://github.com/revideo/revideo/issues/368))

--- a/packages/docs/blog/2023-02-27-version-3.0.0.mdx
+++ b/packages/docs/blog/2023-02-27-version-3.0.0.mdx
@@ -32,12 +32,12 @@ how to update your project.
       </li>
     </ul>
     This change also opens the door to a lot of new features, including the{' '}
-    <Link to="https://github.com/motion-canvas/motion-canvas/issues/213">
+    <Link to="https://github.com/revideo/revideo/issues/213">
       Presentation Mode
     </Link>
-    , <Link to="https://github.com/motion-canvas/motion-canvas/issues/170">
+    , <Link to="https://github.com/revideo/revideo/issues/170">
       Editable Signals
-    </Link> and <Link to="https://github.com/motion-canvas/motion-canvas/issues/364">
+    </Link> and <Link to="https://github.com/revideo/revideo/issues/364">
       Custom Exporters
     </Link>.
   </Issue>

--- a/packages/docs/blog/2023-04-06-example-cubic.tsx
+++ b/packages/docs/blog/2023-04-06-example-cubic.tsx
@@ -1,6 +1,6 @@
 // snippet Cubic Bezier
-import {CubicBezier, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {CubicBezier, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();

--- a/packages/docs/blog/2023-04-06-example-quadratic.tsx
+++ b/packages/docs/blog/2023-04-06-example-quadratic.tsx
@@ -1,6 +1,6 @@
 // snippet Quadratic Bezier
-import {QuadBezier, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {QuadBezier, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<QuadBezier>();

--- a/packages/docs/blog/2023-05-08-cardinal.tsx
+++ b/packages/docs/blog/2023-05-08-cardinal.tsx
@@ -1,5 +1,5 @@
-import {makeScene2D, Rect} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const rect = createRef<Rect>();

--- a/packages/docs/blog/2023-05-13-version-3.8.0.mdx
+++ b/packages/docs/blog/2023-05-13-version-3.8.0.mdx
@@ -16,7 +16,7 @@ import CodeBlock from '@theme/CodeBlock';
     The brand new <Link to="/docs/rendering/video">Video (FFmpeg)</Link>{' '}
     exporter lets you render your animations directly to a video file. It's
     included by default (with the option to opt out) in all new projects created
-    with <code>npm init @motion-canvas</code>. Check out the docs to learn{' '}
+    with <code>npm init @revideo</code>. Check out the docs to learn{' '}
     <Link to="/docs/rendering/video#existing-project">how to install it</Link>{' '}
     in your existing projects.
     <PullRequest id={673} />
@@ -42,7 +42,7 @@ import CodeBlock from '@theme/CodeBlock';
     providing answers without having to go through the interactive prompt:
     <PullRequest id={668} />
     <CodeBlock language={'shell'} className="margin-top--sm margin-bottom--sm">
-      {`npm init @motion-canvas@latest -- --name Hello --path ./hello --language ts`}
+      {`npm init @revideo@latest -- --name Hello --path ./hello --language ts`}
     </CodeBlock>
   </Issue>
   <Issue user={'aarthificial'} pr={664}>

--- a/packages/docs/blog/2023-05-29-version-3.9.0.mdx
+++ b/packages/docs/blog/2023-05-29-version-3.9.0.mdx
@@ -17,10 +17,10 @@ import CodeBlock from '@theme/CodeBlock';
     only exception is the <code>CodeBlock</code> node which still requires the
     full import path:
     <CodeBlock language={'ts'} className="margin-top--sm margin-bottom--sm">
-      {`import {all, createRef} from '@motion-canvas/core';
-import {makeScene2D, Circle} from '@motion-canvas/2d';
+      {`import {all, createRef} from '@revideo/core';
+import {makeScene2D, Circle} from '@revideo/2d';
 // the only exception:
-import {CodeBlock, insert} from '@motion-canvas/2d/lib/components/CodeBlock';`}
+import {CodeBlock, insert} from '@revideo/2d/lib/components/CodeBlock';`}
     </CodeBlock>
     Importing from subdirectories will continue to work until version 4.
     <PullRequest id={721} />

--- a/packages/docs/blog/2023-07-23-curve.tsx
+++ b/packages/docs/blog/2023-07-23-curve.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {all, createRef, easeInCubic, easeOutCubic} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {all, createRef, easeInCubic, easeOutCubic} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const ref = createRef<Circle>();

--- a/packages/docs/blog/2023-07-23-path.tsx
+++ b/packages/docs/blog/2023-07-23-path.tsx
@@ -1,4 +1,4 @@
-import {makeScene2D, Path} from '@motion-canvas/2d';
+import {makeScene2D, Path} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(

--- a/packages/docs/blog/2023-10-14-skew.tsx
+++ b/packages/docs/blog/2023-10-14-skew.tsx
@@ -1,5 +1,5 @@
-import {Img, makeScene2D} from '@motion-canvas/2d';
-import {createRef, easeOutElastic} from '@motion-canvas/core';
+import {Img, makeScene2D} from '@revideo/2d';
+import {createRef, easeOutElastic} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const ref = createRef<Img>();

--- a/packages/docs/blog/2023-12-31-glob.tsx
+++ b/packages/docs/blog/2023-12-31-glob.tsx
@@ -1,4 +1,4 @@
-import motionCanvas from '@motion-canvas/vite-plugin';
+import motionCanvas from '@revideo/vite-plugin';
 import {defineConfig} from 'vite';
 
 export default defineConfig({

--- a/packages/docs/blog/2023-12-31-line.tsx
+++ b/packages/docs/blog/2023-12-31-line.tsx
@@ -1,5 +1,5 @@
-import {Line, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {Line, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const line = createRef<Line>();

--- a/packages/docs/blog/2023-12-31-txt.tsx
+++ b/packages/docs/blog/2023-12-31-txt.tsx
@@ -1,4 +1,4 @@
-import {Txt, makeScene2D} from '@motion-canvas/2d';
+import {Txt, makeScene2D} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.fill('#141414');

--- a/packages/docs/blog/2024-02-04-shaders.tsx
+++ b/packages/docs/blog/2024-02-04-shaders.tsx
@@ -1,5 +1,5 @@
-import {Rect, makeScene2D} from '@motion-canvas/2d';
-import {waitFor} from '@motion-canvas/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
 
 // Original shader created by ufffd
 // https://www.shadertoy.com/view/lcfXD8

--- a/packages/docs/bundle.js
+++ b/packages/docs/bundle.js
@@ -23,9 +23,9 @@ module.exports = () => ({
           },
           innerHTML: JSON.stringify({
             imports: {
-              '@motion-canvas/core': `${core}`,
-              '@motion-canvas/2d': `${two}`,
-              '@motion-canvas/2d/jsx-runtime': `${two}`,
+              '@revideo/core': `${core}`,
+              '@revideo/2d': `${two}`,
+              '@revideo/2d/jsx-runtime': `${two}`,
               '@lezer/javascript': 'https://esm.sh/@lezer/javascript',
             },
           }),

--- a/packages/docs/docs/advanced/code/filters-and-effects/destination-in-example.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/destination-in-example.tsx
@@ -1,5 +1,5 @@
-import {Img, Node, makeScene2D} from '@motion-canvas/2d';
-import {createRef, linear} from '@motion-canvas/core';
+import {Img, Node, makeScene2D} from '@revideo/2d';
+import {createRef, linear} from '@revideo/core';
 
 // Image by Marek Piwnicki (https://unsplash.com/photos/_4o-1pr2oqU)
 const ImageSource =

--- a/packages/docs/docs/advanced/code/filters-and-effects/destination-out-example.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/destination-out-example.tsx
@@ -1,5 +1,5 @@
-import {Img, Node, makeScene2D} from '@motion-canvas/2d';
-import {createRef, linear} from '@motion-canvas/core';
+import {Img, Node, makeScene2D} from '@revideo/2d';
+import {createRef, linear} from '@revideo/core';
 
 // Image by Marek Piwnicki (https://unsplash.com/photos/_4o-1pr2oqU)
 const ImageSource =

--- a/packages/docs/docs/advanced/code/filters-and-effects/filters-order.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/filters-order.tsx
@@ -7,8 +7,8 @@ import {
   contrast,
   makeScene2D,
   saturate,
-} from '@motion-canvas/2d';
-import {createSignal, linear, map, waitFor} from '@motion-canvas/core';
+} from '@revideo/2d';
+import {createSignal, linear, map, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.fontFamily('monospace').fontSize(20).fill('#141414');

--- a/packages/docs/docs/advanced/code/filters-and-effects/filters-preview.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/filters-preview.tsx
@@ -1,5 +1,5 @@
-import {Img, Txt, makeScene2D} from '@motion-canvas/2d';
-import {all, createRef, createSignal, linear} from '@motion-canvas/core';
+import {Img, Txt, makeScene2D} from '@revideo/2d';
+import {all, createRef, createSignal, linear} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.fill('#141414');

--- a/packages/docs/docs/advanced/code/filters-and-effects/masking-visualized-source-in.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/masking-visualized-source-in.tsx
@@ -1,12 +1,4 @@
-import {
-  Grid,
-  Img,
-  Layout,
-  makeScene2D,
-  Node,
-  Rect,
-  Txt,
-} from '@motion-canvas/2d';
+import {Grid, Img, Layout, makeScene2D, Node, Rect, Txt} from '@revideo/2d';
 import {
   all,
   createRef,
@@ -14,7 +6,7 @@ import {
   Origin,
   Vector2,
   waitFor,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 const ImageSource =
   'https://images.unsplash.com/photo-1685901088371-f498db7f8c46';

--- a/packages/docs/docs/advanced/code/filters-and-effects/source-in-example.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/source-in-example.tsx
@@ -1,5 +1,5 @@
-import {Img, Node, makeScene2D} from '@motion-canvas/2d';
-import {createRef, linear} from '@motion-canvas/core';
+import {Img, Node, makeScene2D} from '@revideo/2d';
+import {createRef, linear} from '@revideo/core';
 
 // Image by Marek Piwnicki (https://unsplash.com/photos/_4o-1pr2oqU)
 const ImageSource =

--- a/packages/docs/docs/advanced/code/filters-and-effects/source-out-example.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/source-out-example.tsx
@@ -1,5 +1,5 @@
-import {Img, Node, makeScene2D} from '@motion-canvas/2d';
-import {createRef, linear} from '@motion-canvas/core';
+import {Img, Node, makeScene2D} from '@revideo/2d';
+import {createRef, linear} from '@revideo/core';
 
 // Image by Marek Piwnicki (https://unsplash.com/photos/_4o-1pr2oqU)
 const ImageSource =

--- a/packages/docs/docs/advanced/code/filters-and-effects/xor-destination-in-example.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/xor-destination-in-example.tsx
@@ -1,5 +1,5 @@
-import {Circle, Img, Node, makeScene2D} from '@motion-canvas/2d';
-import {createRef, easeInOutSine, linear} from '@motion-canvas/core';
+import {Circle, Img, Node, makeScene2D} from '@revideo/2d';
+import {createRef, easeInOutSine, linear} from '@revideo/core';
 
 /*
  * This example shows you that you can also nest composite operations.

--- a/packages/docs/docs/advanced/code/filters-and-effects/xor-example.tsx
+++ b/packages/docs/docs/advanced/code/filters-and-effects/xor-example.tsx
@@ -1,5 +1,5 @@
-import {Circle, Img, Node, makeScene2D} from '@motion-canvas/2d';
-import {createRef, easeInOutSine, linear} from '@motion-canvas/core';
+import {Circle, Img, Node, makeScene2D} from '@revideo/2d';
+import {createRef, easeInOutSine, linear} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.fill('#141414');

--- a/packages/docs/docs/advanced/code/tsconfig.json
+++ b/packages/docs/docs/advanced/code/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@motion-canvas/2d/tsconfig.project.json",
+  "extends": "@revideo/2d/tsconfig.project.json",
   "include": ["."]
 }

--- a/packages/docs/docs/advanced/custom-font.mdx
+++ b/packages/docs/docs/advanced/custom-font.mdx
@@ -13,7 +13,7 @@ To use a font from hosters like Google Fonts. First make a css file under `src`
 root
 └─src
   ├─scenes/
-  ├─motion-canvas.d.ts
+  ├─revideo.d.ts
   ├─project.meta
   ├─project.ts
 + └─global.css
@@ -28,7 +28,7 @@ Inside `global.css`, import the font using `@import url(your link)`.
 Then, in `project.ts`, import the css file.
 
 ```ts
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import example from './scenes/example?scene';
 

--- a/packages/docs/docs/advanced/filters-and-effects.mdx
+++ b/packages/docs/docs/advanced/filters-and-effects.mdx
@@ -35,8 +35,8 @@ properties directly on the [`Node`](/api/2d/components/Node#opacity), class.
 
 ```tsx editor
 // snippet Filters Property
-import {Img, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {Img, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.fill('#141414');
@@ -53,8 +53,8 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Filters Array
-import {makeScene2D, Img, blur} from '@motion-canvas/2d';
-import {createSignal} from '@motion-canvas/core';
+import {makeScene2D, Img, blur} from '@revideo/2d';
+import {createSignal} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.fill('#141414');

--- a/packages/docs/docs/advanced/plugins/editor.mdx
+++ b/packages/docs/docs/advanced/plugins/editor.mdx
@@ -73,18 +73,18 @@ export const CustomTabConfig: PluginTabConfig = {
 First of all, the editor is built on top of [Preact](https://preactjs.com/).
 Just like Motion Canvas, Preact uses JSX to define components. This means that
 in `tsx` files extending the editor, we need to let TypeScript know that it
-should import the `jsx` factory function from `preact` and not
-`@revideo/2d`. This can be done in multiple different ways. In this simple
-example, we'll just use a comment at the top of the file:
+should import the `jsx` factory function from `preact` and not `@revideo/2d`.
+This can be done in multiple different ways. In this simple example, we'll just
+use a comment at the top of the file:
 
 ```tsx
 /* @jsxImportSource preact */
 ```
 
 Next, we define a component for the tab itself. This component will be rendered
-in the navigation bar on the left. We use the `Tab` component from
-`@revideo/ui` to stay consistent with the rest of the editor. We also
-borrow the `PhotoCamera` icon and put it inside:
+in the navigation bar on the left. We use the `Tab` component from `@revideo/ui`
+to stay consistent with the rest of the editor. We also borrow the `PhotoCamera`
+icon and put it inside:
 
 ```tsx
 function TabComponent({tab}: PluginTabProps) {

--- a/packages/docs/docs/advanced/plugins/editor.mdx
+++ b/packages/docs/docs/advanced/plugins/editor.mdx
@@ -15,10 +15,10 @@ for extending the editor interface itself.
 
 Let's update our plugin's entry point to export an editor plugin. The main
 difference is that we're now using the `makeEditorPlugin` function imported from
-`@motion-canvas/ui` to define it:
+`@revideo/ui` to define it:
 
 ```ts title="src/plugin.ts"
-import {makeEditorPlugin} from '@motion-canvas/ui';
+import {makeEditorPlugin} from '@revideo/ui';
 import {CustomTabConfig} from './CustomTabConfig';
 
 export default makeEditorPlugin({
@@ -44,7 +44,7 @@ import {
   PluginTabProps,
   Separator,
   Tab,
-} from '@motion-canvas/ui';
+} from '@revideo/ui';
 
 function TabComponent({tab}: PluginTabProps) {
   return (
@@ -74,7 +74,7 @@ First of all, the editor is built on top of [Preact](https://preactjs.com/).
 Just like Motion Canvas, Preact uses JSX to define components. This means that
 in `tsx` files extending the editor, we need to let TypeScript know that it
 should import the `jsx` factory function from `preact` and not
-`@motion-canvas/2d`. This can be done in multiple different ways. In this simple
+`@revideo/2d`. This can be done in multiple different ways. In this simple
 example, we'll just use a comment at the top of the file:
 
 ```tsx
@@ -83,7 +83,7 @@ example, we'll just use a comment at the top of the file:
 
 Next, we define a component for the tab itself. This component will be rendered
 in the navigation bar on the left. We use the `Tab` component from
-`@motion-canvas/ui` to stay consistent with the rest of the editor. We also
+`@revideo/ui` to stay consistent with the rest of the editor. We also
 borrow the `PhotoCamera` icon and put it inside:
 
 ```tsx
@@ -122,9 +122,9 @@ export const CustomTabConfig: PluginTabConfig = {
 
 Editor plugins are still experimental and the API is not yet properly documented
 but if you want to play around with some other available hooks you can take a
-look at [this editor plugin][example-plugin] provided by the `@motion-canvas/2d`
+look at [this editor plugin][example-plugin] provided by the `@revideo/2d`
 package. It's responsible for displaying the inspector tab and drawing an
 overlay on top of the preview when clicking on different nodes.
 
 [example-plugin]:
-  https://github.com/motion-canvas/motion-canvas/blob/main/packages/2d/src/editor/index.ts
+  https://github.com/revideo/revideo/blob/main/packages/2d/src/editor/index.ts

--- a/packages/docs/docs/advanced/plugins/index.mdx
+++ b/packages/docs/docs/advanced/plugins/index.mdx
@@ -33,4 +33,4 @@ fully-fledged plugin. It's runtime portion provides the editor with a Video
 Node.js. The server portion then uses FFmpeg to convert the frames into a video.
 
 [ffmpeg-plugin]:
-  https://github.com/motion-canvas/exporters/tree/main/packages/ffmpeg
+  https://github.com/revideo/exporters/tree/main/packages/ffmpeg

--- a/packages/docs/docs/advanced/plugins/index.mdx
+++ b/packages/docs/docs/advanced/plugins/index.mdx
@@ -32,5 +32,4 @@ fully-fledged plugin. It's runtime portion provides the editor with a Video
 [exporter](/api/core/app/Exporter) that sends the rendered frames over to
 Node.js. The server portion then uses FFmpeg to convert the frames into a video.
 
-[ffmpeg-plugin]:
-  https://github.com/revideo/exporters/tree/main/packages/ffmpeg
+[ffmpeg-plugin]: https://github.com/revideo/exporters/tree/main/packages/ffmpeg

--- a/packages/docs/docs/advanced/plugins/node.mdx
+++ b/packages/docs/docs/advanced/plugins/node.mdx
@@ -11,8 +11,8 @@ sidebar_position: 3
 
 Motion Canvas builds on top of the Vite plugin system. To create a plugin that
 runs on Node.js, you just create a [Vite plugin][vite-plugin] and import it in
-your `vite.config.ts` file. On top of that, `@revideo/vite-plugin`
-provides a symbol that lets you define revideo-specific options.
+your `vite.config.ts` file. On top of that, `@revideo/vite-plugin` provides a
+symbol that lets you define revideo-specific options.
 
 Let's start by creating a file for our plugin. This time we'll put it in the
 root directory of our project because Vite plugins are not part of the runtime

--- a/packages/docs/docs/advanced/plugins/node.mdx
+++ b/packages/docs/docs/advanced/plugins/node.mdx
@@ -11,8 +11,8 @@ sidebar_position: 3
 
 Motion Canvas builds on top of the Vite plugin system. To create a plugin that
 runs on Node.js, you just create a [Vite plugin][vite-plugin] and import it in
-your `vite.config.ts` file. On top of that, `@motion-canvas/vite-plugin`
-provides a symbol that lets you define motion-canvas-specific options.
+your `vite.config.ts` file. On top of that, `@revideo/vite-plugin`
+provides a symbol that lets you define revideo-specific options.
 
 Let's start by creating a file for our plugin. This time we'll put it in the
 root directory of our project because Vite plugins are not part of the runtime
@@ -43,11 +43,11 @@ runtime plugin:
 </div>
 
 ```ts title="myVitePlugin.ts"
-import {Plugin, PLUGIN_OPTIONS} from '@motion-canvas/vite-plugin';
+import {Plugin, PLUGIN_OPTIONS} from '@revideo/vite-plugin';
 
 export default function myVitePlugin(): Plugin {
   return {
-    name: 'vite-plugin-motion-canvas-example',
+    name: 'vite-plugin-revideo-example',
 
     // extend the dev server using Vite plugin hooks:
     configureServer(server) {
@@ -68,7 +68,7 @@ Here's how we would import such plugin in our `vite.config.ts` file:
 
 ```ts title="vite.config.ts"
 import {defineConfig} from 'vite';
-import motionCanvas from '@motion-canvas/vite-plugin';
+import motionCanvas from '@revideo/vite-plugin';
 // highlight-next-line
 import myVitePlugin from './myVitePlugin';
 
@@ -85,7 +85,7 @@ Also, since we defined the entry point in the Node.js plugin, we no longer need
 to import the runtime plugin in our project file:
 
 ```diff title="src/project.ts"
-  import {makeProject} from '@motion-canvas/core';
+  import {makeProject} from '@revideo/core';
 - import myPlugin from './plugin';
   import example from './scenes/example?scene';
 
@@ -112,11 +112,11 @@ A Node.js plugin has the ability to pass options to the runtime plugin. We can
 do that using the `runtimeConfig` property:
 
 ```ts title="myVitePlugin.ts"
-import {Plugin, PLUGIN_OPTIONS} from '@motion-canvas/vite-plugin';
+import {Plugin, PLUGIN_OPTIONS} from '@revideo/vite-plugin';
 
 export default function myVitePlugin(): Plugin {
   return {
-    name: 'vite-plugin-motion-canvas-example',
+    name: 'vite-plugin-revideo-example',
     // ...
     [PLUGIN_OPTIONS]: {
       entryPoint: './plugin.ts',
@@ -133,7 +133,7 @@ export default function myVitePlugin(): Plugin {
 We can then update the runtime plugin to receive these options:
 
 ```ts title="src/plugin.ts"
-import {makePlugin} from '@motion-canvas/core';
+import {makePlugin} from '@revideo/core';
 
 // highlight-start
 interface MyPluginOptions {
@@ -146,7 +146,7 @@ export default makePlugin((options?: MyPluginOptions) => {
   console.log(options?.foo); // 'bar'
 
   return {
-    name: 'motion-canvas-plugin-example',
+    name: 'revideo-plugin-example',
     player(player) {
       player.onRecalculated.subscribe(() => {
         player.requestReset();

--- a/packages/docs/docs/advanced/plugins/runtime.mdx
+++ b/packages/docs/docs/advanced/plugins/runtime.mdx
@@ -44,10 +44,10 @@ available hooks.
 </div>
 
 ```ts title="src/plugin.ts"
-import {makePlugin} from '@motion-canvas/core';
+import {makePlugin} from '@revideo/core';
 
 export default makePlugin({
-  name: 'motion-canvas-plugin-example',
+  name: 'revideo-plugin-example',
   player(player) {
     player.onRecalculated.subscribe(() => {
       player.requestReset();
@@ -68,7 +68,7 @@ actual plugin object (This can come in handy when
 [developing a Node.js plugin](/docs/plugins/node#passing-options-to-runtime)):
 
 ```ts title="src/project.ts"
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 // highlight-next-line
 import myPlugin from './plugin';
 import example from './scenes/example?scene';

--- a/packages/docs/docs/advanced/project-variables.mdx
+++ b/packages/docs/docs/advanced/project-variables.mdx
@@ -14,10 +14,10 @@ Adding variables via the player component can be done by passing a stringified
 json object to the variables attribute:
 
 ```html
-<motion-canvas-player
+<revideo-player
   src="/path/to/project.js"
   variables='{"circleFill":"red"}'
-></motion-canvas-player>
+></revideo-player>
 ```
 
 They can also be added using makeProject():

--- a/packages/docs/docs/advanced/random.mdx
+++ b/packages/docs/docs/advanced/random.mdx
@@ -5,7 +5,7 @@ slug: /random-values
 
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
-import source from '!!raw-loader!@motion-canvas/examples/src/scenes/random';
+import source from '!!raw-loader!@revideo/examples/src/scenes/random';
 
 # Random values
 
@@ -17,7 +17,7 @@ unpredictability in your animation. In Motion Canvas, it's achieved using the
 generator (RNG) for the current scene:
 
 ```ts
-import {useRandom} from '@motion-canvas/core';
+import {useRandom} from '@revideo/core';
 
 const random = useRandom();
 const integer = random.nextInt(0, 10);

--- a/packages/docs/docs/advanced/shaders.mdx
+++ b/packages/docs/docs/advanced/shaders.mdx
@@ -37,7 +37,7 @@ Below is an example of a simple shader that inverts the colors of the node:
 #version 300 es
 precision highp float;
 
-#include "@motion-canvas/core/shaders/common.glsl"
+#include "@revideo/core/shaders/common.glsl"
 
 void main() {
     outColor = texture(sourceTexture, sourceUV);
@@ -64,7 +64,7 @@ It can point to a relative file:
 Or to a file from another package:
 
 ```glsl
-#include "@motion-canvas/core/shaders/common.glsl"
+#include "@revideo/core/shaders/common.glsl"
 ```
 
 For convenience, a GLSL file can be imported only once per shader. Each
@@ -96,7 +96,7 @@ uniform mat4 destinationMatrix;
 They can be included using the following directive:
 
 ```glsl
-#include "@motion-canvas/core/shaders/common.glsl"
+#include "@revideo/core/shaders/common.glsl"
 ```
 
 ## Source and Destination

--- a/packages/docs/docs/advanced/spawners.mdx
+++ b/packages/docs/docs/advanced/spawners.mdx
@@ -44,8 +44,8 @@ dependencies and recompute its value whenever they change. We can animate our
 `count` signal to see if it works:
 
 ```tsx editor
-import {makeScene2D, Layout, Circle} from '@motion-canvas/2d';
-import {createSignal, linear, range} from '@motion-canvas/core';
+import {makeScene2D, Layout, Circle} from '@revideo/2d';
+import {createSignal, linear, range} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const count = createSignal(10);

--- a/packages/docs/docs/components/bezier.mdx
+++ b/packages/docs/docs/components/bezier.mdx
@@ -7,8 +7,8 @@ slug: /bezier-curves
 
 ```tsx editor
 // snippet Cubic Bézier
-import {makeScene2D, CubicBezier} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, CubicBezier} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();
@@ -31,8 +31,8 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Quadratic Bézier
-import {makeScene2D, QuadBezier} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, QuadBezier} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<QuadBezier>();
@@ -79,8 +79,8 @@ a cubic Bézier curve has two.
 
 ```tsx editor
 // snippet Cubic Bézier
-import {makeScene2D, CubicBezier} from '@motion-canvas/2d';
-import {createRef, waitFor} from '@motion-canvas/core';
+import {makeScene2D, CubicBezier} from '@revideo/2d';
+import {createRef, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();
@@ -101,8 +101,8 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Quadratic Bézier
-import {makeScene2D, QuadBezier} from '@motion-canvas/2d';
-import {createRef, waitFor} from '@motion-canvas/core';
+import {makeScene2D, QuadBezier} from '@revideo/2d';
+import {createRef, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<QuadBezier>();
@@ -150,8 +150,8 @@ control the size of the arrowheads with the [`arrowSize`][arrow-size] signal.
 
 ```tsx editor
 // snippet Cubic Bézier
-import {makeScene2D, CubicBezier} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, CubicBezier} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();
@@ -175,8 +175,8 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Quadratic Bézier
-import {makeScene2D, QuadBezier} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, QuadBezier} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<QuadBezier>();
@@ -229,8 +229,8 @@ The following section shows examples of common animations for Bézier curves.
 
 ```tsx editor
 // snippet Drawing Bézier curves
-import {makeScene2D, CubicBezier} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, CubicBezier} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();
@@ -252,13 +252,13 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Moving nodes along a curve
-import {makeScene2D, CubicBezier, Rect} from '@motion-canvas/2d';
+import {makeScene2D, CubicBezier, Rect} from '@revideo/2d';
 import {
   createRef,
   waitFor,
   createSignal,
   createComputed,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();

--- a/packages/docs/docs/components/bezier.mdx
+++ b/packages/docs/docs/components/bezier.mdx
@@ -253,12 +253,7 @@ export default makeScene2D(function* (view) {
 
 // snippet Moving nodes along a curve
 import {makeScene2D, CubicBezier, Rect} from '@revideo/2d';
-import {
-  createRef,
-  waitFor,
-  createSignal,
-  createComputed,
-} from '@revideo/core';
+import {createRef, waitFor, createSignal, createComputed} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const bezier = createRef<CubicBezier>();

--- a/packages/docs/docs/components/code-block.mdx
+++ b/packages/docs/docs/components/code-block.mdx
@@ -21,7 +21,7 @@ important snippets.
 To display code, set the `code` and `language` property.
 
 ```tsx
-import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
+import {CodeBlock} from '@revideo/2d/lib/components/CodeBlock';
 
 yield view.add(
   <CodeBlock language="c#" code={`Console.WriteLine("Hello World!")`} />,
@@ -47,7 +47,7 @@ For convenience, the indentation of code will be automatically adjust whenever
 the code starts with a new line.
 
 ```tsx
-import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
+import {CodeBlock} from '@revideo/2d/lib/components/CodeBlock';
 
 yield view.add(
   // note that the ` bracket is followed by a new line
@@ -70,7 +70,7 @@ console.log('Hello World!');
 The indentation is then set by the least indented code.
 
 ```tsx
-import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
+import {CodeBlock} from '@revideo/2d/lib/components/CodeBlock';
 
 yield view.add(
   // note that the ` bracket is followed by a new line
@@ -101,8 +101,8 @@ You can define the selection with the help of three helper functions — `range`
 `word` and `lines`.
 
 ```tsx
-import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
-import {createRef} from '@motion-canvas/core';
+import {CodeBlock} from '@revideo/2d/lib/components/CodeBlock';
+import {createRef} from '@revideo/core';
 
 const codeBlockRef = createRef<CodeBlock>();
 yield view.add(
@@ -170,7 +170,7 @@ If you wish to undo a selection, you can either select all lines from `0` to
 `Infinity`, or simply pass `DEFAULT` as a selection, as shown below:
 
 ```ts
-import {DEFAULT} from '@motion-canvas/core';
+import {DEFAULT} from '@revideo/core';
 
 // highlight lines 1 and 2
 yield * codeRef().selection(lines(1, 2), 1);
@@ -227,8 +227,8 @@ for future edits. Then call `edit` with an embedded `insert` call to add the new
 code.
 
 ```tsx
-import {CodeBlock, insert} from '@motion-canvas/2d/lib/components/CodeBlock';
-import {createRef} from '@motion-canvas/core';
+import {CodeBlock, insert} from '@revideo/2d/lib/components/CodeBlock';
+import {createRef} from '@revideo/core';
 
 const codeRef = createRef<CodeBlock>();
 
@@ -248,7 +248,7 @@ Removing code is similar, only with the provided code being removed during the
 animation.
 
 ```tsx
-import {CodeBlock, remove} from '@motion-canvas/2d/lib/components/CodeBlock';
+import {CodeBlock, remove} from '@revideo/2d/lib/components/CodeBlock';
 
 yield view.add(<CodeBlock ref={codeRef} code={`var myBool = true;`} />);
 

--- a/packages/docs/docs/components/custom-components.mdx
+++ b/packages/docs/docs/components/custom-components.mdx
@@ -5,7 +5,7 @@ slug: /custom-components
 
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
-import source from '!!raw-loader!@motion-canvas/examples/src/components/Switch';
+import source from '!!raw-loader!@revideo/examples/src/components/Switch';
 
 # Custom Components
 

--- a/packages/docs/docs/components/nodes.mdx
+++ b/packages/docs/docs/components/nodes.mdx
@@ -5,7 +5,7 @@ slug: /nodes
 
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
-import texSource from '!!raw-loader!@motion-canvas/examples/src/scenes/tex';
+import texSource from '!!raw-loader!@revideo/examples/src/scenes/tex';
 
 # LaTeX
 

--- a/packages/docs/docs/components/path.mdx
+++ b/packages/docs/docs/components/path.mdx
@@ -6,8 +6,8 @@ slug: /path
 # Path
 
 ```tsx editor
-import {makeScene2D, Path} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Path} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const path = createRef<Path>();
@@ -43,8 +43,8 @@ You can define path to display by setting `data` property of Path component.
 To morph between two path you can tween `data` property.
 
 ```tsx editor
-import {makeScene2D, Path} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Path} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const path = createRef<Path>();
@@ -73,8 +73,8 @@ Like Spline and Bezier, you can also make other components follow this component
 path. You can use the `getPointAtPercentage` to get point along this path.
 
 ```tsx editor
-import {makeScene2D, Path, Rect} from '@motion-canvas/2d';
-import {createRef, createSignal} from '@motion-canvas/core';
+import {makeScene2D, Path, Rect} from '@revideo/2d';
+import {createRef, createSignal} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const path = createRef<Path>();

--- a/packages/docs/docs/components/spline.mdx
+++ b/packages/docs/docs/components/spline.mdx
@@ -6,8 +6,8 @@ slug: /spline
 # Spline
 
 ```tsx editor
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const spline = createRef<Spline>();
@@ -52,7 +52,7 @@ via the spline's `points` property. Each point will be treated as the position
 of one of the spline's knots.
 
 ```tsx editor
-import {makeScene2D, Spline} from '@motion-canvas/2d';
+import {makeScene2D, Spline} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(
@@ -83,8 +83,8 @@ We can alter the shape of the curve by passing a value between `0` and `1` to
 the `smoothness` property.
 
 ```tsx editor
-import {makeScene2D, Spline} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Spline} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const spline = createRef<Spline>();
@@ -131,7 +131,7 @@ The second way of defining knots is by—fittingly—using the [Knot][knot] node
 The same spline from above can also be written like this.
 
 ```tsx editor
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(
@@ -151,7 +151,7 @@ allows us to control the positions of each knot's handles via the `startHandle`
 and `endHandle` properties.
 
 ```tsx editor
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(
@@ -194,7 +194,7 @@ knot**. Broken knots are very useful because they allow us to add sharp corners
 to our spline.
 
 ```tsx editor
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(
@@ -256,8 +256,8 @@ handles (`1`).
 Since `auto` is a signal, it can also be animated.
 
 ```tsx editor
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
-import {all, makeRef} from '@motion-canvas/core';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
+import {all, makeRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const knots: Knot[] = [];
@@ -323,8 +323,8 @@ taking the offset into account.
 We can then animate drawing a spline by tweening these properties:
 
 ```tsx editor
-import {makeScene2D, Spline} from '@motion-canvas/2d';
-import {all, createRef} from '@motion-canvas/core';
+import {makeScene2D, Spline} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const spline = createRef<Spline>();
@@ -376,8 +376,8 @@ transformations.
 
 ```tsx editor
 // snippet Position
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
-import {all, makeRef, PossibleVector2} from '@motion-canvas/core';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
+import {all, makeRef, PossibleVector2} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const knotPositions: PossibleVector2[] = [
@@ -405,8 +405,8 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Rotation
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
-import {createRef, linear} from '@motion-canvas/core';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
+import {createRef, linear} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const knot = createRef<Knot>();
@@ -423,8 +423,8 @@ export default makeScene2D(function* (view) {
 });
 
 // snippet Scale
-import {makeScene2D, Spline, Knot} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Spline, Knot} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const knot = createRef<Knot>();
@@ -447,8 +447,8 @@ Splines can be useful to model the path that an object should follow. You can
 use the `getPointAtPercentage` method to achieve this.
 
 ```tsx editor
-import {makeScene2D, Spline, Rect} from '@motion-canvas/2d';
-import {createRef, createSignal} from '@motion-canvas/core';
+import {makeScene2D, Spline, Rect} from '@revideo/2d';
+import {createRef, createSignal} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const spline = createRef<Spline>();

--- a/packages/docs/docs/getting-started/configuration.mdx
+++ b/packages/docs/docs/getting-started/configuration.mdx
@@ -9,7 +9,7 @@ Motion Canvas is configured in the Vite's configuration file:
 
 ```ts title="vite.config.ts"
 import {defineConfig} from 'vite';
-import motionCanvas from '@motion-canvas/vite-plugin';
+import motionCanvas from '@revideo/vite-plugin';
 
 export default defineConfig({
   plugins: [
@@ -81,7 +81,7 @@ still working.
 ### `editor`
 
 - Type: `string`
-- Default: `@motion-canvas/ui`
+- Default: `@revideo/ui`
 
 The import path of the editor package.
 

--- a/packages/docs/docs/getting-started/flow.mdx
+++ b/packages/docs/docs/getting-started/flow.mdx
@@ -62,7 +62,7 @@ For instance, we could extract the flickering code from the above example to a
 separate generator and delegate our scene function to it:
 
 ```tsx
-import {ThreadGenerator} from '@motion-canvas/core';
+import {ThreadGenerator} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();
@@ -140,8 +140,8 @@ There are many ways to animate multiple objects. Here are some examples. Try
 using them in the below editor.
 
 ```tsx editor ratio=2
-import {makeScene2D, Rect} from '@motion-canvas/2d';
-import {all, waitFor, makeRef, range} from '@motion-canvas/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+import {all, waitFor, makeRef, range} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const rects: Rect[] = [];

--- a/packages/docs/docs/getting-started/hierarchy.mdx
+++ b/packages/docs/docs/getting-started/hierarchy.mdx
@@ -170,8 +170,8 @@ nodes. In this documentation, we'll be referring to this process as _querying_.
 Consider the following animation:
 
 ```tsx editor
-import {makeScene2D, Layout, Txt, Circle, Rect, is} from '@motion-canvas/2d';
-import {all} from '@motion-canvas/core';
+import {makeScene2D, Layout, Txt, Circle, Rect, is} from '@revideo/2d';
+import {all} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.add(
@@ -215,7 +215,7 @@ But Motion Canvas comes with a helpful utility function called
 [`is`](/api/2d/utils#is) that can create this predicate for us:
 
 ```ts
-import {is} from '@motion-canvas/2d';
+import {is} from '@revideo/2d';
 // ...
 const texts = view.findAll(is(Txt));
 ```

--- a/packages/docs/docs/getting-started/layouts.mdx
+++ b/packages/docs/docs/getting-started/layouts.mdx
@@ -89,8 +89,8 @@ include: [`middle`](/api/2d/components/Layout#middle),
 [`bottomRight`](/api/2d/components/Layout#bottomRight).
 
 ```tsx editor
-import {makeScene2D, Rect} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const rect = createRef<Rect>();

--- a/packages/docs/docs/getting-started/logging.mdx
+++ b/packages/docs/docs/getting-started/logging.mdx
@@ -6,14 +6,14 @@ slug: /logging
 # Logging
 
 One method of debugging your code or animation flow is using logging messages.
-For this, motion-canvas has its own built-in way to log messages.
+For this, revideo has its own built-in way to log messages.
 
-To get a reference to the Logger in motion-canvas you can use the `useLogger`
+To get a reference to the Logger in revideo you can use the `useLogger`
 function:
 
 ```tsx
-import {makeScene2D} from '@motion-canvas/2d';
-import {useLogger} from '@motion-canvas/core';
+import {makeScene2D} from '@revideo/2d';
+import {useLogger} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const logger = useLogger();

--- a/packages/docs/docs/getting-started/media.mdx
+++ b/packages/docs/docs/getting-started/media.mdx
@@ -75,7 +75,7 @@ Then we can use Motion Canvas [`Img`](/api/2d/components/Img) component to
 display the image:
 
 ```tsx
-import {makeScene2D, Img} from '@motion-canvas/2d';
+import {makeScene2D, Img} from '@revideo/2d';
 
 import examplePng from '../../images/example.png';
 
@@ -90,7 +90,7 @@ this, we need to create a [`Reference`](/docs/references) and pass that to the
 
 ```tsx
 // ...
-import {all, createRef} from '@motion-canvas/core';
+import {all, createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const imageRef = createRef<Img>();
@@ -129,7 +129,7 @@ Then we can use Motion Canvas [`Video`](/api/2d/components/Video) component to
 display the video as follows:
 
 ```tsx
-import {makeScene2D, Video} from '@motion-canvas/2d';
+import {makeScene2D, Video} from '@revideo/2d';
 
 import exampleMp4 from '../../videos/example.mp4';
 
@@ -143,7 +143,7 @@ the video we need to create a [`Reference`](/docs/references) to the element.
 
 ```tsx
 // ...
-import {createRef} from '@motion-canvas/core';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const videoRef = createRef<Video>();

--- a/packages/docs/docs/getting-started/presentation.mdx
+++ b/packages/docs/docs/getting-started/presentation.mdx
@@ -18,8 +18,8 @@ beginning of a new slide. When this function is yielded, the playback will pause
 and wait for you to press `SPACE`:
 
 ```ts
-import {makeScene2D, Txt} from '@motion-canvas/2d';
-import {beginSlide, createRef, waitFor} from '@motion-canvas/core';
+import {makeScene2D, Txt} from '@revideo/2d';
+import {beginSlide, createRef, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const title = createRef<Txt>();

--- a/packages/docs/docs/getting-started/quickstart.mdx
+++ b/packages/docs/docs/getting-started/quickstart.mdx
@@ -5,7 +5,7 @@ slug: /quickstart
 
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
-import source from '!!raw-loader!@motion-canvas/examples/src/scenes/quickstart';
+import source from '!!raw-loader!@revideo/examples/src/scenes/quickstart';
 
 # Quickstart
 
@@ -33,7 +33,7 @@ the command fails check out the [troubleshooting](#troubleshooting) section
 below):
 
 ```bash
-npm init @motion-canvas@latest
+npm init @revideo@latest
 ```
 
 Answer the prompts to name your project and select which language you would like
@@ -76,8 +76,8 @@ animations. Open `example.tsx` in a text editor, and replace all code in the
 file with the following snippet.
 
 ```tsx editor
-import {makeScene2D, Circle} from '@motion-canvas/2d';
-import {all, createRef} from '@motion-canvas/core';
+import {makeScene2D, Circle} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const myCircle = createRef<Circle>();
@@ -112,7 +112,7 @@ Each video in Motion Canvas is represented by a project configuration object. In
 our example, this configuration is declared in `src/project.ts`:
 
 ```ts title="src/project.ts"
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import example from './scenes/example?scene';
 
@@ -129,7 +129,7 @@ A scene is a set of elements displayed on the screen and an animation that
 governs them. The most basic scene looks as follows:
 
 ```tsx
-import {makeScene2D} from '@motion-canvas/2d';
+import {makeScene2D} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   // animation
@@ -293,7 +293,7 @@ This brings us back to our initial example:
 
 <details>
   <summary>
-    <code>npm init @motion-canvas@latest</code> fails to execute.
+    <code>npm init @revideo@latest</code> fails to execute.
   </summary>
 
 There was [a bug in npm](https://github.com/npm/cli/issues/5175) causing the
@@ -302,7 +302,7 @@ above command to fail. It got fixed in version `8.15.1`. You can follow
 update your npm. Alternatively, you can use the following command instead:
 
 ```bash
-npm exec @motion-canvas/create@latest
+npm exec @revideo/create@latest
 ```
 
 </details>

--- a/packages/docs/docs/getting-started/references.mdx
+++ b/packages/docs/docs/getting-started/references.mdx
@@ -89,7 +89,7 @@ The preferred way of using the `ref` property is in conjunction with the
 example, we can rewrite it as:
 
 ```tsx
-import {createRef} from '@motion-canvas/core';
+import {createRef} from '@revideo/core';
 
 // ...
 
@@ -142,7 +142,7 @@ We can use the [`makeRef()`](/api/core/utils#makeRef) function to simplify this
 process:
 
 ```tsx
-import {makeRef} from '@motion-canvas/core';
+import {makeRef} from '@revideo/core';
 
 // ...
 
@@ -179,7 +179,7 @@ You can also use the [`createRefArray()`](/api/core/utils#createRefArray) helper
 function to achieve the same result:
 
 ```tsx
-import {createRefArray, range} from '@motion-canvas/core';
+import {createRefArray, range} from '@revideo/core';
 
 // ...
 
@@ -245,7 +245,7 @@ tedious. The [`createRefMap()`](/api/core/utils#createRefMap) helper function
 lets us group references together based on the type of the node:
 
 ```tsx
-import {createRefMap} from '@motion-canvas/core';
+import {createRefMap} from '@revideo/core';
 
 // ...
 
@@ -322,7 +322,7 @@ redundancy. It can extract the type from the `Label` declaration and create an
 empty object matching it:
 
 ```tsx
-import {makeRef, makeRefs} from '@motion-canvas/core';
+import {makeRef, makeRefs} from '@revideo/core';
 
 // ...
 

--- a/packages/docs/docs/getting-started/rendering/video.mdx
+++ b/packages/docs/docs/getting-started/rendering/video.mdx
@@ -33,15 +33,15 @@ If you want to install the exporter in an existing project, run the following
 command:
 
 ```bash
-npm install --save @motion-canvas/ffmpeg
+npm install --save @revideo/ffmpeg
 ```
 
 And then configure it in your `vite.config.ts` file:
 
 ```diff
   import {defineConfig} from 'vite';
-  import motionCanvas from '@motion-canvas/vite-plugin';
-+ import ffmpeg from '@motion-canvas/ffmpeg';
+  import motionCanvas from '@revideo/vite-plugin';
++ import ffmpeg from '@revideo/ffmpeg';
 
   export default defineConfig({
     plugins: [
@@ -69,4 +69,4 @@ optimization for videos that will be served over the web. It rearranges the
 video data in the file, allowing the video to begin playing before it has
 finished downloading.
 
-[issues]: https://github.com/motion-canvas/exporters/issues/new/choose
+[issues]: https://github.com/revideo/exporters/issues/new/choose

--- a/packages/docs/docs/getting-started/signals.mdx
+++ b/packages/docs/docs/getting-started/signals.mdx
@@ -5,7 +5,7 @@ slug: /signals
 
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
-import signalSource from '!!raw-loader!@motion-canvas/examples/src/scenes/node-signal';
+import signalSource from '!!raw-loader!@revideo/examples/src/scenes/node-signal';
 
 # Signals
 
@@ -20,7 +20,7 @@ Signals for primitive types are created using the
 argument specifies their initial value:
 
 ```ts
-import {createSignal} from '@motion-canvas/core';
+import {createSignal} from '@revideo/core';
 
 const signal = createSignal(0);
 ```
@@ -29,7 +29,7 @@ Additionally, each complex type has a static `createSignal()` method that can be
 used to create a signal for said type:
 
 ```ts
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 
 const signal = Vector2.createSignal(Vector2.up);
 ```
@@ -124,7 +124,7 @@ we can reset a signal to its initial value by passing the
 [`DEFAULT`](/api/core/signals#DEFAULT) symbol to it:
 
 ```ts
-import {DEFAULT, createSignal} from '@motion-canvas/core';
+import {DEFAULT, createSignal} from '@revideo/core';
 
 const signal = createSignal(3); // <- initial value is 3
 signal(2);

--- a/packages/docs/docs/getting-started/tweening.mdx
+++ b/packages/docs/docs/getting-started/tweening.mdx
@@ -5,9 +5,9 @@ slug: /tweening
 
 import AnimationPlayer from '@site/src/components/AnimationPlayer';
 import CodeBlock from '@theme/CodeBlock';
-import linearSource from '!!raw-loader!@motion-canvas/examples/src/scenes/tweening-linear';
-import saveRestoreSource from '!!raw-loader!@motion-canvas/examples/src/scenes/tweening-save-restore';
-import springSource from '!!raw-loader!@motion-canvas/examples/src/scenes/tweening-spring';
+import linearSource from '!!raw-loader!@revideo/examples/src/scenes/tweening-linear';
+import saveRestoreSource from '!!raw-loader!@revideo/examples/src/scenes/tweening-save-restore';
+import springSource from '!!raw-loader!@revideo/examples/src/scenes/tweening-spring';
 
 # Tweening
 
@@ -91,7 +91,7 @@ numbers but to animate more complex types we'll need to use interpolation
 functions. Consider the following example:
 
 ```ts
-// import { Color } from "@motion-canvas/core";
+// import { Color } from "@revideo/core";
 yield *
   tween(2, value => {
     circle().fill(

--- a/packages/docs/docs/intro.md
+++ b/packages/docs/docs/intro.md
@@ -23,5 +23,4 @@ by reporting bugs, proposing new features, or contributing to the codebase. If
 you're interested, our [contribution guide][contributing] will help you get
 started.
 
-[contributing]:
-  https://github.com/motion-canvas/motion-canvas/blob/main/CONTRIBUTING.md
+[contributing]: https://github.com/revideo/revideo/blob/main/CONTRIBUTING.md

--- a/packages/docs/docs/migration/3.0.0.mdx
+++ b/packages/docs/docs/migration/3.0.0.mdx
@@ -83,9 +83,8 @@ Over to the meta file:
 
 ## `CodeBlock` revert
 
-Due to technical issues,
-[PR #401](https://github.com/revideo/revideo/pull/401) has been
-reverted.
+Due to technical issues, [PR #401](https://github.com/revideo/revideo/pull/401)
+has been reverted.
 
 - The [`CodeBlock`](/docs/code-block) should be imported using the full path
   again:

--- a/packages/docs/docs/migration/3.0.0.mdx
+++ b/packages/docs/docs/migration/3.0.0.mdx
@@ -7,10 +7,10 @@ slug: /migrating-to-3.0.0
 
 ## Installation
 
-Update all `@motion-canvas` packages to version `3.x.x` by running:
+Update all `@revideo` packages to version `3.x.x` by running:
 
 ```bash
-npm install --save @motion-canvas/2d@3 @motion-canvas/core@3 @motion-canvas/ui@3 @motion-canvas/vite-plugin@3
+npm install --save @revideo/2d@3 @revideo/core@3 @revideo/ui@3 @revideo/vite-plugin@3
 ```
 
 ## Name changes
@@ -38,7 +38,7 @@ automatically updated to contain these new settings.
 You can transfer your configuration from the project file:
 
 ```ts title="src/project.ts"
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import example from './scenes/example?scene';
 
@@ -84,13 +84,13 @@ Over to the meta file:
 ## `CodeBlock` revert
 
 Due to technical issues,
-[PR #401](https://github.com/motion-canvas/motion-canvas/pull/401) has been
+[PR #401](https://github.com/revideo/revideo/pull/401) has been
 reverted.
 
 - The [`CodeBlock`](/docs/code-block) should be imported using the full path
   again:
   ```ts
-  import {CodeBlock} from '@motion-canvas/2d/lib/components/CodeBlock';
+  import {CodeBlock} from '@revideo/2d/lib/components/CodeBlock';
   ```
 - The `stockTheme` property is not supported for the time being.
 

--- a/packages/docs/docs/migration/updating.mdx
+++ b/packages/docs/docs/migration/updating.mdx
@@ -8,8 +8,7 @@ slug: /updating
 The latest patch notes can be found
 [here](https://github.com/revideo/revideo/releases).
 
-To update all the `@revideo` packages to the latest version use the
-following:
+To update all the `@revideo` packages to the latest version use the following:
 
 ```bash
 npm update --save @revideo/2d @revideo/core @revideo/ui @revideo/vite-plugin

--- a/packages/docs/docs/migration/updating.mdx
+++ b/packages/docs/docs/migration/updating.mdx
@@ -6,13 +6,13 @@ slug: /updating
 # Update Guide
 
 The latest patch notes can be found
-[here](https://github.com/motion-canvas/motion-canvas/releases).
+[here](https://github.com/revideo/revideo/releases).
 
-To update all the `@motion-canvas` packages to the latest version use the
+To update all the `@revideo` packages to the latest version use the
 following:
 
 ```bash
-npm update --save @motion-canvas/2d @motion-canvas/core @motion-canvas/ui @motion-canvas/vite-plugin
+npm update --save @revideo/2d @revideo/core @revideo/ui @revideo/vite-plugin
 ```
 
 ## Troubleshooting

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -10,8 +10,8 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.svg',
-  organizationName: 'motion-canvas',
-  projectName: 'motion-canvas.github.io',
+  organizationName: 'revideo',
+  projectName: 'revideo.github.io',
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
@@ -23,8 +23,8 @@ const config = {
     discordApi:
       'https://discord.com/api/guilds/1071029581009657896/widget.json',
     discordUrl: 'https://chat.motioncanvas.io',
-    githubApi: 'https://api.github.com/repos/motion-canvas/motion-canvas',
-    githubUrl: 'https://github.com/motion-canvas/motion-canvas',
+    githubApi: 'https://api.github.com/repos/revideo/revideo',
+    githubUrl: 'https://github.com/revideo/revideo',
   },
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
@@ -93,7 +93,7 @@ const config = {
               },
               {
                 label: 'GitHub',
-                href: 'https://github.com/motion-canvas/motion-canvas',
+                href: 'https://github.com/revideo/revideo',
               },
             ],
           },
@@ -103,7 +103,7 @@ const config = {
       algolia: {
         appId: 'Q6Z7BJ83RF',
         apiKey: '825d6a74e138e6e1378e9669b22720f0',
-        indexName: 'motion-canvasio',
+        indexName: 'revideoio',
       },
       prism: {
         theme: require('./config/codeTheme'),
@@ -144,7 +144,7 @@ const config = {
           ],
         },
         editUrl: ({versionDocsDirPath, docPath}) =>
-          `https://github.com/motion-canvas/motion-canvas/blob/main/packages/docs/${versionDocsDirPath}/${docPath}`,
+          `https://github.com/revideo/revideo/blob/main/packages/docs/${versionDocsDirPath}/${docPath}`,
       },
     ],
     [
@@ -152,7 +152,7 @@ const config = {
       {
         showReadingTime: true,
         editUrl: ({blogDirPath, blogPath}) =>
-          `https://github.com/motion-canvas/motion-canvas/blob/main/packages/docs/${blogDirPath}/${blogPath}`,
+          `https://github.com/revideo/revideo/blob/main/packages/docs/${blogDirPath}/${blogPath}`,
       },
     ],
     '@docusaurus/plugin-content-pages',

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@motion-canvas/docs",
+  "name": "@revideo/docs",
   "version": "0.0.0",
   "private": true,
   "scripts": {
@@ -24,8 +24,8 @@
     "@docusaurus/theme-mermaid": "^2.4.0",
     "@docusaurus/theme-search-algolia": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
-    "@motion-canvas/examples": "*",
-    "@motion-canvas/player": "*",
+    "@revideo/examples": "*",
+    "@revideo/player": "*",
     "clsx": "^1.2.0",
     "codemirror": "^6.0.1",
     "prism-react-renderer": "^1.3.5",

--- a/packages/docs/release-blog-generator.js
+++ b/packages/docs/release-blog-generator.js
@@ -67,7 +67,7 @@ ${issues.map(Issue).join('\n')}
     if (!(type in types)) continue;
 
     const response = await fetch(
-      `https://api.github.com/repos/motion-canvas/motion-canvas/pulls/${pr}`,
+      `https://api.github.com/repos/revideo/revideo/pulls/${pr}`,
     );
     const prData = await response.json();
     types[type].push({

--- a/packages/docs/src/components/AnimationPlayer/AnimationLink.tsx
+++ b/packages/docs/src/components/AnimationPlayer/AnimationLink.tsx
@@ -9,7 +9,7 @@ export interface AnimationLinkProps {
 }
 
 export default function AnimationLink({name}: AnimationLinkProps) {
-  const url = `https://github.com/motion-canvas/motion-canvas/blob/main/packages/examples/src/scenes/${name}.tsx`;
+  const url = `https://github.com/revideo/revideo/blob/main/packages/examples/src/scenes/${name}.tsx`;
   return (
     <Link to={url} className={clsx('padding--sm', styles.link)}>
       <span>View source code</span>

--- a/packages/docs/src/components/AnimationPlayer/index.tsx
+++ b/packages/docs/src/components/AnimationPlayer/index.tsx
@@ -1,19 +1,19 @@
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
-import type {MotionCanvasPlayerProps} from '@motion-canvas/player';
+import type {MotionCanvasPlayerProps} from '@revideo/player';
 import clsx from 'clsx';
 import React, {ComponentProps} from 'react';
 import AnimationLink from './AnimationLink';
 import styles from './styles.module.css';
 
 if (ExecutionEnvironment.canUseDOM) {
-  import('@motion-canvas/player');
+  import('@revideo/player');
 }
 
 declare global {
   namespace JSX {
     interface IntrinsicElements {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      'motion-canvas-player': MotionCanvasPlayerProps & ComponentProps<'div'>;
+      'revideo-player': MotionCanvasPlayerProps & ComponentProps<'div'>;
     }
   }
 }
@@ -39,7 +39,7 @@ export default function AnimationPlayer({
         small && styles.small,
       )}
     >
-      <motion-canvas-player
+      <revideo-player
         class={styles.player}
         src={`/examples/${name}.js`}
         auto={banner}

--- a/packages/docs/src/components/Fiddle/SharedPlayer.ts
+++ b/packages/docs/src/components/Fiddle/SharedPlayer.ts
@@ -1,11 +1,11 @@
-import type {View2D} from '@motion-canvas/2d';
+import type {View2D} from '@revideo/2d';
 import type {
   FullSceneDescription,
   Player as PlayerType,
   Project,
   Stage as StageType,
   ThreadGeneratorFactory,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 let ProjectInstance: Project = null;
 let Description: FullSceneDescription<ThreadGeneratorFactory<View2D>> = null;
@@ -57,10 +57,8 @@ export async function borrowPlayer(
       Stage,
       ValueDispatcher,
       DefaultPlugin,
-    } = await import(/* webpackIgnore: true */ '@motion-canvas/core');
-    const {makeScene2D} = await import(
-      /* webpackIgnore: true */ '@motion-canvas/2d'
-    );
+    } = await import(/* webpackIgnore: true */ '@revideo/core');
+    const {makeScene2D} = await import(/* webpackIgnore: true */ '@revideo/2d');
 
     Description = makeScene2D(function* () {
       yield;

--- a/packages/docs/src/components/Fiddle/autocomplete.ts
+++ b/packages/docs/src/components/Fiddle/autocomplete.ts
@@ -23,12 +23,8 @@ function loadModule(module: Record<string, unknown>) {
 }
 
 if (ExecutionEnvironment.canUseDOM) {
-  import(/* webpackIgnore: true */ '@motion-canvas/core')
-    .then(loadModule)
-    .catch();
-  import(/* webpackIgnore: true */ '@motion-canvas/2d')
-    .then(loadModule)
-    .catch();
+  import(/* webpackIgnore: true */ '@revideo/core').then(loadModule).catch();
+  import(/* webpackIgnore: true */ '@revideo/2d').then(loadModule).catch();
 }
 
 export function autocomplete() {

--- a/packages/docs/src/components/Fiddle/index.tsx
+++ b/packages/docs/src/components/Fiddle/index.tsx
@@ -5,7 +5,7 @@ import {EditorState, Text} from '@codemirror/state';
 import {EditorView, keymap} from '@codemirror/view';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import {useLocation} from '@docusaurus/router';
-import type {Player} from '@motion-canvas/core';
+import type {Player} from '@revideo/core';
 import IconImage from '@site/src/Icon/Image';
 import {Pause} from '@site/src/Icon/Pause';
 import {PlayArrow} from '@site/src/Icon/PlayArrow';

--- a/packages/docs/src/components/Fiddle/transformer.ts
+++ b/packages/docs/src/components/Fiddle/transformer.ts
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import * as Babel from '@babel/standalone';
-import type {View2D} from '@motion-canvas/2d';
-import type {
-  FullSceneDescription,
-  ThreadGeneratorFactory,
-} from '@motion-canvas/core';
+import type {View2D} from '@revideo/2d';
+import type {FullSceneDescription, ThreadGeneratorFactory} from '@revideo/core';
 
 export class TransformError extends Error {
   public constructor(
@@ -30,7 +27,7 @@ export function transform(code: string, name: string): string {
           'react',
           {
             runtime: 'automatic',
-            importSource: '@motion-canvas/2d',
+            importSource: '@revideo/2d',
           },
         ],
       ],
@@ -38,11 +35,11 @@ export function transform(code: string, name: string): string {
         ({types}) => ({
           visitor: {
             ImportDeclaration(path) {
-              if (path.node.source.value.startsWith('@motion-canvas/core')) {
-                path.node.source.value = '@motion-canvas/core';
+              if (path.node.source.value.startsWith('@revideo/core')) {
+                path.node.source.value = '@revideo/core';
               }
-              if (path.node.source.value.startsWith('@motion-canvas/2d')) {
-                path.node.source.value = '@motion-canvas/2d';
+              if (path.node.source.value.startsWith('@revideo/2d')) {
+                path.node.source.value = '@revideo/2d';
               }
             },
             ReferencedIdentifier(path) {

--- a/packages/docs/src/components/Homepage/Features.tsx
+++ b/packages/docs/src/components/Homepage/Features.tsx
@@ -109,7 +109,7 @@ export default function HomepageFeatures(): JSX.Element {
         <p>
           <a
             className="button button--outline button--lg"
-            href="https://github.com/motion-canvas/examples"
+            href="https://github.com/revideo/examples"
             target="_blank"
           >
             Video Source Code

--- a/packages/docs/src/components/Homepage/Header.tsx
+++ b/packages/docs/src/components/Homepage/Header.tsx
@@ -33,7 +33,7 @@ export default function HomepageHeader() {
           </Link>
           <a
             className="button button--outline button--lg"
-            href="https://github.com/motion-canvas/motion-canvas/blob/main/CONTRIBUTING.md"
+            href="https://github.com/revideo/revideo/blob/main/CONTRIBUTING.md"
             target="_blank"
           >
             Contribute

--- a/packages/docs/src/components/Release/PullRequest.tsx
+++ b/packages/docs/src/components/Release/PullRequest.tsx
@@ -10,7 +10,7 @@ export default function PullRequest({id}: PullRequestProps) {
     <a
       className={styles.pr}
       title={`Pull request #${id}`}
-      href={`https://github.com/motion-canvas/motion-canvas/pull/${id}`}
+      href={`https://github.com/revideo/revideo/pull/${id}`}
       target="_blank"
     >
       <small>#{id}</small>

--- a/packages/docs/src/utils/useSubscribable.ts
+++ b/packages/docs/src/utils/useSubscribable.ts
@@ -2,7 +2,7 @@ import type {
   EventHandler,
   Subscribable,
   SubscribableValueEvent,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {DependencyList, useEffect, useState} from 'react';
 
 export function useSubscribable<TValue, THandler extends EventHandler<TValue>>(

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@motion-canvas/e2e",
+  "name": "@revideo/e2e",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -8,14 +8,14 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@motion-canvas/2d": "*",
-    "@motion-canvas/core": "*",
+    "@revideo/2d": "*",
+    "@revideo/core": "*",
     "jest-image-snapshot": "^6.2.0",
     "puppeteer": "^21.5.2",
     "vitest": "^0.34.6"
   },
   "devDependencies": {
-    "@motion-canvas/ui": "*",
-    "@motion-canvas/vite-plugin": "*"
+    "@revideo/ui": "*",
+    "@revideo/vite-plugin": "*"
   }
 }

--- a/packages/e2e/tests/motion-canvas.d.ts
+++ b/packages/e2e/tests/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/e2e/tests/project.meta
+++ b/packages/e2e/tests/project.meta
@@ -21,7 +21,7 @@
     "resolutionScale": 1,
     "colorSpace": "srgb",
     "exporter": {
-      "name": "@motion-canvas/core/image-sequence",
+      "name": "@revideo/core/image-sequence",
       "options": {
         "fileType": "image/png",
         "quality": 100,

--- a/packages/e2e/tests/project.ts
+++ b/packages/e2e/tests/project.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import circle from './scenes/circle?scene';
 import rect from './scenes/rect?scene';

--- a/packages/e2e/tests/revideo.d.ts
+++ b/packages/e2e/tests/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/e2e/tests/scenes/circle.tsx
+++ b/packages/e2e/tests/scenes/circle.tsx
@@ -1,4 +1,4 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
+import {Circle, makeScene2D} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(

--- a/packages/e2e/tests/scenes/rect.tsx
+++ b/packages/e2e/tests/scenes/rect.tsx
@@ -1,4 +1,4 @@
-import {makeScene2D, Rect} from '@motion-canvas/2d';
+import {makeScene2D, Rect} from '@revideo/2d';
 
 export default makeScene2D(function* (view) {
   view.add(

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@motion-canvas/2d/tsconfig.project.json",
+  "extends": "@revideo/2d/tsconfig.project.json",
   "include": ["src", "tests"]
 }

--- a/packages/e2e/vite.config.ts
+++ b/packages/e2e/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 
-import motionCanvas from '@motion-canvas/vite-plugin';
+import motionCanvas from '@revideo/vite-plugin';
 import {defineConfig} from 'vite';
 
 export default defineConfig({

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@motion-canvas/examples",
+  "name": "@revideo/examples",
   "private": true,
   "version": "0.0.0",
   "scripts": {
@@ -7,11 +7,11 @@
     "build": "tsc && vite build --base /examples/"
   },
   "dependencies": {
-    "@motion-canvas/2d": "*",
-    "@motion-canvas/core": "*"
+    "@revideo/2d": "*",
+    "@revideo/core": "*"
   },
   "devDependencies": {
-    "@motion-canvas/ui": "*",
-    "@motion-canvas/vite-plugin": "*"
+    "@revideo/ui": "*",
+    "@revideo/vite-plugin": "*"
   }
 }

--- a/packages/examples/src/code-block.meta
+++ b/packages/examples/src/code-block.meta
@@ -21,7 +21,7 @@
     "resolutionScale": 2,
     "colorSpace": "srgb",
     "exporter": {
-      "name": "@motion-canvas/core/image-sequence",
+      "name": "@revideo/core/image-sequence",
       "options": {
         "fileType": "image/png",
         "quality": 100,

--- a/packages/examples/src/code-block.ts
+++ b/packages/examples/src/code-block.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/code-block?scene';
 

--- a/packages/examples/src/components.ts
+++ b/packages/examples/src/components.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/components?scene';
 

--- a/packages/examples/src/components/Switch.tsx
+++ b/packages/examples/src/components/Switch.tsx
@@ -6,7 +6,7 @@ import {
   colorSignal,
   initial,
   signal,
-} from '@motion-canvas/2d';
+} from '@revideo/2d';
 import {
   Color,
   ColorSignal,
@@ -18,7 +18,7 @@ import {
   createSignal,
   easeInOutCubic,
   tween,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 export interface SwitchProps extends NodeProps {
   initialState?: SignalValue<boolean>;

--- a/packages/examples/src/layout-group.ts
+++ b/packages/examples/src/layout-group.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/layout-group?scene';
 

--- a/packages/examples/src/layout.ts
+++ b/packages/examples/src/layout.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import layout from './scenes/layout?scene';
 

--- a/packages/examples/src/logging.ts
+++ b/packages/examples/src/logging.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/logging?scene';
 

--- a/packages/examples/src/media-image.ts
+++ b/packages/examples/src/media-image.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/media-image?scene';
 

--- a/packages/examples/src/media-video.ts
+++ b/packages/examples/src/media-video.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/media-video?scene';
 

--- a/packages/examples/src/motion-canvas.d.ts
+++ b/packages/examples/src/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/examples/src/node-signal.ts
+++ b/packages/examples/src/node-signal.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/node-signal?scene';
 

--- a/packages/examples/src/positioning.ts
+++ b/packages/examples/src/positioning.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import node from './scenes/positioning?scene';
 

--- a/packages/examples/src/presentation.ts
+++ b/packages/examples/src/presentation.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/presentation?scene';
 

--- a/packages/examples/src/quickstart.ts
+++ b/packages/examples/src/quickstart.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/quickstart?scene';
 

--- a/packages/examples/src/random.ts
+++ b/packages/examples/src/random.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/random?scene';
 

--- a/packages/examples/src/revideo.d.ts
+++ b/packages/examples/src/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/examples/src/scenes/code-block.tsx
+++ b/packages/examples/src/scenes/code-block.tsx
@@ -1,12 +1,12 @@
-import {makeScene2D} from '@motion-canvas/2d';
+import {makeScene2D} from '@revideo/2d';
 import {
   CodeBlock,
   edit,
   insert,
   lines,
   remove,
-} from '@motion-canvas/2d/lib/components/CodeBlock';
-import {all, createRef, waitFor} from '@motion-canvas/core';
+} from '@revideo/2d/lib/components/CodeBlock';
+import {all, createRef, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const codeRef = createRef<CodeBlock>();

--- a/packages/examples/src/scenes/components.tsx
+++ b/packages/examples/src/scenes/components.tsx
@@ -1,6 +1,6 @@
-import {makeScene2D} from '@motion-canvas/2d';
-import {createRef, waitFor} from '@motion-canvas/core';
-import {Switch} from '@motion-canvas/examples/src/components/Switch';
+import {makeScene2D} from '@revideo/2d';
+import {createRef, waitFor} from '@revideo/core';
+import {Switch} from '@revideo/examples/src/components/Switch';
 // see this import for the component ^
 
 // usage of the component:

--- a/packages/examples/src/scenes/layout-group.tsx
+++ b/packages/examples/src/scenes/layout-group.tsx
@@ -1,5 +1,5 @@
-import {Layout, Node, Rect, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {Layout, Node, Rect, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const group = createRef<Node>();

--- a/packages/examples/src/scenes/layout.tsx
+++ b/packages/examples/src/scenes/layout.tsx
@@ -1,5 +1,5 @@
-import {Circle, Layout, Rect, makeScene2D} from '@motion-canvas/2d';
-import {all, createRef} from '@motion-canvas/core';
+import {Circle, Layout, Rect, makeScene2D} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
 
 const RED = '#ff6470';
 

--- a/packages/examples/src/scenes/logging.tsx
+++ b/packages/examples/src/scenes/logging.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {useLogger, waitFor, waitUntil} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {useLogger, waitFor, waitUntil} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const logger = useLogger();

--- a/packages/examples/src/scenes/media-image.tsx
+++ b/packages/examples/src/scenes/media-image.tsx
@@ -1,7 +1,7 @@
-import {Img, makeScene2D} from '@motion-canvas/2d';
-import {all, createRef} from '@motion-canvas/core';
+import {Img, makeScene2D} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
 
-import logoSvg from '@motion-canvas/examples/assets/logo.svg';
+import logoSvg from '@revideo/examples/assets/logo.svg';
 
 export default makeScene2D(function* (view) {
   const imageRef = createRef<Img>();

--- a/packages/examples/src/scenes/media-video.tsx
+++ b/packages/examples/src/scenes/media-video.tsx
@@ -1,7 +1,7 @@
-import {Video, makeScene2D} from '@motion-canvas/2d';
-import {createRef} from '@motion-canvas/core';
+import {Video, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
 
-import exampleMp4 from '@motion-canvas/examples/assets/example.mp4';
+import exampleMp4 from '@revideo/examples/assets/example.mp4';
 
 export default makeScene2D(function* (view) {
   const videoRef = createRef<Video>();

--- a/packages/examples/src/scenes/node-signal.tsx
+++ b/packages/examples/src/scenes/node-signal.tsx
@@ -1,5 +1,5 @@
-import {Circle, Line, Txt, makeScene2D} from '@motion-canvas/2d';
-import {Vector2, createSignal, waitFor} from '@motion-canvas/core';
+import {Circle, Line, Txt, makeScene2D} from '@revideo/2d';
+import {Vector2, createSignal, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   // highlight-start

--- a/packages/examples/src/scenes/positioning.tsx
+++ b/packages/examples/src/scenes/positioning.tsx
@@ -1,5 +1,5 @@
-import {Circle, Grid, Line, Node, makeScene2D} from '@motion-canvas/2d';
-import {Vector2, all, createRef, createSignal} from '@motion-canvas/core';
+import {Circle, Grid, Line, Node, makeScene2D} from '@revideo/2d';
+import {Vector2, all, createRef, createSignal} from '@revideo/core';
 
 const RED = '#ff6470';
 const GREEN = '#99C47A';

--- a/packages/examples/src/scenes/presentation.tsx
+++ b/packages/examples/src/scenes/presentation.tsx
@@ -1,4 +1,4 @@
-import {Rect, Txt, makeScene2D} from '@motion-canvas/2d';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
 import {
   Color,
   all,
@@ -8,7 +8,7 @@ import {
   createSignal,
   easeInOutCubic,
   loop,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 const YELLOW = '#FFC66D';
 const RED = '#FF6470';

--- a/packages/examples/src/scenes/quickstart.tsx
+++ b/packages/examples/src/scenes/quickstart.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {all, createRef} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const myCircle = createRef<Circle>();

--- a/packages/examples/src/scenes/random.tsx
+++ b/packages/examples/src/scenes/random.tsx
@@ -1,12 +1,5 @@
-import {Layout, Rect, makeScene2D} from '@motion-canvas/2d';
-import {
-  all,
-  loop,
-  makeRef,
-  range,
-  sequence,
-  useRandom,
-} from '@motion-canvas/core';
+import {Layout, Rect, makeScene2D} from '@revideo/2d';
+import {all, loop, makeRef, range, sequence, useRandom} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   // highlight-next-line

--- a/packages/examples/src/scenes/tex.tsx
+++ b/packages/examples/src/scenes/tex.tsx
@@ -1,5 +1,5 @@
-import {Latex, makeScene2D} from '@motion-canvas/2d';
-import {createRef, waitFor} from '@motion-canvas/core';
+import {Latex, makeScene2D} from '@revideo/2d';
+import {createRef, waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const tex = createRef<Latex>();

--- a/packages/examples/src/scenes/transitions-first.tsx
+++ b/packages/examples/src/scenes/transitions-first.tsx
@@ -1,5 +1,5 @@
-import {Rect, Txt, makeScene2D} from '@motion-canvas/2d';
-import {waitFor} from '@motion-canvas/core';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   view.add(

--- a/packages/examples/src/scenes/transitions-second.tsx
+++ b/packages/examples/src/scenes/transitions-second.tsx
@@ -1,11 +1,11 @@
-import {Rect, Txt, makeScene2D} from '@motion-canvas/2d';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
 import {
   Direction,
   all,
   createRef,
   slideTransition,
   waitFor,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const rect = createRef<Rect>();

--- a/packages/examples/src/scenes/tweening-color.tsx
+++ b/packages/examples/src/scenes/tweening-color.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {Color, createRef, easeInOutCubic, tween} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {Color, createRef, easeInOutCubic, tween} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();

--- a/packages/examples/src/scenes/tweening-cubic.tsx
+++ b/packages/examples/src/scenes/tweening-cubic.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {createRef, easeInOutCubic, map, tween} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {createRef, easeInOutCubic, map, tween} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();

--- a/packages/examples/src/scenes/tweening-linear.tsx
+++ b/packages/examples/src/scenes/tweening-linear.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {createRef, map, tween} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {createRef, map, tween} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();

--- a/packages/examples/src/scenes/tweening-save-restore.tsx
+++ b/packages/examples/src/scenes/tweening-save-restore.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {all, createRef} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();

--- a/packages/examples/src/scenes/tweening-spring.tsx
+++ b/packages/examples/src/scenes/tweening-spring.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {PlopSpring, SmoothSpring, createRef, spring} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {PlopSpring, SmoothSpring, createRef, spring} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();

--- a/packages/examples/src/scenes/tweening-vector.tsx
+++ b/packages/examples/src/scenes/tweening-vector.tsx
@@ -1,5 +1,5 @@
-import {Circle, makeScene2D} from '@motion-canvas/2d';
-import {Vector2, createRef, easeInOutCubic, tween} from '@motion-canvas/core';
+import {Circle, makeScene2D} from '@revideo/2d';
+import {Vector2, createRef, easeInOutCubic, tween} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const circle = createRef<Circle>();

--- a/packages/examples/src/scenes/tweening-visualiser.tsx
+++ b/packages/examples/src/scenes/tweening-visualiser.tsx
@@ -7,14 +7,14 @@ import {
   Rect,
   Txt,
   makeScene2D,
-} from '@motion-canvas/2d';
+} from '@revideo/2d';
 import {
   all,
   createSignal,
   easeInOutBounce,
   linear,
   waitFor,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   // Signals

--- a/packages/examples/src/tex.ts
+++ b/packages/examples/src/tex.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tex?scene';
 

--- a/packages/examples/src/transitions.ts
+++ b/packages/examples/src/transitions.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import first from './scenes/transitions-first?scene';
 import second from './scenes/transitions-second?scene';

--- a/packages/examples/src/tweening-color.ts
+++ b/packages/examples/src/tweening-color.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-color?scene';
 

--- a/packages/examples/src/tweening-cubic.ts
+++ b/packages/examples/src/tweening-cubic.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-cubic?scene';
 

--- a/packages/examples/src/tweening-linear.ts
+++ b/packages/examples/src/tweening-linear.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-linear?scene';
 

--- a/packages/examples/src/tweening-save-restore.ts
+++ b/packages/examples/src/tweening-save-restore.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-save-restore?scene';
 

--- a/packages/examples/src/tweening-spring.ts
+++ b/packages/examples/src/tweening-spring.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-spring?scene';
 

--- a/packages/examples/src/tweening-vector.ts
+++ b/packages/examples/src/tweening-vector.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-vector?scene';
 

--- a/packages/examples/src/tweening-visualiser.ts
+++ b/packages/examples/src/tweening-visualiser.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import scene from './scenes/tweening-visualiser?scene';
 

--- a/packages/examples/tsconfig.json
+++ b/packages/examples/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@motion-canvas/2d/tsconfig.project.json",
+  "extends": "@revideo/2d/tsconfig.project.json",
   "include": ["src"]
 }

--- a/packages/examples/vite.config.ts
+++ b/packages/examples/vite.config.ts
@@ -1,4 +1,4 @@
-import motionCanvas from '@motion-canvas/vite-plugin';
+import motionCanvas from '@revideo/vite-plugin';
 import {defineConfig} from 'vite';
 
 export default defineConfig({

--- a/packages/ffmpeg/CHANGELOG.md
+++ b/packages/ffmpeg/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.1](https://github.com/havenhq/revideo/compare/v0.1.0...v0.1.1) (2024-03-17)
+
+
+### Bug Fixes
+
+* resolve import issues in quickstart project ([e839086](https://github.com/havenhq/revideo/commit/e8390869c087c92c9d448cd16e9cc648d6b2dbe0))
+
+
+
+
+
 
 
 **Note:** Version bump only for package @revideo/ffmpeg

--- a/packages/ffmpeg/CHANGELOG.md
+++ b/packages/ffmpeg/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* resolve asset file paths differently when they are inside project ([#5](https://github.com/havenhq/revideo/issues/5)) ([e0a3917](https://github.com/havenhq/revideo/commit/e0a39175a34f501ffce0fa4508c83e84244fd43c))
+
+
+
+
+
+# Change Log
+
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 

--- a/packages/ffmpeg/CHANGELOG.md
+++ b/packages/ffmpeg/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+
+**Note:** Version bump only for package @revideo/ffmpeg
+
+
+
+
+
 # 0.1.0 (2024-03-17)
 
 

--- a/packages/ffmpeg/client/FFmpegExporterClient.ts
+++ b/packages/ffmpeg/client/FFmpegExporterClient.ts
@@ -4,14 +4,14 @@ import type {
   Project,
   RendererResult,
   RendererSettings,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {
   BoolMetaField,
   EventDispatcher,
   Exporter,
   ObjectMetaField,
   ValueOf,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 type ServerResponse =
   | {
@@ -48,7 +48,7 @@ type FFmpegExporterOptions = ValueOf<
  * initialized by invoking `start`.
  */
 export class FFmpegExporterClient implements Exporter {
-  public static readonly id = '@motion-canvas/ffmpeg';
+  public static readonly id = '@revideo/ffmpeg';
   public static readonly displayName = 'Video (FFmpeg)';
 
   public static meta(project: Project): MetaField<any> {
@@ -68,9 +68,8 @@ export class FFmpegExporterClient implements Exporter {
 
   static {
     if (import.meta.hot) {
-      import.meta.hot.on(
-        `motion-canvas/ffmpeg-ack`,
-        (response: ServerResponse) => this.response.dispatch(response),
+      import.meta.hot.on(`revideo/ffmpeg-ack`, (response: ServerResponse) =>
+        this.response.dispatch(response),
       );
     }
   }
@@ -142,7 +141,7 @@ export class FFmpegExporterClient implements Exporter {
           }
         };
         FFmpegExporterClient.response.subscribe(handle);
-        import.meta.hot!.send('motion-canvas/ffmpeg', {method, data});
+        import.meta.hot!.send('revideo/ffmpeg', {method, data});
       });
     } else {
       throw new Error('FFmpegExporter can only be used locally.');

--- a/packages/ffmpeg/client/index.ts
+++ b/packages/ffmpeg/client/index.ts
@@ -1,5 +1,5 @@
-import type {ExporterClass} from '@motion-canvas/core';
-import {makePlugin} from '@motion-canvas/core';
+import type {ExporterClass} from '@revideo/core';
+import {makePlugin} from '@revideo/core';
 import {FFmpegExporterClient} from './FFmpegExporterClient';
 
 export default makePlugin({

--- a/packages/ffmpeg/client/motion-canvas.d.ts
+++ b/packages/ffmpeg/client/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/ffmpeg/client/revideo.d.ts
+++ b/packages/ffmpeg/client/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/ffmpeg",
-  "version": "1.1.1",
+  "version": "0.1.0",
   "description": "An FFmpeg video exporter for revideo",
   "main": "lib/server/index.js",
   "author": "revideo",
@@ -27,9 +27,9 @@
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.0.0",
+    "@revideo/core": "^0.1.0",
+    "@revideo/vite-plugin": "^0.1.0",
     "fluent-ffmpeg": "^2.1.2",
-    "@revideo/core": "^3.14.1",
-    "@revideo/vite-plugin": "^3.14.1",
     "vite": "^4.5"
   }
 }

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -30,7 +30,7 @@
     "@revideo/core": "^0.1.0",
     "@revideo/vite-plugin": "^0.1.0",
     "fluent-ffmpeg": "^2.1.2",
-    "vite": "^4.5",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "vite": "^4.5"
   }
 }

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/ffmpeg",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An FFmpeg video exporter for revideo",
   "main": "lib/server/index.js",
   "author": "revideo",

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -30,6 +30,7 @@
     "@revideo/core": "^0.1.0",
     "@revideo/vite-plugin": "^0.1.0",
     "fluent-ffmpeg": "^2.1.2",
-    "vite": "^4.5"
+    "vite": "^4.5",
+    "uuid": "^9.0.1"
   }
 }

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@motion-canvas/ffmpeg",
+  "name": "@revideo/ffmpeg",
   "version": "1.1.1",
-  "description": "An FFmpeg video exporter for Motion Canvas",
+  "description": "An FFmpeg video exporter for revideo",
   "main": "lib/server/index.js",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/exporters/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "scripts": {
     "build": "npm run client:build && npm run server:build",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/motion-canvas/exporters.git"
+    "url": "git+https://github.com/havenhq/revideo.git"
   },
   "files": [
     "lib"
@@ -28,8 +28,8 @@
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.0.0",
     "fluent-ffmpeg": "^2.1.2",
-    "@motion-canvas/core": "^3.14.1",
-    "@motion-canvas/vite-plugin": "^3.14.1",
+    "@revideo/core": "^3.14.1",
+    "@revideo/vite-plugin": "^3.14.1",
     "vite": "^4.5"
   }
 }

--- a/packages/ffmpeg/server/FFmpegBridge.ts
+++ b/packages/ffmpeg/server/FFmpegBridge.ts
@@ -1,4 +1,4 @@
-import {PluginConfig} from '@motion-canvas/vite-plugin/lib/plugins';
+import {PluginConfig} from '@revideo/vite-plugin/lib/plugins';
 import type {WebSocketServer} from 'vite';
 import {
   FFmpegExporterServer,
@@ -24,7 +24,7 @@ export class FFmpegBridge {
     private readonly ws: WebSocketServer,
     private readonly config: PluginConfig,
   ) {
-    ws.on('motion-canvas/ffmpeg', this.handleMessage);
+    ws.on('revideo/ffmpeg', this.handleMessage);
   }
 
   private handleMessage = async ({method, data}: BrowserRequest) => {
@@ -64,7 +64,7 @@ export class FFmpegBridge {
   };
 
   private respondSuccess(method: string, data: any = {}) {
-    this.ws.send('motion-canvas/ffmpeg-ack', {
+    this.ws.send('revideo/ffmpeg-ack', {
       status: 'success',
       method,
       data,
@@ -72,7 +72,7 @@ export class FFmpegBridge {
   }
 
   private respondError(method: string, message = 'Unknown error.') {
-    this.ws.send('motion-canvas/ffmpeg-ack', {
+    this.ws.send('revideo/ffmpeg-ack', {
       status: 'error',
       method,
       message,

--- a/packages/ffmpeg/server/FFmpegExporterServer.ts
+++ b/packages/ffmpeg/server/FFmpegExporterServer.ts
@@ -4,8 +4,8 @@ import type {
   AssetInfo,
   RendererResult,
   RendererSettings,
-} from '@motion-canvas/core/lib/app';
-import type {PluginConfig} from '@motion-canvas/vite-plugin/lib/plugins';
+} from '@revideo/core/lib/app';
+import type {PluginConfig} from '@revideo/vite-plugin/lib/plugins';
 
 import * as ffmpeg from 'fluent-ffmpeg';
 import * as fs from 'fs';

--- a/packages/ffmpeg/server/index.ts
+++ b/packages/ffmpeg/server/index.ts
@@ -2,15 +2,15 @@ import {
   Plugin,
   PLUGIN_OPTIONS,
   PluginConfig,
-} from '@motion-canvas/vite-plugin/lib/plugins';
+} from '@revideo/vite-plugin/lib/plugins';
 import {FFmpegBridge} from './FFmpegBridge';
 
 export default (): Plugin => {
   let config: PluginConfig;
   return {
-    name: 'motion-canvas/ffmpeg',
+    name: 'revideo/ffmpeg',
     [PLUGIN_OPTIONS]: {
-      entryPoint: '@motion-canvas/ffmpeg/lib/client',
+      entryPoint: '@revideo/ffmpeg/lib/client',
       async config(value) {
         config = value;
       },

--- a/packages/ffmpeg/server/motion-canvas.d.ts
+++ b/packages/ffmpeg/server/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/ffmpeg/server/revideo.d.ts
+++ b/packages/ffmpeg/server/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@motion-canvas/internal",
+  "name": "@revideo/internal",
   "private": true,
   "version": "0.0.0",
   "devDependencies": {

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* use correct scene sizes ([#146](https://github.com/havenhq/revideo/issues/146)) ([f279638](https://github.com/havenhq/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+
+
+### Features
+
+* animation player ([#92](https://github.com/havenhq/revideo/issues/92)) ([8155118](https://github.com/havenhq/revideo/commit/8155118eb13dc2a8b422b81aabacc923ce2f919b))
+* expose parts of player to outside of shadow root ([#956](https://github.com/havenhq/revideo/issues/956)) ([c996d39](https://github.com/havenhq/revideo/commit/c996d394dda9ba8c6a32f0360bf09e722ec15b0e)), closes [#950](https://github.com/havenhq/revideo/issues/950)
+* new playback architecture ([#402](https://github.com/havenhq/revideo/issues/402)) ([bbe3e2a](https://github.com/havenhq/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)), closes [#166](https://github.com/havenhq/revideo/issues/166)
+* **player:** add auto mode ([c107259](https://github.com/havenhq/revideo/commit/c107259f7c2a3886ccfe4ca0140d13064aed238f))
+* **player:** improve accessibility ([0fc9235](https://github.com/havenhq/revideo/commit/0fc923576e7b12f9bc799f3a4e861861d49a2406))
+* project variables ([#255](https://github.com/havenhq/revideo/issues/255)) ([4883295](https://github.com/havenhq/revideo/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
+* support multiple players ([#128](https://github.com/havenhq/revideo/issues/128)) ([24f75cf](https://github.com/havenhq/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+
+
+### Reverts
+
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+
+
+### BREAKING CHANGES
+
+* `makeProject` no longer accepts some settings.
+
+Settings such as `background` and `audioOffset` are now stored in the project
+meta file.
+
+
+
+
+
 ## [3.14.1](https://github.com/revideo/revideo/compare/v3.14.0...v3.14.1) (2024-02-06)
 
 **Note:** Version bump only for package @revideo/player

--- a/packages/player/CHANGELOG.md
+++ b/packages/player/CHANGELOG.md
@@ -3,152 +3,152 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.14.1](https://github.com/motion-canvas/motion-canvas/compare/v3.14.0...v3.14.1) (2024-02-06)
+## [3.14.1](https://github.com/revideo/revideo/compare/v3.14.0...v3.14.1) (2024-02-06)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-
-
-
-
-# [3.14.0](https://github.com/motion-canvas/motion-canvas/compare/v3.13.0...v3.14.0) (2024-02-04)
-
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 
 
 
 
-# [3.13.0](https://github.com/motion-canvas/motion-canvas/compare/v3.12.4...v3.13.0) (2024-01-10)
+# [3.14.0](https://github.com/revideo/revideo/compare/v3.13.0...v3.14.0) (2024-02-04)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-
-
-
-
-## [3.12.1](https://github.com/motion-canvas/motion-canvas/compare/v3.12.0...v3.12.1) (2023-12-31)
-
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 
 
 
 
-# [3.12.0](https://github.com/motion-canvas/motion-canvas/compare/v3.11.0...v3.12.0) (2023-12-31)
+# [3.13.0](https://github.com/revideo/revideo/compare/v3.12.4...v3.13.0) (2024-01-10)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-
+**Note:** Version bump only for package @revideo/player
 
 
 
-# Change Log
 
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.11.0](https://github.com/motion-canvas/motion-canvas/compare/v3.10.1...v3.11.0) (2023-10-13)
+## [3.12.1](https://github.com/revideo/revideo/compare/v3.12.0...v3.12.1) (2023-12-31)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
+
+
+
+
+
+# [3.12.0](https://github.com/revideo/revideo/compare/v3.11.0...v3.12.0) (2023-12-31)
+
+**Note:** Version bump only for package @revideo/player
+
+
+
+
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.10.0](https://github.com/motion-canvas/motion-canvas/compare/v3.9.0...v3.10.0) (2023-07-23)
+# [3.11.0](https://github.com/revideo/revideo/compare/v3.10.1...v3.11.0) (2023-10-13)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [3.9.0](https://github.com/motion-canvas/motion-canvas/compare/v3.8.0...v3.9.0) (2023-05-29)
-
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.8.0](https://github.com/motion-canvas/motion-canvas/compare/v3.7.0...v3.8.0) (2023-05-13)
+# [3.10.0](https://github.com/revideo/revideo/compare/v3.9.0...v3.10.0) (2023-07-23)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [3.7.0](https://github.com/motion-canvas/motion-canvas/compare/v3.6.2...v3.7.0) (2023-05-10)
-
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.6.1](https://github.com/motion-canvas/motion-canvas/compare/v3.6.0...v3.6.1) (2023-05-08)
+# [3.9.0](https://github.com/revideo/revideo/compare/v3.8.0...v3.9.0) (2023-05-29)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-# [3.6.0](https://github.com/motion-canvas/motion-canvas/compare/v3.5.1...v3.6.0) (2023-05-08)
-
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.4.0](https://github.com/motion-canvas/motion-canvas/compare/v3.3.4...v3.4.0) (2023-03-28)
+# [3.8.0](https://github.com/revideo/revideo/compare/v3.7.0...v3.8.0) (2023-05-13)
 
-**Note:** Version bump only for package @motion-canvas/player
-
-# Change Log
-
-All notable changes to this project will be documented in this file. See
-[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## [3.3.4](https://github.com/motion-canvas/motion-canvas/compare/v3.3.3...v3.3.4) (2023-03-19)
-
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.3.0](https://github.com/motion-canvas/motion-canvas/compare/v3.2.1...v3.3.0) (2023-03-18)
+# [3.7.0](https://github.com/revideo/revideo/compare/v3.6.2...v3.7.0) (2023-05-10)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
-# [3.2.0](https://github.com/motion-canvas/motion-canvas/compare/v3.1.0...v3.2.0) (2023-03-10)
+# Change Log
 
-**Note:** Version bump only for package @motion-canvas/player
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.1.0](https://github.com/motion-canvas/motion-canvas/compare/v3.0.2...v3.1.0) (2023-03-07)
+## [3.6.1](https://github.com/revideo/revideo/compare/v3.6.0...v3.6.1) (2023-05-08)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
-# [3.0.0](https://github.com/motion-canvas/motion-canvas/compare/v2.6.0...v3.0.0) (2023-02-27)
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.6.0](https://github.com/revideo/revideo/compare/v3.5.1...v3.6.0) (2023-05-08)
+
+**Note:** Version bump only for package @revideo/player
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.4.0](https://github.com/revideo/revideo/compare/v3.3.4...v3.4.0) (2023-03-28)
+
+**Note:** Version bump only for package @revideo/player
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [3.3.4](https://github.com/revideo/revideo/compare/v3.3.3...v3.3.4) (2023-03-19)
+
+**Note:** Version bump only for package @revideo/player
+
+# Change Log
+
+All notable changes to this project will be documented in this file. See
+[Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [3.3.0](https://github.com/revideo/revideo/compare/v3.2.1...v3.3.0) (2023-03-18)
+
+**Note:** Version bump only for package @revideo/player
+
+# [3.2.0](https://github.com/revideo/revideo/compare/v3.1.0...v3.2.0) (2023-03-10)
+
+**Note:** Version bump only for package @revideo/player
+
+# [3.1.0](https://github.com/revideo/revideo/compare/v3.0.2...v3.1.0) (2023-03-07)
+
+**Note:** Version bump only for package @revideo/player
+
+# [3.0.0](https://github.com/revideo/revideo/compare/v2.6.0...v3.0.0) (2023-02-27)
 
 ### Features
 
 - new playback architecture
-  ([#402](https://github.com/motion-canvas/motion-canvas/issues/402))
-  ([bbe3e2a](https://github.com/motion-canvas/motion-canvas/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)),
-  closes [#166](https://github.com/motion-canvas/motion-canvas/issues/166)
+  ([#402](https://github.com/revideo/revideo/issues/402))
+  ([bbe3e2a](https://github.com/revideo/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)),
+  closes [#166](https://github.com/revideo/revideo/issues/166)
 
 ### BREAKING CHANGES
 
@@ -157,60 +157,60 @@ All notable changes to this project will be documented in this file. See
 Settings such as `background` and `audioOffset` are now stored in the project
 meta file.
 
-# [2.6.0](https://github.com/motion-canvas/motion-canvas/compare/v2.5.0...v2.6.0) (2023-02-24)
+# [2.6.0](https://github.com/revideo/revideo/compare/v2.5.0...v2.6.0) (2023-02-24)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
-# [2.5.0](https://github.com/motion-canvas/motion-canvas/compare/v2.4.0...v2.5.0) (2023-02-20)
+# [2.5.0](https://github.com/revideo/revideo/compare/v2.4.0...v2.5.0) (2023-02-20)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
-# [2.4.0](https://github.com/motion-canvas/motion-canvas/compare/v2.3.0...v2.4.0) (2023-02-18)
+# [2.4.0](https://github.com/revideo/revideo/compare/v2.3.0...v2.4.0) (2023-02-18)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
-# [2.3.0](https://github.com/motion-canvas/motion-canvas/compare/v2.2.0...v2.3.0) (2023-02-11)
+# [2.3.0](https://github.com/revideo/revideo/compare/v2.2.0...v2.3.0) (2023-02-11)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
-# [2.2.0](https://github.com/motion-canvas/motion-canvas/compare/v2.1.0...v2.2.0) (2023-02-09)
+# [2.2.0](https://github.com/revideo/revideo/compare/v2.1.0...v2.2.0) (2023-02-09)
 
 ### Features
 
 - project variables
-  ([#255](https://github.com/motion-canvas/motion-canvas/issues/255))
-  ([4883295](https://github.com/motion-canvas/motion-canvas/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
+  ([#255](https://github.com/revideo/revideo/issues/255))
+  ([4883295](https://github.com/revideo/revideo/commit/488329525939928af52b4a4d8488f1e1cd4cf6f7))
 
-# [2.1.0](https://github.com/motion-canvas/motion-canvas/compare/v2.0.0...v2.1.0) (2023-02-07)
+# [2.1.0](https://github.com/revideo/revideo/compare/v2.0.0...v2.1.0) (2023-02-07)
 
-**Note:** Version bump only for package @motion-canvas/player
+**Note:** Version bump only for package @revideo/player
 
 # 2.0.0 (2023-02-04)
 
 ### Bug Fixes
 
 - use correct scene sizes
-  ([#146](https://github.com/motion-canvas/motion-canvas/issues/146))
-  ([f279638](https://github.com/motion-canvas/motion-canvas/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+  ([#146](https://github.com/revideo/revideo/issues/146))
+  ([f279638](https://github.com/revideo/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
 
 ### Features
 
 - animation player
-  ([#92](https://github.com/motion-canvas/motion-canvas/issues/92))
-  ([8155118](https://github.com/motion-canvas/motion-canvas/commit/8155118eb13dc2a8b422b81aabacc923ce2f919b))
+  ([#92](https://github.com/revideo/revideo/issues/92))
+  ([8155118](https://github.com/revideo/revideo/commit/8155118eb13dc2a8b422b81aabacc923ce2f919b))
 - **player:** add auto mode
-  ([c107259](https://github.com/motion-canvas/motion-canvas/commit/c107259f7c2a3886ccfe4ca0140d13064aed238f))
+  ([c107259](https://github.com/revideo/revideo/commit/c107259f7c2a3886ccfe4ca0140d13064aed238f))
 - **player:** improve accessibility
-  ([0fc9235](https://github.com/motion-canvas/motion-canvas/commit/0fc923576e7b12f9bc799f3a4e861861d49a2406))
+  ([0fc9235](https://github.com/revideo/revideo/commit/0fc923576e7b12f9bc799f3a4e861861d49a2406))
 - support multiple players
-  ([#128](https://github.com/motion-canvas/motion-canvas/issues/128))
-  ([24f75cf](https://github.com/motion-canvas/motion-canvas/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+  ([#128](https://github.com/revideo/revideo/issues/128))
+  ([24f75cf](https://github.com/revideo/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
 
 ### Reverts
 
 - ci(release): 1.0.1 [skip ci]
-  ([#175](https://github.com/motion-canvas/motion-canvas/issues/175))
-  ([161a046](https://github.com/motion-canvas/motion-canvas/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+  ([#175](https://github.com/revideo/revideo/issues/175))
+  ([161a046](https://github.com/revideo/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
 - ci(release): 2.0.0 [skip ci]
-  ([#176](https://github.com/motion-canvas/motion-canvas/issues/176))
-  ([551096b](https://github.com/motion-canvas/motion-canvas/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+  ([#176](https://github.com/revideo/revideo/issues/176))
+  ([551096b](https://github.com/revideo/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))

--- a/packages/player/index.html
+++ b/packages/player/index.html
@@ -13,9 +13,9 @@
   </head>
   <body>
     <script type="module" src="/src/main.ts"></script>
-    <motion-canvas-player
+    <revideo-player
       src="/@id/__x00__virtual:template"
       style="aspect-ratio: 16 / 9"
-    ></motion-canvas-player>
+    ></revideo-player>
   </body>
 </html>

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/player",
-  "version": "3.14.1",
+  "version": "0.1.0",
   "description": "A custom element for displaying animations made with revideo",
   "main": "dist/main.js",
   "types": "types/main.d.ts",
@@ -22,7 +22,7 @@
     "types"
   ],
   "devDependencies": {
-    "@revideo/core": "^3.14.1",
+    "@revideo/core": "^0.1.0",
     "sass": "^1.58.0",
     "terser": "^5.16.1"
   }

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@motion-canvas/player",
+  "name": "@revideo/player",
   "version": "3.14.1",
-  "description": "A custom element for displaying animations made with Motion Canvas",
+  "description": "A custom element for displaying animations made with revideo",
   "main": "dist/main.js",
   "types": "types/main.d.ts",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -15,14 +15,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/motion-canvas/motion-canvas.git"
+    "url": "https://github.com/havenhq/revideo.git"
   },
   "files": [
     "dist",
     "types"
   ],
   "devDependencies": {
-    "@motion-canvas/core": "^3.14.1",
+    "@revideo/core": "^3.14.1",
     "sass": "^1.58.0",
     "terser": "^5.16.1"
   }

--- a/packages/player/src/main.ts
+++ b/packages/player/src/main.ts
@@ -1,12 +1,12 @@
-import type {PlayerSettings, Project, StageSettings} from '@motion-canvas/core';
-import {Player, Stage} from '@motion-canvas/core';
+import type {PlayerSettings, Project, StageSettings} from '@revideo/core';
+import {Player, Stage} from '@revideo/core';
 
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import styles from './styles.scss?inline';
 import html from './template.html?raw';
 
 const TEMPLATE = `<style>${styles}</style>${html}`;
-const ID = 'motion-canvas-player';
+const ID = 'revideo-player';
 
 enum State {
   Initial = 'initial',

--- a/packages/player/vite.config.ts
+++ b/packages/player/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       fileName: 'main',
     },
     rollupOptions: {
-      external: ['@motion-canvas/core'],
+      external: ['@revideo/core'],
     },
   },
   plugins: [

--- a/packages/renderer/CHANGELOG.md
+++ b/packages/renderer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2024-03-17)
+
+**Note:** Version bump only for package @revideo/renderer

--- a/packages/renderer/client/motion-canvas.d.ts
+++ b/packages/renderer/client/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/renderer/client/render.ts
+++ b/packages/renderer/client/render.ts
@@ -1,5 +1,5 @@
-import type {Project} from '@motion-canvas/core';
-import {Renderer} from '@motion-canvas/core';
+import type {Project} from '@revideo/core';
+import {Renderer} from '@revideo/core';
 
 declare global {
   interface Window {

--- a/packages/renderer/client/revideo.d.ts
+++ b/packages/renderer/client/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/renderer",
-  "version": "3.14.1",
+  "version": "0.1.0",
   "description": "A headless renderer for revideo",
   "main": "dist/index.js",
   "author": "revideo",
@@ -19,7 +19,7 @@
     "types"
   ],
   "devDependencies": {
-    "@revideo/core": "*",
+    "@revideo/core": "^0.1.0",
     "puppeteer": "^22.3.0"
   }
 }

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@motion-canvas/renderer",
+  "name": "@revideo/renderer",
   "version": "3.14.1",
-  "description": "A headless renderer for Motion Canvas",
+  "description": "A headless renderer for revideo",
   "main": "dist/index.js",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "scripts": {
     "build": "npm run client:build && npm run server:build",
@@ -19,7 +19,7 @@
     "types"
   ],
   "devDependencies": {
-    "@motion-canvas/core": "*",
+    "@revideo/core": "*",
     "puppeteer": "^22.3.0"
   }
 }

--- a/packages/renderer/server/motion-canvas.d.ts
+++ b/packages/renderer/server/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/renderer/server/plugin.ts
+++ b/packages/renderer/server/plugin.ts
@@ -12,12 +12,12 @@ function createHtml(src: string) {
 
 export function rendererPlugin(): Plugin {
   return {
-    name: 'motion-canvas-renderer-plugin',
+    name: 'revideo-renderer-plugin',
 
     async load(id) {
       if (id.startsWith('\x00virtual:renderer')) {
         return `\
-            import {render} from '@motion-canvas/renderer/client/render';
+            import {render} from '@revideo/renderer/client/render';
             import project from './src/project.ts?project';
             render(project);
             `;

--- a/packages/renderer/server/revideo.d.ts
+++ b/packages/renderer/server/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/renderer/server/tsconfig.json
+++ b/packages/renderer/server/tsconfig.json
@@ -10,5 +10,5 @@
     "inlineSourceMap": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["*", "../index.ts", "../main.ts", "../motion-canvas.d.ts"]
+  "include": ["*", "../index.ts", "../main.ts", "../revideo.d.ts"]
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@motion-canvas/template",
+  "name": "@revideo/template",
   "private": true,
   "version": "0.0.0",
-  "description": "Basic project template for Motion Canvas",
-  "author": "motion-canvas",
+  "description": "Basic project template for revideo",
+  "author": "revideo",
   "license": "MIT",
   "main": "src/project.ts",
   "scripts": {
@@ -12,13 +12,13 @@
     "render": "tsc && node dist/renderScript.mjs"
   },
   "dependencies": {
-    "@motion-canvas/core": "*",
-    "@motion-canvas/2d": "*",
-    "@motion-canvas/renderer": "*",
-    "@motion-canvas/ffmpeg": "*"
+    "@revideo/core": "*",
+    "@revideo/2d": "*",
+    "@revideo/renderer": "*",
+    "@revideo/ffmpeg": "*"
   },
   "devDependencies": {
-    "@motion-canvas/ui": "*",
-    "@motion-canvas/vite-plugin": "*"
+    "@revideo/ui": "*",
+    "@revideo/vite-plugin": "*"
   }
 }

--- a/packages/template/src/motion-canvas.d.ts
+++ b/packages/template/src/motion-canvas.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@motion-canvas/core/project" />

--- a/packages/template/src/project.ts
+++ b/packages/template/src/project.ts
@@ -1,4 +1,4 @@
-import {makeProject} from '@motion-canvas/core';
+import {makeProject} from '@revideo/core';
 
 import example from './scenes/example?scene';
 

--- a/packages/template/src/renderScript.ts
+++ b/packages/template/src/renderScript.ts
@@ -1,3 +1,3 @@
-import {renderVideo} from '@motion-canvas/renderer';
+import {renderVideo} from '@revideo/renderer';
 
 renderVideo('./vite.config.ts');

--- a/packages/template/src/revideo.d.ts
+++ b/packages/template/src/revideo.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@revideo/core/project" />

--- a/packages/template/src/scenes/example.tsx
+++ b/packages/template/src/scenes/example.tsx
@@ -1,4 +1,4 @@
-import {Rect, makeScene2D} from '@motion-canvas/2d';
+import {Rect, makeScene2D} from '@revideo/2d';
 import {
   all,
   createRef,
@@ -6,7 +6,7 @@ import {
   easeInOutExpo,
   waitFor,
   waitUntil,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 export default makeScene2D(function* (view) {
   const rect = createRef<Rect>();

--- a/packages/template/tsconfig.json
+++ b/packages/template/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@motion-canvas/2d/tsconfig.project.json",
+  "extends": "@revideo/2d/tsconfig.project.json",
   "compilerOptions": {
     "types": ["node"],
     "noEmit": false,

--- a/packages/template/vite.config.ts
+++ b/packages/template/vite.config.ts
@@ -1,7 +1,7 @@
-import ffmpeg from '@motion-canvas/ffmpeg';
-import markdown from '@motion-canvas/internal/vite/markdown-literals';
-import {rendererPlugin} from '@motion-canvas/renderer';
 import preact from '@preact/preset-vite';
+import ffmpeg from '@revideo/ffmpeg';
+import markdown from '@revideo/internal/vite/markdown-literals';
+import {rendererPlugin} from '@revideo/renderer';
 import {defineConfig} from 'vite';
 import motionCanvas from '../vite-plugin/src/main';
 
@@ -9,18 +9,18 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@motion-canvas/ui',
-        replacement: '@motion-canvas/ui/src/main.tsx',
+        find: '@revideo/ui',
+        replacement: '@revideo/ui/src/main.tsx',
       },
       {
-        find: '@motion-canvas/2d/editor',
-        replacement: '@motion-canvas/2d/src/editor',
+        find: '@revideo/2d/editor',
+        replacement: '@revideo/2d/src/editor',
       },
       {
-        find: /@motion-canvas\/2d(\/lib)?/,
-        replacement: '@motion-canvas/2d/src/lib',
+        find: /@revideo\/2d(\/lib)?/,
+        replacement: '@revideo/2d/src/lib',
       },
-      {find: '@motion-canvas/core', replacement: '@motion-canvas/core/src'},
+      {find: '@revideo/core', replacement: '@revideo/core/src'},
     ],
   },
   plugins: [

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -3,6 +3,174 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* **2d:** fix audio offset editing ([#674](https://github.com/havenhq/revideo/issues/674)) ([58d6ef7](https://github.com/havenhq/revideo/commit/58d6ef79fa06e377e0c1821efe73585586d124a6))
+* **2d:** fix performance issue with audio track ([#427](https://github.com/havenhq/revideo/issues/427)) ([c993770](https://github.com/havenhq/revideo/commit/c993770937ddfdf0ac39b144a1f79f1a300f7899))
+* **2d:** fix version link ([#608](https://github.com/havenhq/revideo/issues/608)) ([4fe5b7a](https://github.com/havenhq/revideo/commit/4fe5b7a5150fbdf43ea50ecf3dc8b4690c0e2e34))
+* correctly await re-renders ([#918](https://github.com/havenhq/revideo/issues/918)) ([873a9a3](https://github.com/havenhq/revideo/commit/873a9a3eed2676de4cc7f31fbd5ea58817a80aff))
+* **create:** update templates ([#439](https://github.com/havenhq/revideo/issues/439)) ([8483557](https://github.com/havenhq/revideo/commit/8483557f0a3ca7914aafacceab5d466abba59df0))
+* fix player state not being saved ([#85](https://github.com/havenhq/revideo/issues/85)) ([74b54b9](https://github.com/havenhq/revideo/commit/74b54b970d1287e80fe2334a034844ad6a80c23b))
+* fix tsdoc comments ([#21](https://github.com/havenhq/revideo/issues/21)) ([4b6cb66](https://github.com/havenhq/revideo/commit/4b6cb660ad82befcfd41188c7a8f9c8c0cba93ed)), closes [#18](https://github.com/havenhq/revideo/issues/18)
+* limit fps to positive numbers ([#937](https://github.com/havenhq/revideo/issues/937)) ([c7c0c67](https://github.com/havenhq/revideo/commit/c7c0c6730e1a00e6b23077188bfc2d389e98cff2)), closes [#936](https://github.com/havenhq/revideo/issues/936)
+* support hmr when navigating ([370ea16](https://github.com/havenhq/revideo/commit/370ea1676a1c34313c0fb917c0f0691538f72016))
+* the resolution fields in Rendering no longer reset each other ([#73](https://github.com/havenhq/revideo/issues/73)) ([ddabec5](https://github.com/havenhq/revideo/commit/ddabec549be3cecec27cf9f5643b036e12a83472))
+* **ui:** correctly drag time events ([#912](https://github.com/havenhq/revideo/issues/912)) ([81f6dd6](https://github.com/havenhq/revideo/commit/81f6dd6e485be451a50a695a146ed6b69e30bbc2))
+* **ui:** correctly reset zoom ([#432](https://github.com/havenhq/revideo/issues/432)) ([a33ee14](https://github.com/havenhq/revideo/commit/a33ee14dfac3e1fe24c89d76631e23fe4cb625a6))
+* **ui:** don't seek when editing time events ([#26](https://github.com/havenhq/revideo/issues/26)) ([524c200](https://github.com/havenhq/revideo/commit/524c200ef1bd6a6f52096d04c2aeed24a24cda6f))
+* **ui:** downgrade preact ([#1](https://github.com/havenhq/revideo/issues/1)) ([5f7456f](https://github.com/havenhq/revideo/commit/5f7456fe4c5a1cc76ccd8fed5a6f9a8a4e846d27))
+* **ui:** fix "go to source" ([#895](https://github.com/havenhq/revideo/issues/895)) ([ec729de](https://github.com/havenhq/revideo/commit/ec729dea0d65bc69aefc0abd601f365af1c4ed68))
+* **ui:** fix collapse ([#698](https://github.com/havenhq/revideo/issues/698)) ([6bd8703](https://github.com/havenhq/revideo/commit/6bd8703ec9b16f55b3817f6a1f9130f17b66c69a))
+* **ui:** fix inspector tab ([#374](https://github.com/havenhq/revideo/issues/374)) ([c4cb378](https://github.com/havenhq/revideo/commit/c4cb378c2f9d972bb41542bbe3b3aa314fa1f3ad))
+* **ui:** fix new version link ([#505](https://github.com/havenhq/revideo/issues/505)) ([7459e7f](https://github.com/havenhq/revideo/commit/7459e7f8355163f3cb6a3ed791fc41a2962a186e))
+* **ui:** fix onChange handlers ([#515](https://github.com/havenhq/revideo/issues/515)) ([a23d06c](https://github.com/havenhq/revideo/commit/a23d06cbf6e29f37a9259e50fe71c482640b83fb))
+* **ui:** fix out of range warning ([#939](https://github.com/havenhq/revideo/issues/939)) ([c9f466f](https://github.com/havenhq/revideo/commit/c9f466f20ff1a3e2cb77aa5575823947ef9beeee))
+* **ui:** fix play-pause button ([#299](https://github.com/havenhq/revideo/issues/299)) ([191f54a](https://github.com/havenhq/revideo/commit/191f54a0a5a9de2fd2dc27bffc6d21d692ce6f72))
+* **ui:** fix snapshot ([#643](https://github.com/havenhq/revideo/issues/643)) ([590216a](https://github.com/havenhq/revideo/commit/590216ac094d6b6ef3e9c773499bc52063f617b1))
+* **ui:** fix transparent background ([#886](https://github.com/havenhq/revideo/issues/886)) ([83f652f](https://github.com/havenhq/revideo/commit/83f652fdcfa075f5de24186ffdffd1b7db1d8fc9))
+* **ui:** fix typo in viewport ID ([#620](https://github.com/havenhq/revideo/issues/620)) ([3a83f20](https://github.com/havenhq/revideo/commit/3a83f20cb1b8ddc7b95a8e36bf6f3d0cd036693b))
+* **ui:** fix zoom to fit ([#561](https://github.com/havenhq/revideo/issues/561)) ([1c947b4](https://github.com/havenhq/revideo/commit/1c947b417e218809f33928d6cbb89d463bdc2e66))
+* **ui:** ignore shortcuts when typing ([#521](https://github.com/havenhq/revideo/issues/521)) ([4d3e1a1](https://github.com/havenhq/revideo/commit/4d3e1a13caee2ddd03857961a44dd10a7e1cb32a)), closes [#518](https://github.com/havenhq/revideo/issues/518)
+* **ui:** misaligned overlay ([#127](https://github.com/havenhq/revideo/issues/127)) ([0379730](https://github.com/havenhq/revideo/commit/03797302a302e28caf9f2428cfce4a122f827775))
+* **ui:** prevent context menu in viewport ([#123](https://github.com/havenhq/revideo/issues/123)) ([0fdd85e](https://github.com/havenhq/revideo/commit/0fdd85ecf5b61907ce1e16f5fb9253540528a8b0))
+* **ui:** prevent spawning multiple color pickers ([#747](https://github.com/havenhq/revideo/issues/747)) ([48ffd1f](https://github.com/havenhq/revideo/commit/48ffd1f2eec21f9880e172632a2310f5676e3c19)), closes [#744](https://github.com/havenhq/revideo/issues/744)
+* **ui:** prevent timeline scroll when zooming ([#162](https://github.com/havenhq/revideo/issues/162)) ([b8278ae](https://github.com/havenhq/revideo/commit/b8278aeb7b92f215bccbd1aa57de17c9233cff01))
+* **ui:** remember state of custom tabs ([#900](https://github.com/havenhq/revideo/issues/900)) ([eac45b8](https://github.com/havenhq/revideo/commit/eac45b88ed09fc7cddc3336e46d8697de5775b1f))
+* **ui:** remove glossy <select> effect in Safari ([#292](https://github.com/havenhq/revideo/issues/292)) ([9c062b2](https://github.com/havenhq/revideo/commit/9c062b26e48fbdb1905daae25a3fb34df82307d3))
+* **ui:** support small ranges ([#739](https://github.com/havenhq/revideo/issues/739)) ([cf32d8b](https://github.com/havenhq/revideo/commit/cf32d8b08b94f5044987eb554cd250fc79fbc99d)), closes [#738](https://github.com/havenhq/revideo/issues/738)
+* **ui:** use signals correctly ([#906](https://github.com/havenhq/revideo/issues/906)) ([f67d691](https://github.com/havenhq/revideo/commit/f67d691b5f2f6358120e9582a1839ef3d49c77b8))
+* **ui:** version comparison issue ([#520](https://github.com/havenhq/revideo/issues/520)) ([93b5e08](https://github.com/havenhq/revideo/commit/93b5e088b4a4fda0d2177cb2cc6680c34fa72d30)), closes [#519](https://github.com/havenhq/revideo/issues/519)
+* use correct scene sizes ([#146](https://github.com/havenhq/revideo/issues/146)) ([f279638](https://github.com/havenhq/revideo/commit/f279638f9ad7ed1f4c44900d48c10c2d6560946e))
+
+
+### Features
+
+* **2d:** expand animations and reduced motion ([#671](https://github.com/havenhq/revideo/issues/671)) ([b8e9d03](https://github.com/havenhq/revideo/commit/b8e9d03488f8ca7085b3e7e1b095a52f39f2bc89))
+* **2d:** visual feedback about rendering process ([#681](https://github.com/havenhq/revideo/issues/681)) ([d0495f5](https://github.com/havenhq/revideo/commit/d0495f5c6396c05454a5323e4486ab4829adbc9e))
+* add audio volume control through arrow keys ([#856](https://github.com/havenhq/revideo/issues/856)) ([8b86fd4](https://github.com/havenhq/revideo/commit/8b86fd4e70f91a0d5b1150d760427ca355666341))
+* add basic logger ([#88](https://github.com/havenhq/revideo/issues/88)) ([3d82e86](https://github.com/havenhq/revideo/commit/3d82e863af3dc88b3709adbcd0b84e790d05c3b8)), closes [#17](https://github.com/havenhq/revideo/issues/17)
+* add basic transform to Node class ([#83](https://github.com/havenhq/revideo/issues/83)) ([9e114c8](https://github.com/havenhq/revideo/commit/9e114c8830a99c78e6a4fd9265b0e7552758af14))
+* add coordinates to preview ([#737](https://github.com/havenhq/revideo/issues/737)) ([330c1f9](https://github.com/havenhq/revideo/commit/330c1f962fb920269301e7ee8a2c49cbfc723d85))
+* add E2E testing ([#101](https://github.com/havenhq/revideo/issues/101)) ([6398c54](https://github.com/havenhq/revideo/commit/6398c54e4c4d6667ce9f45b9bbef6ea110ea2215)), closes [#42](https://github.com/havenhq/revideo/issues/42)
+* add experimental features ([#876](https://github.com/havenhq/revideo/issues/876)) ([498d387](https://github.com/havenhq/revideo/commit/498d3871d05d4dcc83453654bec7762d2ab32e7e))
+* add inspection ([#82](https://github.com/havenhq/revideo/issues/82)) ([4d7f2ae](https://github.com/havenhq/revideo/commit/4d7f2aee6daeda1a2146b632dfdc28b455295776))
+* add markdown logs ([#138](https://github.com/havenhq/revideo/issues/138)) ([e42447a](https://github.com/havenhq/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+* add new hooks for plugins ([#679](https://github.com/havenhq/revideo/issues/679)) ([74e18bc](https://github.com/havenhq/revideo/commit/74e18bce71abd7e26a6415240603241b48cb36c2))
+* add option to group output by scenes ([#477](https://github.com/havenhq/revideo/issues/477)) ([9934593](https://github.com/havenhq/revideo/commit/99345937e7ac92fb674fdee10288e467ffd941e2))
+* add rendering again ([#43](https://github.com/havenhq/revideo/issues/43)) ([c10d3db](https://github.com/havenhq/revideo/commit/c10d3dbb63f6248eda04128ef0aa9d72c1edfcf7))
+* add video node ([#86](https://github.com/havenhq/revideo/issues/86)) ([f4aa654](https://github.com/havenhq/revideo/commit/f4aa65437a18cc85b00199f80cd5e04654c00c4b))
+* added file type and quality options to rendering panel ([#50](https://github.com/havenhq/revideo/issues/50)) ([bee71ef](https://github.com/havenhq/revideo/commit/bee71ef2673c269db47a4433831720b7ad0fb4e8)), closes [#24](https://github.com/havenhq/revideo/issues/24)
+* animation player ([#92](https://github.com/havenhq/revideo/issues/92)) ([8155118](https://github.com/havenhq/revideo/commit/8155118eb13dc2a8b422b81aabacc923ce2f919b))
+* application settings ([#697](https://github.com/havenhq/revideo/issues/697)) ([54016f5](https://github.com/havenhq/revideo/commit/54016f5cf3500abe13a217537307a3735d60f536)), closes [#167](https://github.com/havenhq/revideo/issues/167)
+* auto meta fields ([#565](https://github.com/havenhq/revideo/issues/565)) ([645af6d](https://github.com/havenhq/revideo/commit/645af6d2b7e8d9332b6f08419c318ee9434d7f3f))
+* better dependencies between packages ([#152](https://github.com/havenhq/revideo/issues/152)) ([a0a37b3](https://github.com/havenhq/revideo/commit/a0a37b3645fcb91206e65fd0a95b2f486b308c75))
+* better dependencies between packages ([#153](https://github.com/havenhq/revideo/issues/153)) ([59a73d4](https://github.com/havenhq/revideo/commit/59a73d49a7b92c416e1f836a0f53bb676e9f924b))
+* button for opening the output directory ([#663](https://github.com/havenhq/revideo/issues/663)) ([79f320c](https://github.com/havenhq/revideo/commit/79f320c07c422ca927b34bf339094fe0e70ffd0d))
+* **core:** switch to vitest ([#99](https://github.com/havenhq/revideo/issues/99)) ([762eeb0](https://github.com/havenhq/revideo/commit/762eeb0a99c2f378d20dbd147f815ba6736099d9)), closes [#48](https://github.com/havenhq/revideo/issues/48)
+* detect circular signal dependencies ([#129](https://github.com/havenhq/revideo/issues/129)) ([6fcdb41](https://github.com/havenhq/revideo/commit/6fcdb41df90dca1c39537a4f6d4960ab551f4d6e))
+* display array values in inspector ([#670](https://github.com/havenhq/revideo/issues/670)) ([e71d74c](https://github.com/havenhq/revideo/commit/e71d74c9c04995393ad8ee942b8e6e5baa6f982f))
+* display current package versions ([#501](https://github.com/havenhq/revideo/issues/501)) ([2972f67](https://github.com/havenhq/revideo/commit/2972f673e201310e69688ab6f2c1adf1cddf2bf3))
+* editor improvements ([#121](https://github.com/havenhq/revideo/issues/121)) ([e8b32ce](https://github.com/havenhq/revideo/commit/e8b32ceff1b8216282c4b5713508ce1172645e20))
+* get name from meta file ([#552](https://github.com/havenhq/revideo/issues/552)) ([ae2ed8a](https://github.com/havenhq/revideo/commit/ae2ed8a5998768f160ec340d8b63d600d27bc15c))
+* improve error logs ([#953](https://github.com/havenhq/revideo/issues/953)) ([3b528cc](https://github.com/havenhq/revideo/commit/3b528cce13a3440c97641d1095ce09e737e89960))
+* introduce editor plugins ([#879](https://github.com/havenhq/revideo/issues/879)) ([2b72007](https://github.com/havenhq/revideo/commit/2b720074d45fc254dc40b534785b591ae44a3f37))
+* make exporting concurrent ([4f9ef8d](https://github.com/havenhq/revideo/commit/4f9ef8d40d9d9c1147e2edfc0766c5ea5cc4297c))
+* meta field descriptions ([#664](https://github.com/havenhq/revideo/issues/664)) ([80c9d07](https://github.com/havenhq/revideo/commit/80c9d07f88f4a3df0f99e5741b31313f891a5d51))
+* minor console improvements ([#145](https://github.com/havenhq/revideo/issues/145)) ([3e32e73](https://github.com/havenhq/revideo/commit/3e32e73434ad872049af9e3f1f711bc0185410f4))
+* navigate to scene and node source ([#144](https://github.com/havenhq/revideo/issues/144)) ([86d495d](https://github.com/havenhq/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+* navigate to slide source ([#490](https://github.com/havenhq/revideo/issues/490)) ([b5ae4bf](https://github.com/havenhq/revideo/commit/b5ae4bf37076b262a20949cca030db3902186c8d))
+* new playback architecture ([#402](https://github.com/havenhq/revideo/issues/402)) ([bbe3e2a](https://github.com/havenhq/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)), closes [#166](https://github.com/havenhq/revideo/issues/166)
+* new plugin hooks ([#723](https://github.com/havenhq/revideo/issues/723)) ([9a2b5ab](https://github.com/havenhq/revideo/commit/9a2b5ab8be0d001414fd00da3053d408e00fd1cd))
+* open time events in editor ([#87](https://github.com/havenhq/revideo/issues/87)) ([74b781d](https://github.com/havenhq/revideo/commit/74b781d57fca7ef1d10904673276f2a7354c01b8))
+* support for multiple projects ([#57](https://github.com/havenhq/revideo/issues/57)) ([573752d](https://github.com/havenhq/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)), closes [#141414](https://github.com/havenhq/revideo/issues/141414)
+* support multiple players ([#128](https://github.com/havenhq/revideo/issues/128)) ([24f75cf](https://github.com/havenhq/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+* switch to Vite ([#28](https://github.com/havenhq/revideo/issues/28)) ([65b9133](https://github.com/havenhq/revideo/commit/65b91337dbc47fe51cecc83657f79fab15343a0d)), closes [#141414](https://github.com/havenhq/revideo/issues/141414) [#13](https://github.com/havenhq/revideo/issues/13)
+* **ui:** add color picker ([#691](https://github.com/havenhq/revideo/issues/691)) ([a33059c](https://github.com/havenhq/revideo/commit/a33059c0f455814919db31bc9e5e932907c797e4))
+* **ui:** add custom presentation overlays ([#884](https://github.com/havenhq/revideo/issues/884)) ([4696d3c](https://github.com/havenhq/revideo/commit/4696d3c8cb8b68e3475406359f9cf6b875b1c838)), closes [#825](https://github.com/havenhq/revideo/issues/825)
+* **ui:** add direct range selection & playhead shortcuts ([#907](https://github.com/havenhq/revideo/issues/907)) ([39264fc](https://github.com/havenhq/revideo/commit/39264fc074da739efddf24ef080f6c5f279f8014))
+* **ui:** add external link to docs ([#346](https://github.com/havenhq/revideo/issues/346)) ([fc4ee5d](https://github.com/havenhq/revideo/commit/fc4ee5d028312904ed9e11c5341ac00f36e7242b))
+* **ui:** add goto start and goto end buttons ([#814](https://github.com/havenhq/revideo/issues/814)) ([449f194](https://github.com/havenhq/revideo/commit/449f1946474af9886135571c14c83b8440bdf28c))
+* **ui:** add number input dragging ([#917](https://github.com/havenhq/revideo/issues/917)) ([1b5c232](https://github.com/havenhq/revideo/commit/1b5c23260c3015608f202a103b4c0aebd1860e36)), closes [#799](https://github.com/havenhq/revideo/issues/799)
+* **ui:** add quarter resolution ([#421](https://github.com/havenhq/revideo/issues/421)) ([d0160d0](https://github.com/havenhq/revideo/commit/d0160d0d5ef76ffb0d3591566891b5efa4061744))
+* **ui:** add shortcuts to button titles ([#532](https://github.com/havenhq/revideo/issues/532)) ([3549dd3](https://github.com/havenhq/revideo/commit/3549dd3fd7ef47376a5a2dd516609499d3985ac3))
+* **ui:** add volume slider ([#872](https://github.com/havenhq/revideo/issues/872)) ([5ac3069](https://github.com/havenhq/revideo/commit/5ac3069f027ee123c212217dcf8d26a78a3aa106))
+* **ui:** custom checkbox style ([#529](https://github.com/havenhq/revideo/issues/529)) ([af98db1](https://github.com/havenhq/revideo/commit/af98db103d66e8af059dc483d49984b9adb9b95c))
+* **ui:** custom inspectors ([#913](https://github.com/havenhq/revideo/issues/913)) ([6c54424](https://github.com/havenhq/revideo/commit/6c544248a2bd733f2d42676a0ed60c93b79ee574))
+* **ui:** estimate remaining rendering time ([#795](https://github.com/havenhq/revideo/issues/795)) ([1a46148](https://github.com/havenhq/revideo/commit/1a4614801869ab36827ca857d66eed8de9cffd09)), closes [#784](https://github.com/havenhq/revideo/issues/784)
+* **ui:** improve rendering button ([#662](https://github.com/havenhq/revideo/issues/662)) ([2b4ae70](https://github.com/havenhq/revideo/commit/2b4ae70ea0b0305fbb2596e95bbc70440718bbe2))
+* **ui:** include function names in stack traces ([#693](https://github.com/havenhq/revideo/issues/693)) ([835c0fa](https://github.com/havenhq/revideo/commit/835c0fa4b70429db6fe96be96d6d9e44949f7f6c))
+* **ui:** list available shortcuts ([#444](https://github.com/havenhq/revideo/issues/444)) ([443fcc9](https://github.com/havenhq/revideo/commit/443fcc9feb1a1ca69aecbc4db2e194ce4f50f72e))
+* **ui:** make inspector toggleable ([#921](https://github.com/havenhq/revideo/issues/921)) ([a365951](https://github.com/havenhq/revideo/commit/a365951e69c01cac1ea23d173034ad83f988c8eb))
+* **ui:** new sidebar ([#692](https://github.com/havenhq/revideo/issues/692)) ([b555ee1](https://github.com/havenhq/revideo/commit/b555ee1d10f8a6e1b380c043dff2717ffa01a068)), closes [#492](https://github.com/havenhq/revideo/issues/492)
+* **ui:** presentation interface ([#487](https://github.com/havenhq/revideo/issues/487)) ([1899f02](https://github.com/havenhq/revideo/commit/1899f020fb1c0b2136de4401e6fc068bcf5e0cc4))
+* **ui:** scene graph ([#909](https://github.com/havenhq/revideo/issues/909)) ([bf85c5b](https://github.com/havenhq/revideo/commit/bf85c5b4a339719e79da1b87b1aed4492166ce79))
+* **ui:** shift + right arrow moves to last frame ([#354](https://github.com/havenhq/revideo/issues/354)) ([4b81709](https://github.com/havenhq/revideo/commit/4b8170971400c5bf4fe690a58d3f44c3e1d00b94)), closes [#353](https://github.com/havenhq/revideo/issues/353)
+* **ui:** small improvements ([#833](https://github.com/havenhq/revideo/issues/833)) ([f44400c](https://github.com/havenhq/revideo/commit/f44400c458a1d7f49520494f01efb9936f4df83e))
+* **ui:** timeline dragging ([#794](https://github.com/havenhq/revideo/issues/794)) ([248e454](https://github.com/havenhq/revideo/commit/248e4546367f9d99221f64b811a07d54a9988e48)), closes [#699](https://github.com/havenhq/revideo/issues/699)
+* **ui:** timeline overhaul ([#47](https://github.com/havenhq/revideo/issues/47)) ([4232a60](https://github.com/havenhq/revideo/commit/4232a6072540b54451e99e18c1001db0175bb93f)), closes [#20](https://github.com/havenhq/revideo/issues/20)
+* **ui:** timeline scrubbing ([#862](https://github.com/havenhq/revideo/issues/862)) ([211b9a4](https://github.com/havenhq/revideo/commit/211b9a4327720afd1ce0ff93868a501c2fd745aa)), closes [#286](https://github.com/havenhq/revideo/issues/286)
+* **ui:** vertical line on time event ([#808](https://github.com/havenhq/revideo/issues/808)) ([18015d6](https://github.com/havenhq/revideo/commit/18015d6714ffe2a6255f26895aa9a7c1908a4f7a)), closes [#804](https://github.com/havenhq/revideo/issues/804)
+* **ui:** visual changes ([#96](https://github.com/havenhq/revideo/issues/96)) ([3d599f4](https://github.com/havenhq/revideo/commit/3d599f4e1788fbd15e996be8bf95679f1c6787bd))
+* **ui:** zoom controls ([#531](https://github.com/havenhq/revideo/issues/531)) ([752350d](https://github.com/havenhq/revideo/commit/752350d0c547e21806f1b70a5c68025012e5ec11))
+* unify core types ([#71](https://github.com/havenhq/revideo/issues/71)) ([9c5853d](https://github.com/havenhq/revideo/commit/9c5853d8bc65204693c38109a25d1fefd44241b7))
+* webgl shaders ([#920](https://github.com/havenhq/revideo/issues/920)) ([849216e](https://github.com/havenhq/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+
+
+### Reverts
+
+* "ci(release): 9.1.3 [skip ci]" ([62953a6](https://github.com/havenhq/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+* ci(release): 3.12.4 [skip ci] ([#908](https://github.com/havenhq/revideo/issues/908)) ([86c5170](https://github.com/havenhq/revideo/commit/86c517067c7225f827aa05b47e2397e0d90fe622))
+
+
+### BREAKING CHANGES
+
+* `makeProject` no longer accepts some settings.
+
+Settings such as `background` and `audioOffset` are now stored in the project
+meta file.
+* change the overall structure of a project
+
+`vite` and `@motion-canvas/vite-plugin` packages are now required to build a project:
+```
+npm i -D vite @motion-canvas/vite-plugin
+```
+The following `vite.config.ts` file needs to be created in the root of the project:
+```ts
+import {defineConfig} from 'vite';
+import motionCanvas from '@motion-canvas/vite-plugin';
+
+export default defineConfig({
+  plugins: [motionCanvas()],
+});
+```
+
+Types exposed by Motion Canvas are no longer global.
+An additional `motion-canvas.d.ts` file needs to be created in the `src` directory:
+```ts
+/// <reference types="@motion-canvas/core/project" />
+```
+
+ Finally, the `bootstrap` function no longer exists.
+ Project files should export an instance of the `Project` class instead:
+ ```ts
+ import {Project} from '@motion-canvas/core/lib';
+
+ import example from './scenes/example.scene';
+
+ export default new Project({
+   name: 'project',
+   scenes: [example],
+   // same options as in bootstrap() are available:
+
+
+
+
+
 ## [3.14.2](https://github.com/motion-canvas/motion-canvas/compare/v3.14.1...v3.14.2) (2024-02-08)
 
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@motion-canvas/ui",
+  "name": "@revideo/ui",
   "version": "3.14.2",
-  "description": "A visual editor for Motion Canvas",
+  "description": "A visual editor for revideo",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/motion-canvas/motion-canvas.git"
+    "url": "https://github.com/havenhq/revideo.git"
   },
   "files": [
     "dist",
@@ -26,7 +26,7 @@
     "tsconfig.plugin.json"
   ],
   "dependencies": {
-    "@motion-canvas/core": "^3.14.1",
+    "@revideo/core": "^3.14.1",
     "@preact/signals": "^1.2.1",
     "preact": "^10.19.2"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/ui",
-  "version": "3.14.2",
+  "version": "0.1.0",
   "description": "A visual editor for revideo",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
@@ -26,8 +26,8 @@
     "tsconfig.plugin.json"
   ],
   "dependencies": {
-    "@revideo/core": "^3.14.1",
     "@preact/signals": "^1.2.1",
+    "@revideo/core": "^0.1.0",
     "preact": "^10.19.2"
   },
   "devDependencies": {

--- a/packages/ui/src/Editor.tsx
+++ b/packages/ui/src/Editor.tsx
@@ -1,4 +1,4 @@
-import {PresenterState} from '@motion-canvas/core';
+import {PresenterState} from '@revideo/core';
 import styles from './Editor.module.scss';
 import {Console} from './components/console';
 import {Footer} from './components/footer';

--- a/packages/ui/src/components/console/Console.tsx
+++ b/packages/ui/src/components/console/Console.tsx
@@ -1,6 +1,6 @@
 import styles from './Console.module.scss';
 
-import {LogLevel, capitalize} from '@motion-canvas/core';
+import {LogLevel, capitalize} from '@revideo/core';
 import clsx from 'clsx';
 import {useLayoutEffect, useRef} from 'preact/hooks';
 import {useApplication} from '../../contexts';

--- a/packages/ui/src/components/console/Log.tsx
+++ b/packages/ui/src/components/console/Log.tsx
@@ -1,6 +1,6 @@
 import styles from './Console.module.scss';
 
-import {LogLevel, LogPayload} from '@motion-canvas/core';
+import {LogLevel, LogPayload} from '@revideo/core';
 import clsx from 'clsx';
 import {useEffect, useMemo, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';

--- a/packages/ui/src/components/controls/ColorInput.tsx
+++ b/packages/ui/src/components/controls/ColorInput.tsx
@@ -1,4 +1,4 @@
-import {Color} from '@motion-canvas/core';
+import {Color} from '@revideo/core';
 import {valid} from 'chroma-js';
 import clsx from 'clsx';
 import {useReducedMotion} from '../../hooks';

--- a/packages/ui/src/components/fields/AutoField.tsx
+++ b/packages/ui/src/components/fields/AutoField.tsx
@@ -1,4 +1,4 @@
-import {Color, Spacing, Vector2, isType} from '@motion-canvas/core';
+import {Color, Spacing, Vector2, isType} from '@revideo/core';
 import {FunctionComponent} from 'preact';
 import {ArrayField} from './ArrayField';
 import {ColorField} from './ColorField';

--- a/packages/ui/src/components/fields/ColorField.tsx
+++ b/packages/ui/src/components/fields/ColorField.tsx
@@ -1,4 +1,4 @@
-import {Color} from '@motion-canvas/core';
+import {Color} from '@revideo/core';
 import {ColorPreview} from '../controls/ColorPreview';
 import {Field, FieldSet, FieldValue, NumericField} from './Layout';
 

--- a/packages/ui/src/components/fields/SpacingField.tsx
+++ b/packages/ui/src/components/fields/SpacingField.tsx
@@ -1,4 +1,4 @@
-import {Spacing} from '@motion-canvas/core';
+import {Spacing} from '@revideo/core';
 import {Field, FieldSet, FieldValue, NumericField} from './Layout';
 
 export interface SpacingFieldProps {

--- a/packages/ui/src/components/fields/Vector2Field.tsx
+++ b/packages/ui/src/components/fields/Vector2Field.tsx
@@ -1,4 +1,4 @@
-import {Vector2} from '@motion-canvas/core';
+import {Vector2} from '@revideo/core';
 import {useFormattedNumber} from '../../hooks';
 import {Field, FieldSet, FieldValue, NumericField} from './Layout';
 

--- a/packages/ui/src/components/footer/Versions.tsx
+++ b/packages/ui/src/components/footer/Versions.tsx
@@ -16,7 +16,7 @@ export function Versions() {
 
   useEffect(() => {
     const abort = new AbortController();
-    fetch('https://registry.npmjs.org/@motion-canvas/core/latest', {
+    fetch('https://registry.npmjs.org/@revideo/core/latest', {
       signal: abort.signal,
     })
       .then(response => response.json())
@@ -28,7 +28,7 @@ export function Versions() {
     <div className={styles.root}>
       {isOld && (
         <a
-          href="https://github.com/motion-canvas/motion-canvas/releases"
+          href="https://github.com/revideo/revideo/releases"
           target="_blank"
           title="See what's new"
           className={clsx(styles.link, styles.main)}

--- a/packages/ui/src/components/layout/Navigation.tsx
+++ b/packages/ui/src/components/layout/Navigation.tsx
@@ -1,4 +1,4 @@
-import {LogLevel} from '@motion-canvas/core';
+import {LogLevel} from '@revideo/core';
 import {useEffect, useRef, useState} from 'preact/hooks';
 import {useApplication, usePanels} from '../../contexts';
 import {useReducedMotion} from '../../hooks';

--- a/packages/ui/src/components/meta/BoolMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/BoolMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {BoolMetaField} from '@motion-canvas/core';
+import type {BoolMetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {Checkbox} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';

--- a/packages/ui/src/components/meta/ColorMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/ColorMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {ColorMetaField} from '@motion-canvas/core';
+import type {ColorMetaField} from '@revideo/core';
 import {useState} from 'preact/hooks';
 import {useSubscribableValue} from '../../hooks';
 import {ColorInput} from '../controls';

--- a/packages/ui/src/components/meta/EnumMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/EnumMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {EnumMetaField} from '@motion-canvas/core';
+import type {EnumMetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {Select} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';

--- a/packages/ui/src/components/meta/MetaFieldGroup.tsx
+++ b/packages/ui/src/components/meta/MetaFieldGroup.tsx
@@ -1,4 +1,4 @@
-import type {MetaField} from '@motion-canvas/core';
+import type {MetaField} from '@revideo/core';
 import type {ComponentChildren} from 'preact';
 import {useMemo} from 'preact/hooks';
 import {Group, Label} from '../controls';

--- a/packages/ui/src/components/meta/MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/MetaFieldView.tsx
@@ -1,10 +1,5 @@
-import type {MetaField} from '@motion-canvas/core';
-import {
-  Color,
-  EnumMetaField,
-  RangeMetaField,
-  Vector2,
-} from '@motion-canvas/core';
+import type {MetaField} from '@revideo/core';
+import {Color, EnumMetaField, RangeMetaField, Vector2} from '@revideo/core';
 import type {FunctionComponent} from 'preact';
 import {useSubscribableValue} from '../../hooks';
 import {Separator} from '../controls';

--- a/packages/ui/src/components/meta/NumberMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/NumberMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {NumberMetaField} from '@motion-canvas/core';
+import type {NumberMetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {NumberInput, NumberInputSelect} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';

--- a/packages/ui/src/components/meta/ObjectMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/ObjectMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {MetaField, ObjectMetaField} from '@motion-canvas/core';
+import type {MetaField, ObjectMetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {MetaFieldView} from './MetaFieldView';
 

--- a/packages/ui/src/components/meta/RangeMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/RangeMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {RangeMetaField} from '@motion-canvas/core';
+import type {RangeMetaField} from '@revideo/core';
 import {useApplication} from '../../contexts';
 import {
   useDuration,

--- a/packages/ui/src/components/meta/StringMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/StringMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import type {StringMetaField} from '@motion-canvas/core';
+import type {StringMetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {Input, InputSelect} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';

--- a/packages/ui/src/components/meta/UnknownMetaFieldView.tsx
+++ b/packages/ui/src/components/meta/UnknownMetaFieldView.tsx
@@ -1,4 +1,4 @@
-import {MetaField} from '@motion-canvas/core';
+import {MetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {Group, Label} from '../controls';
 import {AutoField} from '../fields';

--- a/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
+++ b/packages/ui/src/components/meta/Vector2MetaFieldView.tsx
@@ -1,4 +1,4 @@
-import {Vector2MetaField} from '@motion-canvas/core';
+import {Vector2MetaField} from '@revideo/core';
 import {useSubscribableValue} from '../../hooks';
 import {NumberInput} from '../controls';
 import {MetaFieldGroup} from './MetaFieldGroup';

--- a/packages/ui/src/components/presentation/SceneGroup.tsx
+++ b/packages/ui/src/components/presentation/SceneGroup.tsx
@@ -1,4 +1,4 @@
-import type {Scene} from '@motion-canvas/core';
+import type {Scene} from '@revideo/core';
 import {useEffect, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';
 import {useSubscribableValue} from '../../hooks';

--- a/packages/ui/src/components/presentation/SlideElement.tsx
+++ b/packages/ui/src/components/presentation/SlideElement.tsx
@@ -1,4 +1,4 @@
-import type {Slide} from '@motion-canvas/core';
+import type {Slide} from '@revideo/core';
 import clsx from 'clsx';
 import {useApplication} from '../../contexts';
 import styles from './SlideGraph.module.scss';

--- a/packages/ui/src/components/sidebar/Threads.tsx
+++ b/packages/ui/src/components/sidebar/Threads.tsx
@@ -1,6 +1,6 @@
 import styles from './Sidebar.module.scss';
 
-import {getTaskName, isThreadable, type Thread} from '@motion-canvas/core';
+import {getTaskName, isThreadable, type Thread} from '@revideo/core';
 import {
   useCurrentFrame,
   useCurrentScene,

--- a/packages/ui/src/components/sidebar/VideoSettings.tsx
+++ b/packages/ui/src/components/sidebar/VideoSettings.tsx
@@ -1,4 +1,4 @@
-import {RendererState} from '@motion-canvas/core';
+import {RendererState} from '@revideo/core';
 import {useApplication} from '../../contexts';
 import {useRendererState, useStorage} from '../../hooks';
 import {openOutputPath} from '../../utils';

--- a/packages/ui/src/components/tabs/Badge.tsx
+++ b/packages/ui/src/components/tabs/Badge.tsx
@@ -1,4 +1,4 @@
-import {LogLevel} from '@motion-canvas/core';
+import {LogLevel} from '@revideo/core';
 import clsx from 'clsx';
 import {ComponentChildren, Ref} from 'preact';
 import styles from './Tabs.module.scss';

--- a/packages/ui/src/components/timeline/Label.tsx
+++ b/packages/ui/src/components/timeline/Label.tsx
@@ -1,7 +1,7 @@
 import styles from './Timeline.module.scss';
 
-import type {Scene} from '@motion-canvas/core';
-import type {TimeEvent} from '@motion-canvas/core/lib/scenes/timeEvents';
+import type {Scene} from '@revideo/core';
+import type {TimeEvent} from '@revideo/core/lib/scenes/timeEvents';
 import {useLayoutEffect, useState} from 'preact/hooks';
 import {useApplication, useTimelineContext} from '../../contexts';
 import {labelClipDraggingLeftSignal} from '../../signals';

--- a/packages/ui/src/components/timeline/LabelGroup.tsx
+++ b/packages/ui/src/components/timeline/LabelGroup.tsx
@@ -1,4 +1,4 @@
-import type {Scene} from '@motion-canvas/core';
+import type {Scene} from '@revideo/core';
 import {useTimelineContext} from '../../contexts';
 import {useSubscribableValue} from '../../hooks';
 import {Label} from './Label';

--- a/packages/ui/src/components/timeline/SceneTrack.tsx
+++ b/packages/ui/src/components/timeline/SceneTrack.tsx
@@ -1,6 +1,6 @@
 import styles from './Timeline.module.scss';
 
-import type {Scene} from '@motion-canvas/core';
+import type {Scene} from '@revideo/core';
 import {useMemo} from 'preact/hooks';
 import {useApplication, useTimelineContext} from '../../contexts';
 import {useScenes, useSubscribableValue} from '../../hooks';

--- a/packages/ui/src/components/timeline/SlideTrack.tsx
+++ b/packages/ui/src/components/timeline/SlideTrack.tsx
@@ -1,4 +1,4 @@
-import {Scene} from '@motion-canvas/core';
+import {Scene} from '@revideo/core';
 import clsx from 'clsx';
 import {useApplication} from '../../contexts';
 import {useSubscribableValue} from '../../hooks';

--- a/packages/ui/src/components/viewport/Coordinates.tsx
+++ b/packages/ui/src/components/viewport/Coordinates.tsx
@@ -1,4 +1,4 @@
-import {isInspectable, Vector2} from '@motion-canvas/core';
+import {isInspectable, Vector2} from '@revideo/core';
 import {useCallback} from 'preact/hooks';
 import {useEffect, useState} from 'react';
 import {useViewportContext} from '../../contexts';

--- a/packages/ui/src/components/viewport/PreviewStage.tsx
+++ b/packages/ui/src/components/viewport/PreviewStage.tsx
@@ -1,4 +1,4 @@
-import {Stage} from '@motion-canvas/core';
+import {Stage} from '@revideo/core';
 import {JSX} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';

--- a/packages/ui/src/components/viewport/StageView.tsx
+++ b/packages/ui/src/components/viewport/StageView.tsx
@@ -1,4 +1,4 @@
-import type {Stage} from '@motion-canvas/core';
+import type {Stage} from '@revideo/core';
 import clsx from 'clsx';
 import {JSX} from 'preact';
 import {MutableRef, useLayoutEffect, useRef} from 'preact/hooks';

--- a/packages/ui/src/components/viewport/Viewport.tsx
+++ b/packages/ui/src/components/viewport/Viewport.tsx
@@ -1,4 +1,4 @@
-import {RendererState} from '@motion-canvas/core';
+import {RendererState} from '@revideo/core';
 import clsx from 'clsx';
 import {useEffect, useState} from 'preact/hooks';
 import {useApplication} from '../../contexts';

--- a/packages/ui/src/contexts/application.tsx
+++ b/packages/ui/src/contexts/application.tsx
@@ -1,3 +1,4 @@
+import {Signal, useSignal} from '@preact/signals';
 import type {
   Player,
   Presenter,
@@ -5,8 +6,7 @@ import type {
   ProjectMetadata,
   Renderer,
   SettingsMetadata,
-} from '@motion-canvas/core';
-import {Signal, useSignal} from '@preact/signals';
+} from '@revideo/core';
 import {ComponentChildren, createContext} from 'preact';
 import {useContext, useRef} from 'preact/hooks';
 import {useSubscribable} from '../hooks';

--- a/packages/ui/src/hooks/useCurrentFrame.ts
+++ b/packages/ui/src/hooks/useCurrentFrame.ts
@@ -1,4 +1,4 @@
-import {RendererState} from '@motion-canvas/core';
+import {RendererState} from '@revideo/core';
 import {useApplication} from '../contexts';
 import {useRendererState} from './useRendererState';
 import {usePreviewSettings, useRenderingSettings} from './useSettings';

--- a/packages/ui/src/hooks/useSubscribable.ts
+++ b/packages/ui/src/hooks/useSubscribable.ts
@@ -2,7 +2,7 @@ import type {
   EventHandler,
   Subscribable,
   SubscribableValueEvent,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {Inputs, useEffect, useState} from 'preact/hooks';
 
 export function useSubscribable<TValue, THandler extends EventHandler<TValue>>(

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -6,7 +6,7 @@ import {
   Renderer,
   experimentalLog,
   type Project,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 import {ComponentChild, render} from 'preact';
 import {Editor} from './Editor';
 import {ProjectData, ProjectSelection} from './ProjectSelection';
@@ -44,7 +44,7 @@ export function editor(project: Project) {
 
   if (!project.experimentalFeatures) {
     for (const plugin of project.plugins) {
-      if (plugin.name.startsWith('@motion-canvas')) {
+      if (plugin.name.startsWith('@revideo')) {
         continue;
       }
 

--- a/packages/ui/src/plugin/EditorPlugin.ts
+++ b/packages/ui/src/plugin/EditorPlugin.ts
@@ -1,4 +1,4 @@
-import {Plugin} from '@motion-canvas/core';
+import {Plugin} from '@revideo/core';
 import {FunctionComponent} from 'preact';
 
 /**

--- a/packages/ui/src/plugin/GridPlugin/index.ts
+++ b/packages/ui/src/plugin/GridPlugin/index.ts
@@ -5,7 +5,7 @@ import {makeEditorPlugin} from '../makeEditorPlugin';
 const GRID_SIZE = 40;
 
 export default makeEditorPlugin({
-  name: '@motion-canvas/ui/grid',
+  name: '@revideo/ui/grid',
   previewOverlay: {
     drawHook: () => {
       const state = useViewportContext();

--- a/packages/ui/src/utils/LoggerManager.ts
+++ b/packages/ui/src/utils/LoggerManager.ts
@@ -4,7 +4,7 @@ import {
   LogPayload,
   Logger,
   ValueDispatcher,
-} from '@motion-canvas/core';
+} from '@revideo/core';
 
 export class LoggerManager {
   public get onInspected() {

--- a/packages/ui/types/main.d.ts
+++ b/packages/ui/types/main.d.ts
@@ -1,4 +1,4 @@
-import type {Project} from '@motion-canvas/core';
+import type {Project} from '@revideo/core';
 
 export function editor(project: Project): void;
 

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -7,9 +7,9 @@ export default defineConfig({
   resolve: {
     alias: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      '@motion-canvas/ui': '/src/main.tsx',
+      '@revideo/ui': '/src/main.tsx',
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      '@motion-canvas/2d/editor': '@motion-canvas/2d/src/editor',
+      '@revideo/2d/editor': '@revideo/2d/src/editor',
     },
   },
   build: {
@@ -19,7 +19,7 @@ export default defineConfig({
       fileName: 'main',
     },
     rollupOptions: {
-      external: [/^@motion-canvas\/core/, /^@?preact/],
+      external: [/^@revideo\/core/, /^@?preact/],
     },
   },
   plugins: [

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -3,79 +3,79 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [3.14.1](https://github.com/motion-canvas/motion-canvas/compare/v3.14.0...v3.14.1) (2024-02-06)
+## [3.14.1](https://github.com/revideo/revideo/compare/v3.14.0...v3.14.1) (2024-02-06)
 
 
 ### Bug Fixes
 
-* fix project selection screen ([#938](https://github.com/motion-canvas/motion-canvas/issues/938)) ([3b3f287](https://github.com/motion-canvas/motion-canvas/commit/3b3f2871d9884c67f7d46215dd12fc02e27f8054))
+* fix project selection screen ([#938](https://github.com/revideo/revideo/issues/938)) ([3b3f287](https://github.com/revideo/revideo/commit/3b3f2871d9884c67f7d46215dd12fc02e27f8054))
 
 
 
 
 
-# [3.14.0](https://github.com/motion-canvas/motion-canvas/compare/v3.13.0...v3.14.0) (2024-02-04)
+# [3.14.0](https://github.com/revideo/revideo/compare/v3.13.0...v3.14.0) (2024-02-04)
 
 
 ### Features
 
-* webgl shaders ([#920](https://github.com/motion-canvas/motion-canvas/issues/920)) ([849216e](https://github.com/motion-canvas/motion-canvas/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+* webgl shaders ([#920](https://github.com/revideo/revideo/issues/920)) ([849216e](https://github.com/revideo/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
 
 
 
 
 
-# [3.13.0](https://github.com/motion-canvas/motion-canvas/compare/v3.12.4...v3.13.0) (2024-01-10)
+# [3.13.0](https://github.com/revideo/revideo/compare/v3.12.4...v3.13.0) (2024-01-10)
 
-**Note:** Version bump only for package @motion-canvas/vite-plugin
-
-
-
-
-
-## [3.12.3](https://github.com/motion-canvas/motion-canvas/compare/v3.12.2...v3.12.3) (2024-01-04)
-
-**Note:** Version bump only for package @motion-canvas/vite-plugin
+**Note:** Version bump only for package @revideo/vite-plugin
 
 
 
 
 
-## [3.12.2](https://github.com/motion-canvas/motion-canvas/compare/v3.12.1...v3.12.2) (2023-12-31)
+## [3.12.3](https://github.com/revideo/revideo/compare/v3.12.2...v3.12.3) (2024-01-04)
 
-
-### Bug Fixes
-
-* fix dependency bundling again ([#898](https://github.com/motion-canvas/motion-canvas/issues/898)) ([d6e0f48](https://github.com/motion-canvas/motion-canvas/commit/d6e0f48e67cf6baee710b8d5b185e620e67ceda5))
+**Note:** Version bump only for package @revideo/vite-plugin
 
 
 
 
 
-## [3.12.1](https://github.com/motion-canvas/motion-canvas/compare/v3.12.0...v3.12.1) (2023-12-31)
+## [3.12.2](https://github.com/revideo/revideo/compare/v3.12.1...v3.12.2) (2023-12-31)
 
 
 ### Bug Fixes
 
-* fix dependency bundling ([#897](https://github.com/motion-canvas/motion-canvas/issues/897)) ([5376012](https://github.com/motion-canvas/motion-canvas/commit/5376012cd02b8bca5abc2d3cf5a724662244c449))
+* fix dependency bundling again ([#898](https://github.com/revideo/revideo/issues/898)) ([d6e0f48](https://github.com/revideo/revideo/commit/d6e0f48e67cf6baee710b8d5b185e620e67ceda5))
 
 
 
 
 
-# [3.12.0](https://github.com/motion-canvas/motion-canvas/compare/v3.11.0...v3.12.0) (2023-12-31)
+## [3.12.1](https://github.com/revideo/revideo/compare/v3.12.0...v3.12.1) (2023-12-31)
 
 
 ### Bug Fixes
 
-* exclude preact from optimizations ([#894](https://github.com/motion-canvas/motion-canvas/issues/894)) ([15687cc](https://github.com/motion-canvas/motion-canvas/commit/15687cc975abcf4538a5ce51402d2308057d42e5))
-* **vite-plugin:** create empty output directory if not exist ([#787](https://github.com/motion-canvas/motion-canvas/issues/787)) ([20cceef](https://github.com/motion-canvas/motion-canvas/commit/20cceef8525e809bff9706fcd7082d7e103a085b))
-* **vite-plugin:** handle unusual characters in file names ([#821](https://github.com/motion-canvas/motion-canvas/issues/821)) ([1e57497](https://github.com/motion-canvas/motion-canvas/commit/1e5749785d55a41605a5438eee08672ef01f3914)), closes [#764](https://github.com/motion-canvas/motion-canvas/issues/764)
+* fix dependency bundling ([#897](https://github.com/revideo/revideo/issues/897)) ([5376012](https://github.com/revideo/revideo/commit/5376012cd02b8bca5abc2d3cf5a724662244c449))
+
+
+
+
+
+# [3.12.0](https://github.com/revideo/revideo/compare/v3.11.0...v3.12.0) (2023-12-31)
+
+
+### Bug Fixes
+
+* exclude preact from optimizations ([#894](https://github.com/revideo/revideo/issues/894)) ([15687cc](https://github.com/revideo/revideo/commit/15687cc975abcf4538a5ce51402d2308057d42e5))
+* **vite-plugin:** create empty output directory if not exist ([#787](https://github.com/revideo/revideo/issues/787)) ([20cceef](https://github.com/revideo/revideo/commit/20cceef8525e809bff9706fcd7082d7e103a085b))
+* **vite-plugin:** handle unusual characters in file names ([#821](https://github.com/revideo/revideo/issues/821)) ([1e57497](https://github.com/revideo/revideo/commit/1e5749785d55a41605a5438eee08672ef01f3914)), closes [#764](https://github.com/revideo/revideo/issues/764)
 
 
 ### Features
 
-* **vite-plugin:** support glob for project files ([#834](https://github.com/motion-canvas/motion-canvas/issues/834)) ([67029c4](https://github.com/motion-canvas/motion-canvas/commit/67029c4c2cf756cbe2b7ed59dc55cb895de81d52)), closes [#324](https://github.com/motion-canvas/motion-canvas/issues/324)
+* **vite-plugin:** support glob for project files ([#834](https://github.com/revideo/revideo/issues/834)) ([67029c4](https://github.com/revideo/revideo/commit/67029c4c2cf756cbe2b7ed59dc55cb895de81d52)), closes [#324](https://github.com/revideo/revideo/issues/324)
 
 
 
@@ -86,134 +86,134 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.11.0](https://github.com/motion-canvas/motion-canvas/compare/v3.10.1...v3.11.0) (2023-10-13)
+# [3.11.0](https://github.com/revideo/revideo/compare/v3.10.1...v3.11.0) (2023-10-13)
 
 ### Features
 
 - **core:** hot module replacement for audio
-  ([#793](https://github.com/motion-canvas/motion-canvas/issues/793))
-  ([d40c1a8](https://github.com/motion-canvas/motion-canvas/commit/d40c1a83c645c8984cca1ebc6fe687b445a0550c))
+  ([#793](https://github.com/revideo/revideo/issues/793))
+  ([d40c1a8](https://github.com/revideo/revideo/commit/d40c1a83c645c8984cca1ebc6fe687b445a0550c))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.10.0](https://github.com/motion-canvas/motion-canvas/compare/v3.9.0...v3.10.0) (2023-07-23)
+# [3.10.0](https://github.com/revideo/revideo/compare/v3.9.0...v3.10.0) (2023-07-23)
 
-**Note:** Version bump only for package @motion-canvas/vite-plugin
+**Note:** Version bump only for package @revideo/vite-plugin
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.9.0](https://github.com/motion-canvas/motion-canvas/compare/v3.8.0...v3.9.0) (2023-05-29)
+# [3.9.0](https://github.com/revideo/revideo/compare/v3.8.0...v3.9.0) (2023-05-29)
 
 ### Features
 
 - application settings
-  ([#697](https://github.com/motion-canvas/motion-canvas/issues/697))
-  ([54016f5](https://github.com/motion-canvas/motion-canvas/commit/54016f5cf3500abe13a217537307a3735d60f536)),
-  closes [#167](https://github.com/motion-canvas/motion-canvas/issues/167)
+  ([#697](https://github.com/revideo/revideo/issues/697))
+  ([54016f5](https://github.com/revideo/revideo/commit/54016f5cf3500abe13a217537307a3735d60f536)),
+  closes [#167](https://github.com/revideo/revideo/issues/167)
 - **vite-plugin:** add entry point
-  ([#721](https://github.com/motion-canvas/motion-canvas/issues/721))
-  ([e634b6c](https://github.com/motion-canvas/motion-canvas/commit/e634b6cb67b3c569d21d424661708ca946ea4cc3))
+  ([#721](https://github.com/revideo/revideo/issues/721))
+  ([e634b6c](https://github.com/revideo/revideo/commit/e634b6cb67b3c569d21d424661708ca946ea4cc3))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.8.0](https://github.com/motion-canvas/motion-canvas/compare/v3.7.0...v3.8.0) (2023-05-13)
+# [3.8.0](https://github.com/revideo/revideo/compare/v3.7.0...v3.8.0) (2023-05-13)
 
 ### Bug Fixes
 
 - remove dependency pre-bundling warning
-  ([#676](https://github.com/motion-canvas/motion-canvas/issues/676))
-  ([38c81ff](https://github.com/motion-canvas/motion-canvas/commit/38c81ffa5ea0ef2d2beec9d015896f5873629d74))
+  ([#676](https://github.com/revideo/revideo/issues/676))
+  ([38c81ff](https://github.com/revideo/revideo/commit/38c81ffa5ea0ef2d2beec9d015896f5873629d74))
 
 ### Features
 
 - add new hooks for plugins
-  ([#679](https://github.com/motion-canvas/motion-canvas/issues/679))
-  ([74e18bc](https://github.com/motion-canvas/motion-canvas/commit/74e18bce71abd7e26a6415240603241b48cb36c2))
+  ([#679](https://github.com/revideo/revideo/issues/679))
+  ([74e18bc](https://github.com/revideo/revideo/commit/74e18bce71abd7e26a6415240603241b48cb36c2))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.7.0](https://github.com/motion-canvas/motion-canvas/compare/v3.6.2...v3.7.0) (2023-05-10)
+# [3.7.0](https://github.com/revideo/revideo/compare/v3.6.2...v3.7.0) (2023-05-10)
 
 ### Features
 
 - button for opening the output directory
-  ([#663](https://github.com/motion-canvas/motion-canvas/issues/663))
-  ([79f320c](https://github.com/motion-canvas/motion-canvas/commit/79f320c07c422ca927b34bf339094fe0e70ffd0d))
+  ([#663](https://github.com/revideo/revideo/issues/663))
+  ([79f320c](https://github.com/revideo/revideo/commit/79f320c07c422ca927b34bf339094fe0e70ffd0d))
 - finalize custom exporters
-  ([#660](https://github.com/motion-canvas/motion-canvas/issues/660))
-  ([6a50430](https://github.com/motion-canvas/motion-canvas/commit/6a50430cdf9928992ca078eba39c484a5253da2b))
+  ([#660](https://github.com/revideo/revideo/issues/660))
+  ([6a50430](https://github.com/revideo/revideo/commit/6a50430cdf9928992ca078eba39c484a5253da2b))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.4.0](https://github.com/motion-canvas/motion-canvas/compare/v3.3.4...v3.4.0) (2023-03-28)
+# [3.4.0](https://github.com/revideo/revideo/compare/v3.3.4...v3.4.0) (2023-03-28)
 
 ### Features
 
 - get name from meta file
-  ([#552](https://github.com/motion-canvas/motion-canvas/issues/552))
-  ([ae2ed8a](https://github.com/motion-canvas/motion-canvas/commit/ae2ed8a5998768f160ec340d8b63d600d27bc15c))
+  ([#552](https://github.com/revideo/revideo/issues/552))
+  ([ae2ed8a](https://github.com/revideo/revideo/commit/ae2ed8a5998768f160ec340d8b63d600d27bc15c))
 - plugin architecture
-  ([#564](https://github.com/motion-canvas/motion-canvas/issues/564))
-  ([1c375b8](https://github.com/motion-canvas/motion-canvas/commit/1c375b81e0af8a76467d42dd46a7031adb9d71d3))
+  ([#564](https://github.com/revideo/revideo/issues/564))
+  ([1c375b8](https://github.com/revideo/revideo/commit/1c375b81e0af8a76467d42dd46a7031adb9d71d3))
 
 # Change Log
 
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [3.3.0](https://github.com/motion-canvas/motion-canvas/compare/v3.2.1...v3.3.0) (2023-03-18)
+# [3.3.0](https://github.com/revideo/revideo/compare/v3.2.1...v3.3.0) (2023-03-18)
 
 ### Bug Fixes
 
 - **vite-plugin:** can't assign port
-  ([#538](https://github.com/motion-canvas/motion-canvas/issues/538))
-  ([61b692b](https://github.com/motion-canvas/motion-canvas/commit/61b692bf97bb7e15d31469ada2e3dda84c2b99f8))
+  ([#538](https://github.com/revideo/revideo/issues/538))
+  ([61b692b](https://github.com/revideo/revideo/commit/61b692bf97bb7e15d31469ada2e3dda84c2b99f8))
 
 ### Features
 
 - add option to group output by scenes
-  ([#477](https://github.com/motion-canvas/motion-canvas/issues/477))
-  ([9934593](https://github.com/motion-canvas/motion-canvas/commit/99345937e7ac92fb674fdee10288e467ffd941e2))
+  ([#477](https://github.com/revideo/revideo/issues/477))
+  ([9934593](https://github.com/revideo/revideo/commit/99345937e7ac92fb674fdee10288e467ffd941e2))
 - update vite from v3 to v4
-  ([#495](https://github.com/motion-canvas/motion-canvas/issues/495))
-  ([c409eee](https://github.com/motion-canvas/motion-canvas/commit/c409eee0e61b67e43afed240c5ae279714681246)),
-  closes [#197](https://github.com/motion-canvas/motion-canvas/issues/197)
+  ([#495](https://github.com/revideo/revideo/issues/495))
+  ([c409eee](https://github.com/revideo/revideo/commit/c409eee0e61b67e43afed240c5ae279714681246)),
+  closes [#197](https://github.com/revideo/revideo/issues/197)
 
-# [3.2.0](https://github.com/motion-canvas/motion-canvas/compare/v3.1.0...v3.2.0) (2023-03-10)
+# [3.2.0](https://github.com/revideo/revideo/compare/v3.1.0...v3.2.0) (2023-03-10)
 
 ### Features
 
 - display current package versions
-  ([#501](https://github.com/motion-canvas/motion-canvas/issues/501))
-  ([2972f67](https://github.com/motion-canvas/motion-canvas/commit/2972f673e201310e69688ab6f2c1adf1cddf2bf3))
+  ([#501](https://github.com/revideo/revideo/issues/501))
+  ([2972f67](https://github.com/revideo/revideo/commit/2972f673e201310e69688ab6f2c1adf1cddf2bf3))
 
-# [3.1.0](https://github.com/motion-canvas/motion-canvas/compare/v3.0.2...v3.1.0) (2023-03-07)
+# [3.1.0](https://github.com/revideo/revideo/compare/v3.0.2...v3.1.0) (2023-03-07)
 
-**Note:** Version bump only for package @motion-canvas/vite-plugin
+**Note:** Version bump only for package @revideo/vite-plugin
 
-# [3.0.0](https://github.com/motion-canvas/motion-canvas/compare/v2.6.0...v3.0.0) (2023-02-27)
+# [3.0.0](https://github.com/revideo/revideo/compare/v2.6.0...v3.0.0) (2023-02-27)
 
 ### Features
 
 - new playback architecture
-  ([#402](https://github.com/motion-canvas/motion-canvas/issues/402))
-  ([bbe3e2a](https://github.com/motion-canvas/motion-canvas/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)),
-  closes [#166](https://github.com/motion-canvas/motion-canvas/issues/166)
+  ([#402](https://github.com/revideo/revideo/issues/402))
+  ([bbe3e2a](https://github.com/revideo/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)),
+  closes [#166](https://github.com/revideo/revideo/issues/166)
 
 ### BREAKING CHANGES
 
@@ -222,96 +222,96 @@ All notable changes to this project will be documented in this file. See
 Settings such as `background` and `audioOffset` are now stored in the project
 meta file.
 
-# [2.6.0](https://github.com/motion-canvas/motion-canvas/compare/v2.5.0...v2.6.0) (2023-02-24)
+# [2.6.0](https://github.com/revideo/revideo/compare/v2.5.0...v2.6.0) (2023-02-24)
 
 ### Features
 
 - **vite-plugin:** add CORS Proxy
-  ([#357](https://github.com/motion-canvas/motion-canvas/issues/357))
-  ([a3c5822](https://github.com/motion-canvas/motion-canvas/commit/a3c58228b7d3dab08fc27414d19870d35773b280)),
-  closes [#338](https://github.com/motion-canvas/motion-canvas/issues/338)
+  ([#357](https://github.com/revideo/revideo/issues/357))
+  ([a3c5822](https://github.com/revideo/revideo/commit/a3c58228b7d3dab08fc27414d19870d35773b280)),
+  closes [#338](https://github.com/revideo/revideo/issues/338)
 
-# [2.4.0](https://github.com/motion-canvas/motion-canvas/compare/v2.3.0...v2.4.0) (2023-02-18)
+# [2.4.0](https://github.com/revideo/revideo/compare/v2.3.0...v2.4.0) (2023-02-18)
 
 ### Bug Fixes
 
 - **vite-plugin:** ignore query param in devserver
-  ([#351](https://github.com/motion-canvas/motion-canvas/issues/351))
-  ([5644d72](https://github.com/motion-canvas/motion-canvas/commit/5644d72d36adcdc817f0856aaff0be5507338cb8))
+  ([#351](https://github.com/revideo/revideo/issues/351))
+  ([5644d72](https://github.com/revideo/revideo/commit/5644d72d36adcdc817f0856aaff0be5507338cb8))
 
-# [2.2.0](https://github.com/motion-canvas/motion-canvas/compare/v2.1.0...v2.2.0) (2023-02-09)
+# [2.2.0](https://github.com/revideo/revideo/compare/v2.1.0...v2.2.0) (2023-02-09)
 
-**Note:** Version bump only for package @motion-canvas/vite-plugin
+**Note:** Version bump only for package @revideo/vite-plugin
 
-# [2.1.0](https://github.com/motion-canvas/motion-canvas/compare/v2.0.0...v2.1.0) (2023-02-07)
+# [2.1.0](https://github.com/revideo/revideo/compare/v2.0.0...v2.1.0) (2023-02-07)
 
 ### Bug Fixes
 
 - **vite-plugin:** add missing headers to html
-  ([#219](https://github.com/motion-canvas/motion-canvas/issues/219))
-  ([2552bcf](https://github.com/motion-canvas/motion-canvas/commit/2552bcfbe2e90f3d4b86810d39f8cee24349e405)),
-  closes [#201](https://github.com/motion-canvas/motion-canvas/issues/201)
+  ([#219](https://github.com/revideo/revideo/issues/219))
+  ([2552bcf](https://github.com/revideo/revideo/commit/2552bcfbe2e90f3d4b86810d39f8cee24349e405)),
+  closes [#201](https://github.com/revideo/revideo/issues/201)
 
 # 2.0.0 (2023-02-04)
 
 ### Code Refactoring
 
 - remove legacy package
-  ([6a84120](https://github.com/motion-canvas/motion-canvas/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+  ([6a84120](https://github.com/revideo/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
 
 ### Features
 
 - add markdown logs
-  ([#138](https://github.com/motion-canvas/motion-canvas/issues/138))
-  ([e42447a](https://github.com/motion-canvas/motion-canvas/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+  ([#138](https://github.com/revideo/revideo/issues/138))
+  ([e42447a](https://github.com/revideo/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
 - add rendering again
-  ([#43](https://github.com/motion-canvas/motion-canvas/issues/43))
-  ([c10d3db](https://github.com/motion-canvas/motion-canvas/commit/c10d3dbb63f6248eda04128ef0aa9d72c1edfcf7))
+  ([#43](https://github.com/revideo/revideo/issues/43))
+  ([c10d3db](https://github.com/revideo/revideo/commit/c10d3dbb63f6248eda04128ef0aa9d72c1edfcf7))
 - add scaffolding package
-  ([#36](https://github.com/motion-canvas/motion-canvas/issues/36))
-  ([266a561](https://github.com/motion-canvas/motion-canvas/commit/266a561c619b57b403ec9c64185985b48bff29da)),
-  closes [#30](https://github.com/motion-canvas/motion-canvas/issues/30)
+  ([#36](https://github.com/revideo/revideo/issues/36))
+  ([266a561](https://github.com/revideo/revideo/commit/266a561c619b57b403ec9c64185985b48bff29da)),
+  closes [#30](https://github.com/revideo/revideo/issues/30)
 - detect circular signal dependencies
-  ([#129](https://github.com/motion-canvas/motion-canvas/issues/129))
-  ([6fcdb41](https://github.com/motion-canvas/motion-canvas/commit/6fcdb41df90dca1c39537a4f6d4960ab551f4d6e))
+  ([#129](https://github.com/revideo/revideo/issues/129))
+  ([6fcdb41](https://github.com/revideo/revideo/commit/6fcdb41df90dca1c39537a4f6d4960ab551f4d6e))
 - extract konva to separate package
-  ([#60](https://github.com/motion-canvas/motion-canvas/issues/60))
-  ([4ecad3c](https://github.com/motion-canvas/motion-canvas/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
+  ([#60](https://github.com/revideo/revideo/issues/60))
+  ([4ecad3c](https://github.com/revideo/revideo/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
 - make exporting concurrent
-  ([4f9ef8d](https://github.com/motion-canvas/motion-canvas/commit/4f9ef8d40d9d9c1147e2edfc0766c5ea5cc4297c))
+  ([4f9ef8d](https://github.com/revideo/revideo/commit/4f9ef8d40d9d9c1147e2edfc0766c5ea5cc4297c))
 - make scenes independent of names
-  ([#53](https://github.com/motion-canvas/motion-canvas/issues/53))
-  ([417617e](https://github.com/motion-canvas/motion-canvas/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)),
-  closes [#25](https://github.com/motion-canvas/motion-canvas/issues/25)
+  ([#53](https://github.com/revideo/revideo/issues/53))
+  ([417617e](https://github.com/revideo/revideo/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)),
+  closes [#25](https://github.com/revideo/revideo/issues/25)
 - navigate to scene and node source
-  ([#144](https://github.com/motion-canvas/motion-canvas/issues/144))
-  ([86d495d](https://github.com/motion-canvas/motion-canvas/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+  ([#144](https://github.com/revideo/revideo/issues/144))
+  ([86d495d](https://github.com/revideo/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
 - support for multiple projects
-  ([#57](https://github.com/motion-canvas/motion-canvas/issues/57))
-  ([573752d](https://github.com/motion-canvas/motion-canvas/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)),
-  closes [#141414](https://github.com/motion-canvas/motion-canvas/issues/141414)
+  ([#57](https://github.com/revideo/revideo/issues/57))
+  ([573752d](https://github.com/revideo/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)),
+  closes [#141414](https://github.com/revideo/revideo/issues/141414)
 - support multiple players
-  ([#128](https://github.com/motion-canvas/motion-canvas/issues/128))
-  ([24f75cf](https://github.com/motion-canvas/motion-canvas/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+  ([#128](https://github.com/revideo/revideo/issues/128))
+  ([24f75cf](https://github.com/revideo/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
 - switch to Vite
-  ([#28](https://github.com/motion-canvas/motion-canvas/issues/28))
-  ([65b9133](https://github.com/motion-canvas/motion-canvas/commit/65b91337dbc47fe51cecc83657f79fab15343a0d)),
-  closes [#141414](https://github.com/motion-canvas/motion-canvas/issues/141414)
-  [#13](https://github.com/motion-canvas/motion-canvas/issues/13)
+  ([#28](https://github.com/revideo/revideo/issues/28))
+  ([65b9133](https://github.com/revideo/revideo/commit/65b91337dbc47fe51cecc83657f79fab15343a0d)),
+  closes [#141414](https://github.com/revideo/revideo/issues/141414)
+  [#13](https://github.com/revideo/revideo/issues/13)
 - **vite-plugin:** improve audio handling
-  ([#154](https://github.com/motion-canvas/motion-canvas/issues/154))
-  ([482f144](https://github.com/motion-canvas/motion-canvas/commit/482f14447ae54543346fab0f9e5b94631c5cfd4d))
+  ([#154](https://github.com/revideo/revideo/issues/154))
+  ([482f144](https://github.com/revideo/revideo/commit/482f14447ae54543346fab0f9e5b94631c5cfd4d))
 
 ### Reverts
 
 - "ci(release): 9.1.3 [skip ci]"
-  ([62953a6](https://github.com/motion-canvas/motion-canvas/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+  ([62953a6](https://github.com/revideo/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
 - ci(release): 1.0.1 [skip ci]
-  ([#175](https://github.com/motion-canvas/motion-canvas/issues/175))
-  ([161a046](https://github.com/motion-canvas/motion-canvas/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+  ([#175](https://github.com/revideo/revideo/issues/175))
+  ([161a046](https://github.com/revideo/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
 - ci(release): 2.0.0 [skip ci]
-  ([#176](https://github.com/motion-canvas/motion-canvas/issues/176))
-  ([551096b](https://github.com/motion-canvas/motion-canvas/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+  ([#176](https://github.com/revideo/revideo/issues/176))
+  ([551096b](https://github.com/revideo/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
 
 ### BREAKING CHANGES
 
@@ -319,7 +319,7 @@ meta file.
 - change to import paths
 
 See
-[the migration guide](https://motion-canvas.github.io/guides/migration/12.0.0)
+[the migration guide](https://revideo.github.io/guides/migration/12.0.0)
 for more info.
 
 - change the way scenes are imported
@@ -339,11 +339,11 @@ export default new Project({
 
 - change the overall structure of a project
 
-`vite` and `@motion-canvas/vite-plugin` packages are now required to build a
+`vite` and `@revideo/vite-plugin` packages are now required to build a
 project:
 
 ```
-npm i -D vite @motion-canvas/vite-plugin
+npm i -D vite @revideo/vite-plugin
 ```
 
 The following `vite.config.ts` file needs to be created in the root of the
@@ -351,7 +351,7 @@ project:
 
 ```ts
 import {defineConfig} from 'vite';
-import motionCanvas from '@motion-canvas/vite-plugin';
+import motionCanvas from '@revideo/vite-plugin';
 
 export default defineConfig({
   plugins: [motionCanvas()],
@@ -359,17 +359,17 @@ export default defineConfig({
 ```
 
 Types exposed by Motion Canvas are no longer global. An additional
-`motion-canvas.d.ts` file needs to be created in the `src` directory:
+`revideo.d.ts` file needs to be created in the `src` directory:
 
 ```ts
-/// <reference types="@motion-canvas/core/project" />
+/// <reference types="@revideo/core/project" />
 ```
 
 Finally, the `bootstrap` function no longer exists. Project files should export
 an instance of the `Project` class instead:
 
 ```ts
-import {Project} from '@motion-canvas/core/lib';
+import {Project} from '@revideo/core/lib';
 
 import example from './scenes/example.scene';
 

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -3,6 +3,126 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# 0.1.0 (2024-03-17)
+
+
+### Bug Fixes
+
+* exclude preact from optimizations ([#894](https://github.com/havenhq/revideo/issues/894)) ([15687cc](https://github.com/havenhq/revideo/commit/15687cc975abcf4538a5ce51402d2308057d42e5))
+* fix dependency bundling ([#897](https://github.com/havenhq/revideo/issues/897)) ([5376012](https://github.com/havenhq/revideo/commit/5376012cd02b8bca5abc2d3cf5a724662244c449))
+* fix dependency bundling again ([#898](https://github.com/havenhq/revideo/issues/898)) ([d6e0f48](https://github.com/havenhq/revideo/commit/d6e0f48e67cf6baee710b8d5b185e620e67ceda5))
+* fix project selection screen ([#938](https://github.com/havenhq/revideo/issues/938)) ([3b3f287](https://github.com/havenhq/revideo/commit/3b3f2871d9884c67f7d46215dd12fc02e27f8054))
+* remove dependency pre-bundling warning ([#676](https://github.com/havenhq/revideo/issues/676)) ([38c81ff](https://github.com/havenhq/revideo/commit/38c81ffa5ea0ef2d2beec9d015896f5873629d74))
+* **vite-plugin:** add missing headers to html ([#219](https://github.com/havenhq/revideo/issues/219)) ([2552bcf](https://github.com/havenhq/revideo/commit/2552bcfbe2e90f3d4b86810d39f8cee24349e405)), closes [#201](https://github.com/havenhq/revideo/issues/201)
+* **vite-plugin:** can't assign port ([#538](https://github.com/havenhq/revideo/issues/538)) ([61b692b](https://github.com/havenhq/revideo/commit/61b692bf97bb7e15d31469ada2e3dda84c2b99f8))
+* **vite-plugin:** create empty output directory if not exist ([#787](https://github.com/havenhq/revideo/issues/787)) ([20cceef](https://github.com/havenhq/revideo/commit/20cceef8525e809bff9706fcd7082d7e103a085b))
+* **vite-plugin:** handle unusual characters in file names ([#821](https://github.com/havenhq/revideo/issues/821)) ([1e57497](https://github.com/havenhq/revideo/commit/1e5749785d55a41605a5438eee08672ef01f3914)), closes [#764](https://github.com/havenhq/revideo/issues/764)
+* **vite-plugin:** ignore query param in devserver ([#351](https://github.com/havenhq/revideo/issues/351)) ([5644d72](https://github.com/havenhq/revideo/commit/5644d72d36adcdc817f0856aaff0be5507338cb8))
+
+
+### Code Refactoring
+
+* remove legacy package ([6a84120](https://github.com/havenhq/revideo/commit/6a84120d949a32dff0ad413a9f359510ff109af1))
+
+
+### Features
+
+* add markdown logs ([#138](https://github.com/havenhq/revideo/issues/138)) ([e42447a](https://github.com/havenhq/revideo/commit/e42447a0c07a8192c06d21c5f1801f0266279075))
+* add new hooks for plugins ([#679](https://github.com/havenhq/revideo/issues/679)) ([74e18bc](https://github.com/havenhq/revideo/commit/74e18bce71abd7e26a6415240603241b48cb36c2))
+* add option to group output by scenes ([#477](https://github.com/havenhq/revideo/issues/477)) ([9934593](https://github.com/havenhq/revideo/commit/99345937e7ac92fb674fdee10288e467ffd941e2))
+* add rendering again ([#43](https://github.com/havenhq/revideo/issues/43)) ([c10d3db](https://github.com/havenhq/revideo/commit/c10d3dbb63f6248eda04128ef0aa9d72c1edfcf7))
+* add scaffolding package ([#36](https://github.com/havenhq/revideo/issues/36)) ([266a561](https://github.com/havenhq/revideo/commit/266a561c619b57b403ec9c64185985b48bff29da)), closes [#30](https://github.com/havenhq/revideo/issues/30)
+* application settings ([#697](https://github.com/havenhq/revideo/issues/697)) ([54016f5](https://github.com/havenhq/revideo/commit/54016f5cf3500abe13a217537307a3735d60f536)), closes [#167](https://github.com/havenhq/revideo/issues/167)
+* button for opening the output directory ([#663](https://github.com/havenhq/revideo/issues/663)) ([79f320c](https://github.com/havenhq/revideo/commit/79f320c07c422ca927b34bf339094fe0e70ffd0d))
+* **core:** hot module replacement for audio ([#793](https://github.com/havenhq/revideo/issues/793)) ([d40c1a8](https://github.com/havenhq/revideo/commit/d40c1a83c645c8984cca1ebc6fe687b445a0550c))
+* detect circular signal dependencies ([#129](https://github.com/havenhq/revideo/issues/129)) ([6fcdb41](https://github.com/havenhq/revideo/commit/6fcdb41df90dca1c39537a4f6d4960ab551f4d6e))
+* display current package versions ([#501](https://github.com/havenhq/revideo/issues/501)) ([2972f67](https://github.com/havenhq/revideo/commit/2972f673e201310e69688ab6f2c1adf1cddf2bf3))
+* extract konva to separate package ([#60](https://github.com/havenhq/revideo/issues/60)) ([4ecad3c](https://github.com/havenhq/revideo/commit/4ecad3ca2732bd5147af670c230f8f959129a707))
+* finalize custom exporters ([#660](https://github.com/havenhq/revideo/issues/660)) ([6a50430](https://github.com/havenhq/revideo/commit/6a50430cdf9928992ca078eba39c484a5253da2b))
+* get name from meta file ([#552](https://github.com/havenhq/revideo/issues/552)) ([ae2ed8a](https://github.com/havenhq/revideo/commit/ae2ed8a5998768f160ec340d8b63d600d27bc15c))
+* make exporting concurrent ([4f9ef8d](https://github.com/havenhq/revideo/commit/4f9ef8d40d9d9c1147e2edfc0766c5ea5cc4297c))
+* make scenes independent of names ([#53](https://github.com/havenhq/revideo/issues/53)) ([417617e](https://github.com/havenhq/revideo/commit/417617eb5f0af771e7413c9ce4c7e9b998e3e490)), closes [#25](https://github.com/havenhq/revideo/issues/25)
+* navigate to scene and node source ([#144](https://github.com/havenhq/revideo/issues/144)) ([86d495d](https://github.com/havenhq/revideo/commit/86d495d01a9f8f0a58e676fedb6df9c12a14d14a))
+* new playback architecture ([#402](https://github.com/havenhq/revideo/issues/402)) ([bbe3e2a](https://github.com/havenhq/revideo/commit/bbe3e2a24de068a88f49ed7a2f13e9717039733b)), closes [#166](https://github.com/havenhq/revideo/issues/166)
+* plugin architecture ([#564](https://github.com/havenhq/revideo/issues/564)) ([1c375b8](https://github.com/havenhq/revideo/commit/1c375b81e0af8a76467d42dd46a7031adb9d71d3))
+* support for multiple projects ([#57](https://github.com/havenhq/revideo/issues/57)) ([573752d](https://github.com/havenhq/revideo/commit/573752dd4d79d62a1a30958f1ed550d2cf22c344)), closes [#141414](https://github.com/havenhq/revideo/issues/141414)
+* support multiple players ([#128](https://github.com/havenhq/revideo/issues/128)) ([24f75cf](https://github.com/havenhq/revideo/commit/24f75cf7cdaf38f890e3936edf175afbfd340210))
+* switch to Vite ([#28](https://github.com/havenhq/revideo/issues/28)) ([65b9133](https://github.com/havenhq/revideo/commit/65b91337dbc47fe51cecc83657f79fab15343a0d)), closes [#141414](https://github.com/havenhq/revideo/issues/141414) [#13](https://github.com/havenhq/revideo/issues/13)
+* update vite from v3 to v4 ([#495](https://github.com/havenhq/revideo/issues/495)) ([c409eee](https://github.com/havenhq/revideo/commit/c409eee0e61b67e43afed240c5ae279714681246)), closes [#197](https://github.com/havenhq/revideo/issues/197)
+* **vite-plugin:** add CORS Proxy ([#357](https://github.com/havenhq/revideo/issues/357)) ([a3c5822](https://github.com/havenhq/revideo/commit/a3c58228b7d3dab08fc27414d19870d35773b280)), closes [#338](https://github.com/havenhq/revideo/issues/338)
+* **vite-plugin:** add entry point ([#721](https://github.com/havenhq/revideo/issues/721)) ([e634b6c](https://github.com/havenhq/revideo/commit/e634b6cb67b3c569d21d424661708ca946ea4cc3))
+* **vite-plugin:** improve audio handling ([#154](https://github.com/havenhq/revideo/issues/154)) ([482f144](https://github.com/havenhq/revideo/commit/482f14447ae54543346fab0f9e5b94631c5cfd4d))
+* **vite-plugin:** support glob for project files ([#834](https://github.com/havenhq/revideo/issues/834)) ([67029c4](https://github.com/havenhq/revideo/commit/67029c4c2cf756cbe2b7ed59dc55cb895de81d52)), closes [#324](https://github.com/havenhq/revideo/issues/324)
+* webgl shaders ([#920](https://github.com/havenhq/revideo/issues/920)) ([849216e](https://github.com/havenhq/revideo/commit/849216ed34c4d29742c621b43a95ec4d99f8c755))
+
+
+### Reverts
+
+* "ci(release): 9.1.3 [skip ci]" ([62953a6](https://github.com/havenhq/revideo/commit/62953a6a8a1b1da3eb2e5f51c9fe60c716d6b94b))
+* ci(release): 1.0.1 [skip ci] ([#175](https://github.com/havenhq/revideo/issues/175)) ([161a046](https://github.com/havenhq/revideo/commit/161a04647ecdc8203daf2d887a6a44c79a92ee20))
+* ci(release): 2.0.0 [skip ci] ([#176](https://github.com/havenhq/revideo/issues/176)) ([551096b](https://github.com/havenhq/revideo/commit/551096bf636a791ea7c7c1d38d8e03c360433008))
+
+
+### BREAKING CHANGES
+
+* `makeProject` no longer accepts some settings.
+
+Settings such as `background` and `audioOffset` are now stored in the project
+meta file.
+* remove legacy package
+* change to import paths
+
+See [the migration guide](https://motion-canvas.github.io/guides/migration/12.0.0) for more info.
+* change the way scenes are imported
+
+Scene files no longer need to follow the pattern: `[name].scene.tsx`.
+When importing scenes in the project file, a dedicated `?scene` query param should be used:
+```ts
+import example from './scenes/example?scene';
+
+export default new Project({
+  name: 'project',
+  scenes: [example],
+});
+```
+* change the overall structure of a project
+
+`vite` and `@motion-canvas/vite-plugin` packages are now required to build a project:
+```
+npm i -D vite @motion-canvas/vite-plugin
+```
+The following `vite.config.ts` file needs to be created in the root of the project:
+```ts
+import {defineConfig} from 'vite';
+import motionCanvas from '@motion-canvas/vite-plugin';
+
+export default defineConfig({
+  plugins: [motionCanvas()],
+});
+```
+
+Types exposed by Motion Canvas are no longer global.
+An additional `motion-canvas.d.ts` file needs to be created in the `src` directory:
+```ts
+/// <reference types="@motion-canvas/core/project" />
+```
+
+ Finally, the `bootstrap` function no longer exists.
+ Project files should export an instance of the `Project` class instead:
+ ```ts
+ import {Project} from '@motion-canvas/core/lib';
+
+ import example from './scenes/example.scene';
+
+ export default new Project({
+   name: 'project',
+   scenes: [example],
+   // same options as in bootstrap() are available:
+
+
+
+
+
 ## [3.14.1](https://github.com/revideo/revideo/compare/v3.14.0...v3.14.1) (2024-02-06)
 
 

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@motion-canvas/vite-plugin",
+  "name": "@revideo/vite-plugin",
   "version": "3.14.1",
-  "description": "A Vite plugin for Motion Canvas projects",
+  "description": "A Vite plugin for revideo projects",
   "main": "lib/index.js",
-  "author": "motion-canvas",
-  "homepage": "https://motioncanvas.io/",
-  "bugs": "https://github.com/motion-canvas/motion-canvas/issues",
+  "author": "revideo",
+  "homepage": "https://re.video/",
+  "bugs": "https://github.com/havenhq/revideo/issues",
   "license": "MIT",
   "scripts": {
     "dev": "tsc -w",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/motion-canvas/motion-canvas.git"
+    "url": "git+https://github.com/havenhq/revideo.git"
   },
   "files": [
     "lib"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@revideo/vite-plugin",
-  "version": "3.14.1",
+  "version": "0.1.0",
   "description": "A Vite plugin for revideo projects",
   "main": "lib/index.js",
   "author": "revideo",

--- a/packages/vite-plugin/src/globals.d.ts
+++ b/packages/vite-plugin/src/globals.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="@motion-canvas/internal" />
+/// <reference types="@revideo/internal" />

--- a/packages/vite-plugin/src/main.ts
+++ b/packages/vite-plugin/src/main.ts
@@ -75,7 +75,7 @@ export interface MotionCanvasPluginConfig {
    * - `index` - Receives a list of all projects as its first argument and
    *             creates the initial page for selecting a project.
    *
-   * @defaultValue '\@motion-canvas/ui'
+   * @defaultValue '\@revideo/ui'
    */
   editor?: string;
   /**
@@ -99,7 +99,7 @@ export default ({
   project = './src/project.ts',
   output = './output',
   bufferedAssets = /^$/,
-  editor = '@motion-canvas/ui',
+  editor = '@revideo/ui',
   proxy,
   buildForEditor,
 }: MotionCanvasPluginConfig = {}): Plugin[] => {
@@ -109,7 +109,7 @@ export default ({
 
   return [
     {
-      name: 'motion-canvas',
+      name: 'revideo',
       async configResolved(resolvedConfig) {
         plugins.push(
           ...resolvedConfig.plugins

--- a/packages/vite-plugin/src/partials/assets.ts
+++ b/packages/vite-plugin/src/partials/assets.ts
@@ -13,7 +13,7 @@ interface AssetsPluginConfig {
 export function assetsPlugin({bufferedAssets}: AssetsPluginConfig): Plugin {
   let config: ResolvedConfig;
   return {
-    name: 'motion-canvas:assets',
+    name: 'revideo:assets',
 
     configResolved(resolvedConfig) {
       config = resolvedConfig;
@@ -49,7 +49,7 @@ export function assetsPlugin({bufferedAssets}: AssetsPluginConfig): Plugin {
       }
 
       if (urls.length > 0) {
-        ctx.server.ws.send('motion-canvas:assets', {urls});
+        ctx.server.ws.send('revideo:assets', {urls});
       }
 
       return modules;

--- a/packages/vite-plugin/src/partials/corsProxy.ts
+++ b/packages/vite-plugin/src/partials/corsProxy.ts
@@ -49,7 +49,7 @@ export function corsProxyPlugin(
 ): Plugin {
   setupEnvVarsForProxy(config);
   return {
-    name: 'motion-canvas:cors-proxy',
+    name: 'revideo:cors-proxy',
     configureServer(server) {
       if (config !== false && config !== undefined) {
         motionCanvasCorsProxy(

--- a/packages/vite-plugin/src/partials/editor.ts
+++ b/packages/vite-plugin/src/partials/editor.ts
@@ -20,7 +20,7 @@ export function editorPlugin({editor, projects}: EditorPluginConfig): Plugin {
   const resolvedEditorId = '\0virtual:editor';
 
   return {
-    name: 'motion-canvas:editor',
+    name: 'revideo:editor',
 
     async load(id) {
       const [, query] = id.split('?');

--- a/packages/vite-plugin/src/partials/exporter.ts
+++ b/packages/vite-plugin/src/partials/exporter.ts
@@ -10,7 +10,7 @@ interface ExporterPluginConfig {
 
 export function exporterPlugin({outputPath}: ExporterPluginConfig): Plugin {
   return {
-    name: 'motion-canvas:exporter',
+    name: 'revideo:exporter',
 
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
@@ -27,7 +27,7 @@ export function exporterPlugin({outputPath}: ExporterPluginConfig): Plugin {
       });
 
       server.ws.on(
-        'motion-canvas:export',
+        'revideo:export',
         async (
           {data, frame, sceneFrame, subDirectories, mimeType, groupByScene},
           client,
@@ -51,7 +51,7 @@ export function exporterPlugin({outputPath}: ExporterPluginConfig): Plugin {
           await fs.promises.writeFile(outputFilePath, base64Data, {
             encoding: 'base64',
           });
-          client.send('motion-canvas:export-ack', {frame});
+          client.send('revideo:export-ack', {frame});
         },
       );
     },

--- a/packages/vite-plugin/src/partials/meta.ts
+++ b/packages/vite-plugin/src/partials/meta.ts
@@ -6,7 +6,7 @@ export function metaPlugin(): Plugin {
   const timeStamps: Record<string, number> = {};
   let config: ResolvedConfig;
   return {
-    name: 'motion-canvas:meta',
+    name: 'revideo:meta',
 
     configResolved(resolvedConfig) {
       config = resolvedConfig;
@@ -24,7 +24,7 @@ export function metaPlugin(): Plugin {
 
       /* language=typescript */
       return `\
-import {MetaFile} from '@motion-canvas/core';
+import {MetaFile} from '@revideo/core';
 let meta;
 if (import.meta.hot) {
   meta = import.meta.hot.data.meta;
@@ -40,7 +40,7 @@ export default meta;
     },
 
     configureServer(server) {
-      server.ws.on('motion-canvas:meta', async ({source, data}, client) => {
+      server.ws.on('revideo:meta', async ({source, data}, client) => {
         // Ignore virtual meta files.
         if (source.startsWith('\0')) {
           return;
@@ -52,7 +52,7 @@ export default meta;
           JSON.stringify(data, undefined, 2),
           'utf8',
         );
-        client.send('motion-canvas:meta-ack', {source});
+        client.send('revideo:meta-ack', {source});
       });
     },
 

--- a/packages/vite-plugin/src/partials/projects.ts
+++ b/packages/vite-plugin/src/partials/projects.ts
@@ -20,7 +20,7 @@ export function projectsPlugin({
   const versions = JSON.stringify(getVersions());
   let config: ResolvedConfig;
   return {
-    name: 'motion-canvas:project',
+    name: 'revideo:project',
 
     configResolved(resolvedConfig) {
       config = resolvedConfig;
@@ -58,10 +58,8 @@ export function projectsPlugin({
       /* language=typescript */
       return `\
 ${imports.join('\n')}
-import {${
-        runsInEditor ? 'editorBootstrap' : 'bootstrap'
-      }} from '@motion-canvas/core';
-import {MetaFile} from '@motion-canvas/core';
+import {${runsInEditor ? 'editorBootstrap' : 'bootstrap'}} from '@revideo/core';
+import {MetaFile} from '@revideo/core';
         import metaFile from './${metaFile}';
         import config from './${name}';
         import settings from 'virtual:settings.meta';
@@ -95,7 +93,7 @@ import {MetaFile} from '@motion-canvas/core';
         },
         esbuild: {
           jsx: 'automatic',
-          jsxImportSource: '@motion-canvas/2d/lib',
+          jsxImportSource: '@revideo/2d/lib',
         },
         optimizeDeps: {
           entries: projects.list.map(project => project.url),

--- a/packages/vite-plugin/src/partials/scenes.ts
+++ b/packages/vite-plugin/src/partials/scenes.ts
@@ -6,7 +6,7 @@ const SCENE_QUERY_REGEX = /[?&]scene\b/;
 
 export function scenesPlugin(): Plugin {
   return {
-    name: 'motion-canvas:scene',
+    name: 'revideo:scene',
 
     async load(id) {
       if (!SCENE_QUERY_REGEX.test(id)) {
@@ -21,7 +21,7 @@ export function scenesPlugin(): Plugin {
 
       /* language=typescript */
       return `\
-import {ValueDispatcher} from '@motion-canvas/core';
+import {ValueDispatcher} from '@revideo/core';
 import metaFile from './${metaFile}';
 import description from './${sceneFile}';
 description.name = '${name}';

--- a/packages/vite-plugin/src/partials/settings.ts
+++ b/packages/vite-plugin/src/partials/settings.ts
@@ -6,14 +6,11 @@ import {Plugin} from 'vite';
 export function settingsPlugin(): Plugin {
   const settingsId = 'virtual:settings.meta';
   const resolvedSettingsId = '\0' + settingsId;
-  const settingsPath = path.resolve(
-    os.homedir(),
-    '.motion-canvas/settings.json',
-  );
+  const settingsPath = path.resolve(os.homedir(), '.revideo/settings.json');
   const outputDirectory = path.dirname(settingsPath);
 
   return {
-    name: 'motion-canvas:settings',
+    name: 'revideo:settings',
 
     resolveId(id) {
       if (id === settingsId) {
@@ -35,7 +32,7 @@ export function settingsPlugin(): Plugin {
     },
 
     configureServer(server) {
-      server.ws.on('motion-canvas:meta', async ({source, data}, client) => {
+      server.ws.on('revideo:meta', async ({source, data}, client) => {
         if (source !== resolvedSettingsId) {
           return;
         }
@@ -62,7 +59,7 @@ export function settingsPlugin(): Plugin {
           ]);
         }
 
-        client.send('motion-canvas:meta-ack', {source});
+        client.send('revideo:meta-ack', {source});
       });
     },
   };

--- a/packages/vite-plugin/src/partials/webgl.ts
+++ b/packages/vite-plugin/src/partials/webgl.ts
@@ -19,7 +19,7 @@ const INCLUDE_REGEX = /^#include "([^"]+)"/;
 export function webglPlugin(): Plugin {
   let config: ResolvedConfig;
   return {
-    name: 'motion-canvas:webgl',
+    name: 'revideo:webgl',
 
     configResolved(resolvedConfig) {
       config = resolvedConfig;

--- a/packages/vite-plugin/src/plugins.ts
+++ b/packages/vite-plugin/src/plugins.ts
@@ -32,9 +32,7 @@ export interface PluginConfig {
   output: string;
 }
 
-export const PLUGIN_OPTIONS = Symbol.for(
-  '@motion-canvas/vite-plugin/PLUGIN_OPTIONS',
-);
+export const PLUGIN_OPTIONS = Symbol.for('@revideo/vite-plugin/PLUGIN_OPTIONS');
 
 export interface PluginOptions {
   /**

--- a/packages/vite-plugin/src/versions.ts
+++ b/packages/vite-plugin/src/versions.ts
@@ -3,9 +3,9 @@ import path from 'path';
 
 export function getVersions() {
   return {
-    core: loadVersion('@motion-canvas/core'),
-    two: loadVersion('@motion-canvas/2d'),
-    ui: loadVersion('@motion-canvas/ui'),
+    core: loadVersion('@revideo/core'),
+    two: loadVersion('@revideo/2d'),
+    ui: loadVersion('@revideo/ui'),
     vitePlugin: loadVersion('..'),
   };
 }

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "plugins": [
       {
-        "transform": "@motion-canvas/internal/transformers/markdown-literals.js"
+        "transform": "@revideo/internal/transformers/markdown-literals.js"
       }
     ]
   },


### PR DESCRIPTION
Makes all changes necessary to publish package to npm as @revideo/*. To test the result, run:

`npm init @revideo@latest`

This will create an example project with @revideo as a dependency.

npm package is published here: https://www.npmjs.com/package/@revideo/2d 